### PR TITLE
feat: add monthly stale content check workflow

### DIFF
--- a/.github/workflows/stale-check.yml
+++ b/.github/workflows/stale-check.yml
@@ -1,0 +1,97 @@
+name: Stale Content Check
+
+on:
+  schedule:
+    # Every month on the 1st at 09:00 JST (= 00:00 UTC on the 1st)
+    - cron: "0 0 1 * *"
+  workflow_dispatch:
+
+concurrency:
+  group: stale-check-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Check stale lastVerified
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run stale check
+        id: stale
+        continue-on-error: true
+        run: npx tsx scripts/check-stale.ts > stale-report.md
+
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: stale-report-${{ github.run_id }}
+          path: stale-report.md
+          retention-days: 30
+
+      - name: Create Issue on stale entries
+        if: steps.stale.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          if [ ! -s stale-report.md ]; then
+            echo "stale-report.md is missing or empty; skipping issue creation."
+            exit 0
+          fi
+
+          # Ensure labels exist (idempotent)
+          for label in automated stale-check needs-human-review; do
+            gh label create "$label" --force >/dev/null 2>&1 || true
+          done
+
+          # Skip if an open Issue already tracks stale entries
+          existing=$(gh issue list \
+            --label stale-check \
+            --state open \
+            --json number \
+            --jq '.[0].number // empty')
+
+          if [ -n "$existing" ]; then
+            echo "Existing open stale-check Issue #$existing found. Skipping creation."
+            exit 0
+          fi
+
+          today=$(date -u +'%Y-%m-%d')
+
+          {
+            echo "月次の自動チェックで、\`lastVerified\` から 365 日以上経過した戦略を検出しました。"
+            echo ""
+            echo "- Workflow run: $RUN_URL"
+            echo "- 検出日 (UTC): $today"
+            echo ""
+            echo "---"
+            echo ""
+            head -c 60000 stale-report.md
+            if [ "$(wc -c < stale-report.md)" -gt 60000 ]; then
+              echo ""
+              echo ""
+              echo "_(レポートが長いため末尾を省略しました。全文は上記 Workflow run のアーティファクト \`stale-report-*\` を参照してください)_"
+            fi
+          } > issue-body.md
+
+          gh issue create \
+            --title "[auto] Stale content detected ($today)" \
+            --body-file issue-body.md \
+            --label "automated,stale-check,needs-human-review"

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "check:text": "textlint 'src/content/**/*.md'",
     "check:text:fix": "textlint --fix 'src/content/**/*.md'",
     "check:consistency": "npx tsx scripts/check-consistency.ts",
+    "check:stale": "npx tsx scripts/check-stale.ts",
     "check:all": "npm run check && npm run check:text && npm run check:consistency && npm run check:links",
     "test:e2e": "npx playwright test",
     "test:e2e:ui": "npx playwright test --ui"

--- a/scripts/check-stale.ts
+++ b/scripts/check-stale.ts
@@ -1,0 +1,165 @@
+/**
+ * 検証期限切れチェックスクリプト
+ *
+ * src/content/strategies/ の各 .md から lastVerified を読み取り、
+ * しきい値(365 日)を超えて経過したエントリをリスト化する。
+ *
+ * 使い方: npx tsx scripts/check-stale.ts
+ * 出力: Markdown (stdout)
+ * exit code: 検出数 (0 = 問題なし、1+ = 検出あり)
+ */
+
+import fs from "fs";
+import path from "path";
+import matter from "gray-matter";
+
+const STRATEGIES_DIR = path.resolve("src/content/strategies");
+const STALE_THRESHOLD_DAYS = 365;
+
+interface StaleEntry {
+  file: string;
+  lastVerified: string;
+  daysSinceVerified: number;
+}
+
+interface MissingEntry {
+  file: string;
+}
+
+interface InvalidEntry {
+  file: string;
+  value: string;
+}
+
+function parseDate(value: string): Date | null {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (!match) return null;
+  const [, y, m, d] = match;
+  const date = new Date(Date.UTC(Number(y), Number(m) - 1, Number(d)));
+  if (Number.isNaN(date.getTime())) return null;
+  return date;
+}
+
+function daysBetween(from: Date, to: Date): number {
+  const ms = to.getTime() - from.getTime();
+  return Math.floor(ms / (1000 * 60 * 60 * 24));
+}
+
+function main() {
+  const now = new Date();
+  const today = new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate())
+  );
+
+  const stale: StaleEntry[] = [];
+  const missing: MissingEntry[] = [];
+  const invalid: InvalidEntry[] = [];
+
+  const files = fs
+    .readdirSync(STRATEGIES_DIR)
+    .filter((f) => f.endsWith(".md"))
+    .sort();
+
+  for (const file of files) {
+    const raw = fs.readFileSync(path.join(STRATEGIES_DIR, file), "utf-8");
+    const { data } = matter(raw);
+    const value = data.lastVerified;
+
+    if (value === undefined || value === null || value === "") {
+      missing.push({ file });
+      continue;
+    }
+
+    if (typeof value !== "string") {
+      invalid.push({ file, value: String(value) });
+      continue;
+    }
+
+    const verifiedAt = parseDate(value);
+    if (!verifiedAt) {
+      invalid.push({ file, value });
+      continue;
+    }
+
+    const days = daysBetween(verifiedAt, today);
+    if (days > STALE_THRESHOLD_DAYS) {
+      stale.push({
+        file,
+        lastVerified: value,
+        daysSinceVerified: days,
+      });
+    }
+  }
+
+  const todayStr = today.toISOString().slice(0, 10);
+  const lines: string[] = [];
+
+  lines.push(`# 検証期限切れチェック (${todayStr})`);
+  lines.push("");
+  lines.push(`- しきい値: ${STALE_THRESHOLD_DAYS} 日`);
+  lines.push(`- 対象: \`src/content/strategies/*.md\` (${files.length} 件)`);
+  lines.push(
+    `- 検出: stale ${stale.length} 件 / 未設定 ${missing.length} 件 / 不正 ${invalid.length} 件`
+  );
+  lines.push("");
+
+  if (stale.length > 0) {
+    lines.push(
+      `## 検証期限切れ (${STALE_THRESHOLD_DAYS} 日超, ${stale.length} 件)`
+    );
+    lines.push("");
+    stale.sort((a, b) => b.daysSinceVerified - a.daysSinceVerified);
+    for (const entry of stale) {
+      lines.push(
+        `- \`strategies/${entry.file}\` — lastVerified: ${entry.lastVerified} (${entry.daysSinceVerified} 日経過)`
+      );
+    }
+    lines.push("");
+  }
+
+  if (missing.length > 0) {
+    lines.push(`## lastVerified 未設定 (${missing.length} 件)`);
+    lines.push("");
+    for (const entry of missing) {
+      lines.push(`- \`strategies/${entry.file}\``);
+    }
+    lines.push("");
+  }
+
+  if (invalid.length > 0) {
+    lines.push(`## lastVerified 形式不正 (${invalid.length} 件)`);
+    lines.push("");
+    for (const entry of invalid) {
+      lines.push(
+        `- \`strategies/${entry.file}\` — 値: \`${entry.value}\``
+      );
+    }
+    lines.push("");
+  }
+
+  const total = stale.length + missing.length + invalid.length;
+
+  if (total === 0) {
+    lines.push(
+      `すべての戦略が ${STALE_THRESHOLD_DAYS} 日以内に検証済みです。`
+    );
+    lines.push("");
+  } else {
+    lines.push("## 対応方法");
+    lines.push("");
+    lines.push("1. 各戦略の一次研究(メタ分析・RCT)を確認");
+    lines.push(
+      "2. 変更がなければ frontmatter の `lastVerified` を今日の日付に更新"
+    );
+    lines.push(
+      "3. 変更があれば本文・`evidence` フィールドを更新した上で `lastVerified` を更新"
+    );
+    lines.push("");
+  }
+
+  console.log(lines.join("\n"));
+
+  process.exit(total);
+}
+
+main();


### PR DESCRIPTION
## 概要

`src/content/strategies/*.md` の frontmatter `lastVerified` から 365 日以上経過した戦略を月次で検出し、GitHub Issue を自動作成する。教育研究は年次でメタ分析が更新されるため、一次研究の再検証タイミングを追跡する目的。

## 変更ファイル

| ファイル | 種別 | 概要 |
|---|---|---|
| `scripts/check-stale.ts` | 新規 | 73 戦略を走査し stale / 未設定 / 不正の 3 区分で Markdown を出力 |
| `.github/workflows/stale-check.yml` | 新規 | 毎月 1 日 09:00 JST cron + `workflow_dispatch`、検出時に Issue 作成 |
| `package.json` | 修正 | `npm run check:stale` を追加(ローカル手動実行用) |

## 設計判断

### セキュリティ
- 最小権限: `contents: read` + `issues: write` のみ
- サードパーティ Action 不使用: `gh` CLI のみで実装
- シークレットは `GITHUB_TOKEN`(Actions 自動付与)のみ

### 正確性(誤検知防止)
- `check-stale.ts` の exit code で検出の有無を判定(step の `outcome == 'failure'`)
- `stale-report.md` が空/不存在ならスキップ
- 既存の open `stale-check` ラベル付き Issue があればスキップ(重複防止)
- Issue 本文に Workflow run URL を含める(トレーサビリティ)
- 本文は 60,000 文字で truncate(GitHub 本文上限 65,536 対策)
- YYYY-MM-DD 以外の形式 / 文字列以外の値 / 未設定 は区別して「不正」「未設定」セクションに分離

### スコープ
- コラムは対象外。`content.config.ts` で `lastVerified` は戦略のみに定義、コラムは時事性が高く検証期限の概念が合わない
- `check-consistency.ts` に統合せず別スクリプトに切り出し(monthsGained 整合性チェックとは目的・頻度・失敗時の扱いが異なる)

### しきい値 365 日の根拠
- EEF Toolkit が概ね年次更新
- 教育研究のメタ分析は年単位で新知見が蓄積される

## ローカル動作確認

```bash
npm run check:stale
```

## CI 実挙動確認

Actions タブ → "Stale Content Check" → "Run workflow" で `workflow_dispatch` から手動実行可能。