### PR TITLE
fix: update 3 broken source URLs detected in issue #21

### DIFF
--- a/src/content/strategies/breakfast-skipping.md
+++ b/src/content/strategies/breakfast-skipping.md
@@ -9,8 +9,8 @@ grades: ["全学年"]
 category: "知っておくべき知見"
 source: japan
 tags: ["生活習慣", "格差", "食育"]
-sourceUrl: https://www.mext.go.jp/b_menu/shingi/chousa/shotou/045/shiryo/__icsFiles/afieldfile/2012/02/07/1314819_1.pdf
-sourceTitle: "文部科学省 — 全国学力・学習状況調査と生活習慣の関連"
+sourceUrl: https://www.mext.go.jp/a_menu/shotou/gakuryoku-chousa/zenkoku/08020513/001/002.htm
+sourceTitle: "文部科学省 — 全国学力・学習状況調査における児童生徒の生活の諸側面等に関する分析"
 evidence:
   japan:
     monthsGained: 1
@@ -19,7 +19,7 @@ evidence:
   hattie:
     cohensD: 0.10
     note: "Adolphus, Lawton & Dye(2013)の系統的レビューでは、朝食欠食と認知機能の関連は『subtle』と結論。効果は**栄養状態が悪い子どもに条件付き**で現れ、十分に栄養が取れている子どもには効果が検出されない。"
-lastVerified: "2026-04-14"
+lastVerified: "2026-04-19"
 culturalContext: |
   **『朝食を食べると成績が上がる』という言説は日本で広く流布しているが、因果関係を証明した研究は存在しない**。全国学力調査の相関を因果として紹介するのは統計的に誤り。ただし、朝食欠食が深刻な子ども(SES 的に不利な家庭)に対する **子ども食堂・朝食提供** の取り組みは、栄養改善と登校継続の両面で意義を持つ(原因が何であれ介入の必要はある)。『朝食指導』と『朝食提供』は別の話。
 ---

--- a/src/content/strategies/flipped-classroom.md
+++ b/src/content/strategies/flipped-classroom.md
@@ -8,24 +8,24 @@ subjects: ["全教科"]
 grades: ["中学年", "高学年"]
 source: mixed
 tags: ["GIGA", "デジタル", "家庭学習"]
-sourceUrl: https://doi.org/10.3102/00346543251323787
-sourceTitle: "Li et al. (2025) Effectiveness of Flipped Classrooms for K-12 Students: A Three-Level Meta-Analysis"
+sourceUrl: https://doi.org/10.3102/00346543241261732
+sourceTitle: "Li, Fu, Liu & Hwang (2025) Effectiveness of Flipped Classrooms for K-12 Students: Evidence From a Three-Level Meta-Analysis"
 evidence:
   eef:
     note: "EEF Toolkit には反転授業の独立したエントリは無い。関連する『Digital technology』(+4)の一部として扱われる可能性がある。"
   hattie:
     cohensD: 0.53
     note: "Li et al.(2025)の K-12 129研究のメタ分析で g=0.53。Shi et al.(2020)等でも d=0.5 前後が報告されている。d=0.53 は『月数換算 +5』に対応。"
-lastVerified: "2026-04-18"
+lastVerified: "2026-04-19"
 methodology:
   studies: 129
   sampleSize: "K-12 129 研究(3レベルメタ分析、多数の国際研究)"
   effectSize: "Hedges' g = 0.53(小〜中)。Låg & Sæle(2019, 高等教育中心)では g = 0.35"
   primaryMetaAnalysis:
-    authors: "Li, Yu, Li & Lian"
+    authors: "Li, Fu, Liu & Hwang"
     year: 2025
-    title: "Effectiveness of Flipped Classrooms for K-12 Students: A Three-Level Meta-Analysis"
-    url: "https://doi.org/10.3102/00346543251323787"
+    title: "Effectiveness of Flipped Classrooms for K-12 Students: Evidence From a Three-Level Meta-Analysis"
+    url: "https://doi.org/10.3102/00346543241261732"
   limitations: "統制群との比較で『動画視聴+対面演習』という設計全体が効いているのか、『反転』の形式自体が効いているのかを切り分けにくい。動画視聴を家庭に依存するため、家庭環境の格差を増幅する懸念。日本の小学校文脈での RCT は未実施。"
 culturalContext: |
   **日本国内での反転授業の効果を検証した RCT は存在しない**。GIGA スクール構想により 1 人 1 台端末が整備され、実践環境は整ってきたが、定量的な効果検証は今後の課題。海外メタ分析の効果量がそのまま日本の小学校文脈で成立するかは未検証である点に注意。特に、日本の家庭学習文化・保護者の関与・就寝時刻などは海外 K-12 と条件が異なる。

--- a/src/content/strategies/school-library.md
+++ b/src/content/strategies/school-library.md
@@ -9,8 +9,8 @@ grades: ["全学年"]
 category: "制度・環境"
 source: japan
 tags: ["読書", "図書館", "習慣"]
-sourceUrl: https://www.mext.go.jp/a_menu/shotou/dokusho/link/1360933.htm
-sourceTitle: "文部科学省 — 学校図書館の現状に関する調査"
+sourceUrl: https://www.mext.go.jp/a_menu/shotou/dokusho/link/1360318.htm
+sourceTitle: "文部科学省 — 学校図書館の現状に関する調査結果"
 evidence:
   japan:
     monthsGained: 1
@@ -20,7 +20,7 @@ evidence:
   hattie:
     cohensD: 0.15
     note: "Lance & Kachel(2018)のレビューは、米国の州別調査で学校図書館の整備度・司書の質と学業達成の正の相関を一貫して報告。ただし横断研究中心で因果推論は限定的。"
-lastVerified: "2026-04-14"
+lastVerified: "2026-04-19"
 culturalContext: |
   日本では学校図書館の整備水準が自治体間で大きく異なり、**司書の専門性と学校図書館の活用頻度が、結果として読書習慣・読解力に影響**する可能性が示唆される。ただし『学校図書館を整備すれば学力が上がる』という単純な因果関係ではなく、**読み聞かせ・調べ学習・利用指導**等の実践の質が鍵。朝読書(morning-reading)との組み合わせで実効性が高まる。
 ---


### PR DESCRIPTION
## 概要

週次 lychee チェック (issue #21) で検出されたリンク切れ 3 件を一次情報の現行 URL に差し替える。

## 変更内容

### `src/content/strategies/breakfast-skipping.md`

2012 年の MEXT PDF (`1314819_1.pdf`) が公開停止。全国学力・学習状況調査の生活諸側面分析ページ (`08020513/001/002.htm`) に変更。朝食摂取と学力の相関、および因果推定の限界 (家庭背景の交絡) への言及はこのページ内に保持される。

### `src/content/strategies/flipped-classroom.md`

旧 DOI `10.3102/00346543251323787` は存在しない番号だった。正しい DOI `10.3102/00346543241261732` (Review of Educational Research 95(5), 929-971, 2025) に修正。併せて `methodology.primaryMetaAnalysis.authors` を ERIC EJ1483640 の記載に合わせ `Li, Yu, Li & Lian` → `Li, Fu, Liu & Hwang` に訂正。

### `src/content/strategies/school-library.md`

MEXT 調査ページ (`1360933.htm`) が廃止。現行の「学校図書館の現状に関する調査結果」トップページ (`1360318.htm`) に差し替え。

## 影響範囲

- `monthsGained` / `evidenceStrength` / `cost` / `culturalContext` に変更なし。
- 本文 markdown に変更なし。
- 3 件とも `lastVerified` を 2026-04-19 に更新。

## 検証

- `npm run check` (astro check): 0 errors
- `npm run check:consistency`: 不一致なし
- `npm run check:stale`: stale 0 件
- `npx textlint` (変更 3 ファイル): 指摘なし
- 代替 URL は curl で 200 / 302 (DOI リダイレクト) を確認

## 参照

Fixes #21