### PR TITLE
docs: sync CONTRIBUTING and README with current npm scripts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,10 +94,14 @@ culturalContext: |
 
 ```bash
 npm install
-npm run dev        # 開発サーバー
-npm run build      # ビルド
-npm run test:e2e   # E2E テスト
-npm run check:text # 日本語校正
+npm run dev                # 開発サーバー
+npm run build              # ビルド
+npm run test:e2e           # E2E テスト
+npm run check              # Astro 型チェック
+npm run check:text         # textlint 日本語校正
+npm run check:consistency  # monthsGained 整合性チェック
+npm run check:stale        # lastVerified 期限切れチェック
+npm run check:all          # 上記チェックを一括実行
 ```
 
 ## 行動規範

--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ npm run test:e2e
 | `npm run preview` | ビルド結果のローカルプレビュー |
 | `npm run check` | Astro の型チェック |
 | `npm run check:text` | textlint による日本語校正 |
+| `npm run check:text:fix` | textlint で自動修正 |
+| `npm run check:consistency` | monthsGained 整合性チェック |
+| `npm run check:stale` | lastVerified 期限切れチェック |
+| `npm run check:links` | ビルド後のローカルリンクチェック |
+| `npm run check:links:live` | 本番サイトのリンクチェック |
+| `npm run check:all` | check + check:text + check:consistency + check:links を一括実行 |
 | `npm run test:e2e` | Playwright E2E テスト |
 | `npm run test:e2e:ui` | Playwright UI モード |
 


### PR DESCRIPTION
## 概要

`CONTRIBUTING.md` と `README.md` に記載されていた npm scripts 一覧が、実際の `package.json` と乖離していたため、現状に合わせて更新する。CLAUDE.md (#18 で整合済み) と同じ一覧が参照できるようにする。

## 変更内容

### `CONTRIBUTING.md` の「開発環境」

以下を追加:

- `check` — Astro 型チェック
- `check:consistency` — monthsGained 整合性チェック
- `check:stale` — lastVerified 期限切れチェック
- `check:all` — 上記チェックを一括実行

### `README.md` の「npm スクリプト」

以下を追加:

- `check:text:fix` — textlint で自動修正
- `check:consistency` — monthsGained 整合性チェック
- `check:stale` — lastVerified 期限切れチェック
- `check:links` — ビルド後のローカルリンクチェック
- `check:links:live` — 本番サイトのリンクチェック
- `check:all` — 一括実行

## 変更サイズ

- `CONTRIBUTING.md`: +8 / -4
- `README.md`: +6

## 関連

- #14: `check:stale` スクリプトの追加元
- #18: CLAUDE.md と npm scripts の整合