### PR TITLE
chore(deps): ignore TypeScript major updates in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,12 @@ updates:
     labels:
       - "dependencies"
       - "npm"
+    # typescript の major 更新は @astrojs/check の peer dependency
+    # (typescript@^5.0.0) と衝突して npm ci が失敗するため除外。
+    # @astrojs/check が TypeScript 6 に対応した時点で、この ignore を削除する。
+    ignore:
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
     groups:
       astro-ecosystem:
         patterns:


### PR DESCRIPTION
## 概要

`.github/dependabot.yml` に `ignore` セクションを追加し、TypeScript の major 更新を Dependabot の提案対象から除外する。

## 背景

TypeScript 6 へのアップグレード試行 (#6) が CI で失敗。原因は依存の衝突:

```
@astrojs/check@0.9.8 は peer dependency で typescript@^5.0.0 を要求
→ TypeScript 6 をインストールすると npm ci が ERESOLVE で失敗
```

上流(Astro エコシステム)が TypeScript 6 に対応するまで、このアップグレードは不可能。

## 変更内容

`.github/dependabot.yml` の npm セクションに以下を追加:

```yaml
ignore:
  - dependency-name: "typescript"
    update-types: ["version-update:semver-major"]
```

## 挙動

| 更新種別 | 挙動 |
|---|---|
| TypeScript 5.9.x → 5.9.y (patch) | Dependabot が PR 作成 |
| TypeScript 5.9.x → 5.10.x (minor) | Dependabot が PR 作成 |
| TypeScript 5.x → 6.x 以上 (major) | 除外(PR 作成されない) |
| その他の依存(linkinator 等) | 影響なし |

## 将来の解除タイミング

`@astrojs/check` が TypeScript 6 対応した時点で、ignore ブロックを削除する。判定コマンド:

```bash
npm view @astrojs/check peerDependencies
```

出力の typescript が `^6.0.0` を含むようになったら解除可能。