### PR TITLE
fix(about): correct field experience from 12年 to 約11年

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -49,7 +49,7 @@ import Layout from "../layouts/Layout.astro";
               Isagawa Hayato
             </div>
             <p class="text-sm text-[var(--color-sub)] leading-relaxed">
-              元小学校教諭。現場経験12年。学級担任の他、非常勤講師・理科専科・特別支援学級担任を経験。<br />
+              元小学校教諭。現場経験約 11 年。学級担任の他、非常勤講師・理科専科・特別支援学級担任を経験。<br />
               小学校一種免許・中学校一種免許(理科)・高等学校一種免許(理科)保持。
             </p>
             <p class="text-sm text-[var(--color-sub)] leading-relaxed pt-2">


### PR DESCRIPTION
About ページの経歴記述「現場経験12年」を「現場経験約11年」に訂正する。

## 背景

執筆者の在職期間は 2011 年 4 月〜2023 年 8 月末で、名目上は約 12 年 4 ヶ月。ただしその間に育休を 1 年半取得していたため、実勤務期間は約 10 年 10 ヶ月。1 年以上の誤差があり、エビデンスサイトとしての正確性の観点で訂正する。

## 変更

`src/pages/about.astro` L52:

- 旧: 元小学校教諭。現場経験12年。
- 新: 元小学校教諭。現場経験約 11 年。

## 検証

- `npm run check` 0 errors