### PR TITLE
feat(about): expand 参考にしているもの with categorized reference list

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -242,6 +242,21 @@ import Layout from "../layouts/Layout.astro";
                 『<a href="https://www.chikumashobo.co.jp/product/9784480072375/" target="_blank" rel="noopener noreferrer" class="link-underline text-[var(--color-accent)]">教育格差</a>』 松岡亮二 (2019), ちくま新書. — 家庭の SES・地域・性別が学力・進学率・学歴に与える影響を体系的に実証。教育格差の論点では本書を基盤に置いている。
               </li>
               <li>
+                『<a href="https://www.chuko.co.jp/laclef/2021/09/150740.html" target="_blank" rel="noopener noreferrer" class="link-underline text-[var(--color-accent)]">教育論の新常識 — 格差・学力・政策・未来</a>』 松岡亮二 編著 (2021), 中公新書ラクレ. — GIGA スクール・子どもの貧困・ジェンダー・九月入学など 20 のキーワードを、中室牧子ら計 22 名の専門家が解説する共著。
+              </li>
+              <li>
+                『<a href="https://www.chikumashobo.co.jp/product/9784480073716/" target="_blank" rel="noopener noreferrer" class="link-underline text-[var(--color-accent)]">日本の教育はダメじゃない — 国際比較データで問いなおす</a>』 小松光・ジェルミー・ラプリー (2021), ちくま新書. — PISA など国際比較データから日本の教育を再評価する一冊。過度な自虐論への実証的な反証。
+              </li>
+              <li>
+                『<a href="https://www.hayakawa-online.co.jp/shopdetail/000000013682/" target="_blank" rel="noopener noreferrer" class="link-underline text-[var(--color-accent)]">日本の15歳はなぜ学力が高いのか? — 5つの教育大国に学ぶ成功の秘密</a>』 ルーシー・クレハン 著 / 橋川史 訳 (2017), 早川書房. — 英国の教育研究者が日本・フィンランド・上海・シンガポール・カナダの 5 教育大国を実地調査したフィールドレポート。
+              </li>
+              <li>
+                『<a href="https://www.chuko.co.jp/ebook/2013/07/513962.html" target="_blank" rel="noopener noreferrer" class="link-underline text-[var(--color-accent)]">人間形成の日米比較 — かくれたカリキュラム</a>』 恒吉僚子 (1992), 中公新書. — 日本と米国の「個と集団」をめぐる意識の違いを、幼児教育・小学校の観察から浮かび上がらせた「かくれたカリキュラム」論の古典。
+              </li>
+              <li>
+                『<a href="https://www.kadokawa.co.jp/product/322310000993/" target="_blank" rel="noopener noreferrer" class="link-underline text-[var(--color-accent)]">科学的根拠に基づく最高の勉強法</a>』 安川康介 (2024), KADOKAWA. — アクティブ・リコール(検索練習)、分散学習など、本サイトの戦略ページと重なる認知科学的学習法を平易にまとめた一冊。
+              </li>
+              <li>
                 「<a href="https://note.com/junsakamoto/n/n7847cbdae8d7" target="_blank" rel="noopener noreferrer" class="link-underline text-[var(--color-accent)]">デジタル・シティズンシップとは何か</a>」 坂本旬 (2020), note. — 法政大学キャリアデザイン学部教授による概念整理の寄稿。情報モラル教育との違いを明確化し、日本における普及の基盤となった。AI・SNS・ゲームなどデジタル関連の論点で参照。
               </li>
             </ul>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -211,7 +211,7 @@ import Layout from "../layouts/Layout.astro";
       </div>
 
       <!-- 参考元 -->
-      <div class="space-y-4">
+      <div class="space-y-6">
         <h2 class="text-2xl font-black tracking-tight">参考にしているもの</h2>
         <p>
           本サイトは英国の Education Endowment Foundation (EEF) が公開する
@@ -219,10 +219,67 @@ import Layout from "../layouts/Layout.astro";
             class="link-underline text-[var(--color-accent)]"
             href="https://educationendowmentfoundation.org.uk/education-evidence/teaching-learning-toolkit"
             target="_blank"
-            rel="noopener">Teaching and Learning Toolkit</a
+            rel="noopener noreferrer">Teaching and Learning Toolkit</a
           > をベースに、日本の小学校文脈へ翻案しています。
           原典は CC BY-SA 4.0 で公開されており、本サイトのコンテンツも同じライセンスのもとで公開します。
         </p>
+
+        <p>
+          以下は、サイトの記述で繰り返し参照している書籍・報告書・公式資料です。各コラム・戦略ページの末尾には、個別の参考資料を掲載しています。
+        </p>
+
+        <div class="space-y-6">
+          <div class="space-y-3">
+            <h3 class="font-bold text-lg">日本の研究・書籍</h3>
+            <ul class="space-y-3 text-sm leading-relaxed">
+              <li>
+                『<a href="https://d21.co.jp/book/9784799317327" target="_blank" rel="noopener noreferrer" class="link-underline text-[var(--color-accent)]">「学力」の経済学</a>』 中室牧子 (2015), ディスカヴァー・トゥエンティワン. — 教育経済学の入門書。非認知能力・早期教育・インセンティブ設計など、本サイトでも繰り返し参照する知見を日本に紹介した代表作。
+              </li>
+              <li>
+                『<a href="https://www.diamond.co.jp/book/9784478121092.html" target="_blank" rel="noopener noreferrer" class="link-underline text-[var(--color-accent)]">科学的根拠(エビデンス)で子育て — 教育経済学の最前線</a>』 中室牧子 (2024), ダイヤモンド社. — 近年の実証研究を保護者・教員向けに整理した最新の一冊。
+              </li>
+              <li>
+                『<a href="https://www.chikumashobo.co.jp/product/9784480072375/" target="_blank" rel="noopener noreferrer" class="link-underline text-[var(--color-accent)]">教育格差</a>』 松岡亮二 (2019), ちくま新書. — 家庭の SES・地域・性別が学力・進学率・学歴に与える影響を体系的に実証。教育格差の論点では本書を基盤に置いている。
+              </li>
+              <li>
+                「<a href="https://note.com/junsakamoto/n/n7847cbdae8d7" target="_blank" rel="noopener noreferrer" class="link-underline text-[var(--color-accent)]">デジタル・シティズンシップとは何か</a>」 坂本旬 (2020), note. — 法政大学キャリアデザイン学部教授による概念整理の寄稿。情報モラル教育との違いを明確化し、日本における普及の基盤となった。AI・SNS・ゲームなどデジタル関連の論点で参照。
+              </li>
+            </ul>
+          </div>
+
+          <div class="space-y-3">
+            <h3 class="font-bold text-lg">国際的な枠組み・研究データベース</h3>
+            <ul class="space-y-3 text-sm leading-relaxed">
+              <li>
+                <a href="https://educationendowmentfoundation.org.uk/education-evidence/teaching-learning-toolkit" target="_blank" rel="noopener noreferrer" class="link-underline text-[var(--color-accent)]">Education Endowment Foundation — Teaching and Learning Toolkit</a>. — 英国の教育研究財団が 30 以上の指導法をメタ分析で評価。本サイトの効果量(+◯ヶ月)の主要な参照元。
+              </li>
+              <li>
+                <a href="https://www.oecd.org/pisa/" target="_blank" rel="noopener noreferrer" class="link-underline text-[var(--color-accent)]">OECD — PISA (Programme for International Student Assessment)</a>. — 3 年ごとの国際学力調査。読解・数学・科学の国際比較データの出典。
+              </li>
+              <li>
+                Hattie, J. <a href="https://www.visiblelearningmetax.com/" target="_blank" rel="noopener noreferrer" class="link-underline text-[var(--color-accent)]">Visible Learning MetaX</a>. — 800 以上のメタ分析を統合した教育要因のデータベース。効果量が楽観的に出やすい点を注記した上で参考値として併記している。
+              </li>
+            </ul>
+          </div>
+
+          <div class="space-y-3">
+            <h3 class="font-bold text-lg">日本の公式資料</h3>
+            <ul class="space-y-3 text-sm leading-relaxed">
+              <li>
+                <a href="https://www.mext.go.jp/a_menu/shotou/gakuryoku-chousa/" target="_blank" rel="noopener noreferrer" class="link-underline text-[var(--color-accent)]">文部科学省 — 全国学力・学習状況調査</a>. — 毎年実施の小 6・中 3 対象学力調査。学力・家庭環境・学習習慣のデータ源。
+              </li>
+              <li>
+                <a href="https://www.mext.go.jp/content/20230220-mxt_jidou01-000024699-201-1.pdf" target="_blank" rel="noopener noreferrer" class="link-underline text-[var(--color-accent)]">文部科学省 — 生徒指導提要(2022 年改訂)</a>. — 生徒指導の 4 層構造(発達支持的・課題予防的 2 層・困難課題対応的)を定義した公式ガイドライン。
+              </li>
+              <li>
+                <a href="https://www.mext.go.jp/a_menu/other/mext_02412.html" target="_blank" rel="noopener noreferrer" class="link-underline text-[var(--color-accent)]">文部科学省 — 初等中等教育段階における生成 AI の利活用に関するガイドライン(Ver.2.0)</a>. — 2024 年 12 月公表。生成 AI の学校現場での扱い方に関する公式指針。
+              </li>
+              <li>
+                <a href="https://www.j-sla.or.jp/material/research/dokusyotyousa.html" target="_blank" rel="noopener noreferrer" class="link-underline text-[var(--color-accent)]">全国学校図書館協議会 — 学校読書調査</a>. — 毎年実施される読書冊数調査。小中高の読書習慣データ源。
+              </li>
+            </ul>
+          </div>
+        </div>
       </div>
 
       <!-- 免責 -->


### PR DESCRIPTION
About ページの「参考にしているもの」を拡張し、サイトが繰り返し参照している書籍・報告書・公式資料を 3 カテゴリに整理した一覧として明示する。エビデンス主義サイトとしての透明性と、助成金応募時の知的基盤の説明材料を強化する目的。

## 背景

これまでの「参考にしているもの」は EEF Toolkit への参照 1 件のみだった。実際にはコラム・戦略ページで中室牧子・松岡亮二の著作、文科省の複数の公式資料、OECD PISA、Visible Learning などを繰り返し参照しているため、About ページでまとめて示すことで読者の透明性判断に資する。

## 新設した 3 カテゴリ

### 日本の研究・書籍(書名→著者の順で記載)
- 『「学力」の経済学』 中室牧子 (2015), ディスカヴァー・トゥエンティワン
- 『科学的根拠(エビデンス)で子育て — 教育経済学の最前線』 中室牧子 (2024), ダイヤモンド社
- 『教育格差』 松岡亮二 (2019), ちくま新書
- 「デジタル・シティズンシップとは何か」 坂本旬 (2020), note

### 国際的な枠組み・研究データベース
- EEF Teaching and Learning Toolkit
- OECD PISA
- Hattie Visible Learning MetaX

### 日本の公式資料
- 文部科学省 全国学力・学習状況調査
- 文部科学省 生徒指導提要 (2022 改訂)
- 文部科学省 生成 AI ガイドライン Ver.2.0
- 全国学校図書館協議会 学校読書調査

## 運用上の判断

実際にサイトの記述で一次情報として verify・引用しているものに限定して記載する方針。坂本旬のデジタル・シティズンシップの論点については、執筆者が書籍そのものを参照しておらず実際に利用した note 記事「デジタル・シティズンシップとは何か」を記載した。読者に「参考にしている」と提示する以上、実際に当たった一次情報と一致させる。

## 実装メモ

すべての外部リンクに target="_blank" rel="noopener noreferrer" を付与。Astro テンプレートは rehype-external-links の自動処理対象外のため明示した。

## 検証

- `npm run check` 0 errors
- `npm run build` 成功
- 追加した 11 件の URL はすべて HTTP 200 または bot ブロックによる 403(URL 自体は有効)を確認済