### PR TITLE
fix(content): replace worldscorecard secondary source with OECD Education GPS (Rule 1.2)

### DIFF
--- a/scripts/check-source-links.ts
+++ b/scripts/check-source-links.ts
@@ -49,6 +49,7 @@ const KNOWN_BOT_PROTECTED_HOSTS: readonly string[] = [
   "www.tandfonline.com",
   "www.nier.go.jp",
   "www.oecd.org",
+  "gpseducation.oecd.org",
   "www.mhlw.go.jp",
   "link.springer.com",
   "onlinelibrary.wiley.com",

--- a/src/content/columns/finland-education-myth.md
+++ b/src/content/columns/finland-education-myth.md
@@ -2,7 +2,7 @@
 title: フィンランド教育神話を冷静に見る — PISA スコアの推移と「成功モデル」の終わり
 summary: 2000 年代に「世界最高峰」と評価されたフィンランド教育は、PISA スコアの 20 年の推移で見ると 2006 年をピークに一貫して低下し、2022 年には OECD 平均より少し上の水準まで落ち込んだ。なぜ神話が広まり、なぜ終わったのか。海外事例から学ぶときの落とし穴も含めて整理する。
 date: "2026-04-11"
-lastVerified: "2026-04-21"
+lastVerified: "2026-04-22"
 tags: ["国際比較", "PISA", "フィンランド", "政策"]
 relatedStrategies: []
 ---
@@ -111,5 +111,5 @@ relatedStrategies: []
 - [PISA 2022 Results (Volume I): The state of learning and equity in education](https://www.oecd.org/publication/pisa-2022-results/). OECD (2023). — 最新の PISA 結果。フィンランドの数学 484 点(2022 年)は 2006 年ピークから 64 点の低下。OECD 平均(数学 472・読解 476)を若干上回る水準。
 - [PISA 2022 Country Notes — Finland](https://www.oecd.org/en/publications/2023/11/pisa-2022-results-volume-i-and-ii-country-notes_2fca04b9/finland_ac04e1eb.html). OECD (2023). — フィンランド個別の分析。3 科目すべてで過去最低を更新し、「2018〜2022 年の急落は以前から始まっていた低下を強化するもの」と評価。
 - [PISA 2022 Country Notes — Japan](https://www.oecd.org/en/publications/pisa-2022-results-volume-i-and-ii-country-notes_ed6fbcc5-en/japan_f7d7daad-en.html). OECD (2023). — 日本の数学 536 点(OECD 平均 472 より 64 点高く歴代最高タイ)を記録。2018 年から 2022 年にかけてスコアが上昇した数少ない国として分析。
-- [Finland PISA Scores (Math) — Trends & Historical Data](https://worldscorecard.com/scorecards/finnish-scorecard/pisa-scores-math/). World Scorecard. — 2003〜2022 年のフィンランド数学スコアの集約データ(544 → 548 → 541 → 524 → 511 → 507 → 484)。
+- [Education GPS — Finland Country Profile](https://gpseducation.oecd.org/CountryProfile?primaryCountry=FIN). OECD. — OECD 公式のフィンランド国別プロファイル。PISA 2000〜2022 の各科目時系列スコア・国際比較を参照できる。本コラム掲載の数学スコア(544 → 548 → 541 → 524 → 511 → 507 → 484)の一次出典。
 - 『[World Class: How to Build a 21st-Century School System](https://www.oecd.org/content/dam/oecd/en/publications/reports/2018/05/world-class_g1g8d583/9789264300002-en.pdf)』 Andreas Schleicher (2018), OECD Publishing. — PISA 責任者による国際比較分析(OECD が全文を無料公開)。各国の教育制度を PISA データの視点から検討。


### PR DESCRIPTION
## 概要

`finland-education-myth.md` の参考資料 L114 で、フィンランド数学 PISA の時系列データ(`544 → 548 → 541 → 524 → 511 → 507 → 484`)の出典として二次まとめサイト `worldscorecard.com` を参照していた。Rule 1.2(引用は一次情報で確認)の観点から **OECD 公式の Education GPS Finland Country Profile** に差し替え。

PR #64 の `check:links:source` 導入で未登録警告として検出され、確認した結果 Rule 1.2 違反として対処すべきものと判断。

## 変更

### `src/content/columns/finland-education-myth.md`

| 旧 | 新 |
|---|---|
| [Finland PISA Scores (Math) — Trends & Historical Data](https://worldscorecard.com/scorecards/finnish-scorecard/pisa-scores-math/). World Scorecard. | [Education GPS — Finland Country Profile](https://gpseducation.oecd.org/CountryProfile?primaryCountry=FIN). OECD. |

一言補足も「OECD 公式のフィンランド国別プロファイル。PISA 2000〜2022 の各科目時系列スコア・国際比較を参照できる。本コラム掲載の数学スコア(544 → 548 → 541 → 524 → 511 → 507 → 484)の一次出典。」に差し替え。

`lastVerified: 2026-04-21 → 2026-04-22`。

### `scripts/check-source-links.ts`

`KNOWN_BOT_PROTECTED_HOSTS` に `gpseducation.oecd.org` を追加。OECD Education GPS もボット対策で HEAD/GET とも常時 403 を返すため、`check:links:source` の warn 出力をホスト別サマリに集約してノイズを抑える。

## 検証

`npm run check:links:source` の最新結果:

- ✓ 2xx / 3xx: 275
- ⚠️ 要目視(未登録ドメイン): **0**
- ℹ️ 既知ボット対策ドメイン: 148(`gpseducation.oecd.org` が新規 1 件として収納)
- ❌ 404 / 410 / network error: 0

本文(L22-28 / L30 / L102)で用いている年次スコア値はすべて差し替え先の OECD Education GPS プロファイルで確認可能。

Refs #45