### PR TITLE
fix: remove GitHub direct links from about page transparency section

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -97,18 +97,10 @@ import Layout from "../layouts/Layout.astro";
                 <strong>下書き生成</strong> — 候補となる指導法やコラムの下書きを AI が作成します
               </li>
               <li>
-                <strong>一次研究での検証(ここが要)</strong> — 効果量(+◯ヶ月)や引用論文は、著者が一次研究(メタ分析・RCT)を<strong>必ず自分の目で確かめてから公開</strong>します。推測で数値を書くことは禁じています(<a
-                  class="link-underline text-[var(--color-accent)]"
-                  href="https://github.com/Hayato-Isagawa/edu-evidence/blob/main/docs/CONTENT_GUIDELINES.md"
-                  target="_blank"
-                  rel="noopener">詳細ルール</a>)
+                <strong>一次研究での検証(ここが要)</strong> — 効果量(+◯ヶ月)や引用論文は、著者が一次研究(メタ分析・RCT)を<strong>必ず自分の目で確かめてから公開</strong>します。推測で数値を書くことは禁じています。
               </li>
               <li>
-                <strong>継続的な再検証</strong> — リンク切れや 12 ヶ月以上前の検証データは自動で検知し、人間が再確認します(<a
-                  class="link-underline text-[var(--color-accent)]"
-                  href="https://github.com/Hayato-Isagawa/edu-evidence/tree/main/.github/workflows"
-                  target="_blank"
-                  rel="noopener">自動化ワークフロー</a>)
+                <strong>継続的な再検証</strong> — リンク切れや 12 ヶ月以上前の検証データは自動で検知し、人間が再確認します。
               </li>
             </ol>
           </div>
@@ -118,11 +110,7 @@ import Layout from "../layouts/Layout.astro";
               運営初期、AI が生成した下書きをそのまま載せた結果、<strong>7 件中 5 件の効果量が研究と一致しない</strong>ことが判明しました。たとえば「朝食欠食は +3 ヶ月」と書いたのですが、実際の研究は「効果は subtle で月数換算できない」が正しい記述でした。
             </p>
             <p>
-              この失敗を受けて、数値はすべて一次研究で裏付けを取るルールを徹底しました。失敗の詳細も <a
-                class="link-underline text-[var(--color-accent)]"
-                href="https://github.com/Hayato-Isagawa/edu-evidence/blob/main/docs/CONTENT_GUIDELINES.md"
-                target="_blank"
-                rel="noopener">GitHub 上で公開</a>しています。
+              この失敗を受けて、数値はすべて一次研究で裏付けを取るルールを徹底しました。
             </p>
           </div>
           <div class="space-y-2">


### PR DESCRIPTION
## 概要

About ページの「本サイトのつくり方」セクションから GitHub 直リンクを 3 箇所削除する。既存の「編集方針 > サイトの公開性」セクション(リンクなしで「オープンに公開」と述べるのみ)と文書スタイルを統一する。

## 削除したリンク

- CONTENT_GUIDELINES.md への「詳細ルール」リンク(2 箇所)
- `.github/workflows/` への「自動化ワークフロー」リンク

## 挙動

- リンク要素を削除し、かかる日本語は自然に閉じるように調整
- 運用説明(「推測で数値を書くことは禁じている」「12 ヶ月以上前のデータは自動検知し人間が再確認する」)は本文に残る
- 既存「サイトの公開性」セクション(リンクなし)と文書スタイルが揃う

## 動作確認

- `npx astro check`: エラー 0、警告 0
- `grep github.com/Hayato src/`: 一致なし(削除完了を確認)

## 変更サイズ

- `src/pages/about.astro`: +3 / -15

## 関連

- #15: 透明性セクションを追加した PR(本 PR の対象箇所を導入)