### PR TITLE
fix(content): unify strategy link text with strategy page titles (4 🔴 mismatches)

### DIFF
--- a/src/content/columns/education-inequality-evidence.md
+++ b/src/content/columns/education-inequality-evidence.md
@@ -44,7 +44,7 @@ relatedStrategies: ["early-years-intervention", "parental-engagement", "summer-l
 
 - **家庭**: 読み聞かせ・学習環境・親の関わり。SES によって差が出やすい領域
 - **学校**: 質の高い授業([フィードバック](/strategies/feedback) +6 ヶ月、[メタ認知](/strategies/metacognition) +8 ヶ月など)、[夏休みの学力低下](/strategies/summer-learning-loss) への対策、[SEL](/strategies/social-emotional-learning) による非認知能力の育成
-- **社会制度**: [就学前教育への投資](/strategies/early-years-intervention) (+6 ヶ月)、SSW を介した福祉機関との連携、自治体の学習支援事業(貧困世帯対象)、奨学金・就学援助
+- **社会制度**: [就学前教育への介入](/strategies/early-years-intervention) (+6 ヶ月)、SSW を介した福祉機関との連携、自治体の学習支援事業(貧困世帯対象)、奨学金・就学援助
 
 一方で、格差を「家庭の責任」に帰してしまうと、学校が何もしない言い訳になり、逆に「学校の努力不足」に帰してしまうと、教員の過剰負担とバーンアウトを招きます。**「家庭でしか打てない手」「学校でしか打てない手」「社会制度でしか打てない手」を分けて考える** のが現実的です。
 

--- a/src/content/columns/experience-gap-school-role.md
+++ b/src/content/columns/experience-gap-school-role.md
@@ -47,7 +47,7 @@ relatedStrategies: ["social-emotional-learning", "outdoor-learning", "tokkatsu",
 | [社会性と情動の学習(SEL)](/strategies/social-emotional-learning) | +4ヶ月 | Durlak et al.(2011)の 213 プログラム・270,034 人のメタ分析 |
 | [就学前教育への介入](/strategies/early-years-intervention) | +6ヶ月 | 特に社会経済的に不利な子どもで効果が大きい |
 | [屋外学習](/strategies/outdoor-learning) | +3ヶ月 | 冒険的活動・自然体験 |
-| [芸術への参加](/strategies/arts-participation) | +3ヶ月 | 音楽・美術・演劇の直接体験 |
+| [芸術活動への参加](/strategies/arts-participation) | +3ヶ月 | 音楽・美術・演劇の直接体験 |
 | [特別活動](/strategies/tokkatsu) | +2ヶ月 | 日本独自の枠組み |
 
 SEL は学力にも波及するエビデンスがあり、Durlak et al.(2011)のメタ分析では学力が平均 11 パーセンタイル向上と報告されています。就学前教育は **社会経済的に不利な子どもで効果が大きい** ため、早期の公的支援は格差縮小に直結する領域です。

--- a/src/content/columns/special-needs-8-8-percent.md
+++ b/src/content/columns/special-needs-8-8-percent.md
@@ -68,7 +68,7 @@ Five-a-day の各原則は、本サイトの戦略と次のように対応しま
 加えて、日常的に効くエビデンスが 2 つ。
 
 - [フィードバック](/strategies/feedback) +6ヶ月 — つまずきに即応し、次の一歩を具体的に示す
-- [ユニバーサルデザイン・学びのデザイン(UDL)](/strategies/universal-design-learning) — 最初から多様な子どもを想定した授業設計
+- [授業のユニバーサルデザイン](/strategies/universal-design-learning) — 最初から多様な子どもを想定した授業設計(UDL、Universal Design for Learning)
 
 ## 教室で今できる 3 つのこと
 

--- a/src/content/columns/teacher-shortage-evidence.md
+++ b/src/content/columns/teacher-shortage-evidence.md
@@ -76,7 +76,7 @@ relatedStrategies: ["teacher-workload-reform", "teacher-student-relationships", 
 
 [中学校 35 人学級の実施等のための法律](https://www.mext.go.jp/b_menu/activity/detail/2026/20260331.html) が 2026 年 3 月 31 日に成立し、令和 8 年度から中学校でも段階的に 35 人学級が実施されます(令和 8: 中 1、令和 9: 中 1・2、令和 10: 中 1〜3)。約 40 年ぶりの中学校学級編制標準の引下げです。
 
-ただし、学級規模縮小の学力効果は [EEF Toolkit で +1 ヶ月](/strategies/reducing-class-size) と限定的。35 人学級は教員の労働環境改善・個別対応の余裕確保には寄与しますが、**学力向上の直接的な手段としては限界がある** という点は、エビデンスベースに誠実であるために併記しておきます(詳細は [少人数学級にどれだけの効果があるか?](/columns/class-size-cost-effectiveness))。
+ただし、[学級規模の縮小](/strategies/reducing-class-size) の学力効果は EEF Toolkit で **+1 ヶ月** と限定的。35 人学級は教員の労働環境改善・個別対応の余裕確保には寄与しますが、**学力向上の直接的な手段としては限界がある** という点は、エビデンスベースに誠実であるために併記しておきます(詳細は [少人数学級にどれだけの効果があるか?](/columns/class-size-cost-effectiveness))。
 
 ## 教員として考えたいこと
 


### PR DESCRIPTION
## 概要

サイト内監査で **24 件のコラム→戦略リンク text と戦略ページタイトルの不一致** を発見。うち **意味が明確にずれる 5 件(🔴)** を修正(1 件は PR #54 で active-deep-learning の `形成的評価・フィードバック` → `フィードバック` として既に対応、本 PR は残り 4 件)。

## 修正一覧

| コラム | Before(リンク text) | After(戦略タイトルに一致) |
|---|---|---|
| education-inequality | 就学前教育への **投資** | 就学前教育への **介入** |
| experience-gap | 芸術 **への** 参加 | 芸術 **活動への** 参加 |
| special-needs | ユニバーサルデザイン・学びのデザイン(UDL) | 授業のユニバーサルデザイン |
| teacher-shortage | EEF Toolkit で +1 ヶ月 | 学級規模の縮小 |

特に teacher-shortage の修正は最重要: **リンク text が戦略名ではなく効果量の主張文** になっており、読者がリンク先で何を学べるかが text から判断できない状態だった。

## 本 PR のスコープ外(19 件、🟡)

戦略タイトルの短縮形を使っているだけで意味は保たれているケース(「SEL」「メタ認知」「フォニックス」「分散学習」「検索練習」「足場かけ」「スクリーンタイム」「SNS 利用」等、19 箇所)。これらは教員読者に既に浸透した略称なので現状維持。

別 Issue で「第一言及は戦略ページ正式名称、二回目以降は短縮可」のガイドラインを §8 / §9 に追加する予定。

## Rule 1.9 遵守の検証

修正後、再度 audit スクリプトを走らせて **🔴 意味が大きく外れる不一致はゼロ** を確認。残る 🟡 短縮形は今後の別対応。

Refs #45