### PR TITLE
refactor(content): reading-quantity-myth — fix bibliography + count consistency (Group A 7/9)

### DIFF
--- a/src/content/columns/reading-quantity-myth.md
+++ b/src/content/columns/reading-quantity-myth.md
@@ -2,7 +2,7 @@
 title: 「読書 100 冊目標」は学力を上げるか — 冊数信仰をエビデンスで問い直す
 summary: 2024 年、小学生の月平均読書冊数は 13.8 冊で過去 31 年の最高値。自治体や学校が「年間◯冊」の目標を掲げる例も多い。しかし、冊数を追うことと学力が上がることの因果は、思うほど明確ではない。
 date: "2026-04-18"
-lastVerified: "2026-04-19"
+lastVerified: "2026-04-22"
 tags: ["読書", "国語", "学力"]
 relatedStrategies: ["morning-reading", "school-library", "reading-comprehension"]
 ---
@@ -35,7 +35,7 @@ relatedStrategies: ["morning-reading", "school-library", "reading-comprehension"
 
 読書習慣は、本質的に **家庭で形成される** 領域です。国際的には、[Mol & Bus(2011)の 99 研究メタ分析(N=7,669)](https://pubmed.ncbi.nlm.nih.gov/21219054/) が、就学前から大学生までを対象に「家庭での本との接触量」と「読解力・語彙力」の間に一貫した正の相関を報告しており、家庭での読み聞かせ・蔵書・保護者の読書モデルが、読書習慣と読解力の基礎になることが示されています。
 
-学校は、家庭で育った読書習慣を **維持・強化するサポート役** であり、家庭の役割を代替する手段は持ちません。ただし、**家庭環境に格差がある現実** において、学校の果たす役割は小さくありません。特に家庭での蔵書アクセスや保護者モデルが限られる家庭にとって、学校図書館と学校での読書時間は、教育格差を緩和する装置として機能します。
+学校は、家庭で育った読書習慣を **維持・強化するサポート役** であり、家庭の役割を代替する手段は持ちません。ただし、**家庭環境に格差がある現実** において、学校の果たす役割は小さくありません。特に家庭での蔵書アクセスや保護者モデルが限られる家庭にとって、[学校図書館](/strategies/school-library) と学校での [朝読書](/strategies/morning-reading) のような読書時間は、教育格差を緩和する装置として機能します。
 
 ## 因果を示した少数の研究 — フィリピン Sa Aklat Sisikat
 
@@ -61,9 +61,9 @@ relatedStrategies: ["morning-reading", "school-library", "reading-comprehension"
 
 つまり本サイトでも、朝読書について「確実に +2ヶ月の効果」とは言っていません。**「量より習慣化」「習慣化より継続」** の視点が重要です。
 
-## 冊数目標の 3 つの落とし穴
+## 冊数目標の 4 つの落とし穴
 
-エビデンスを踏まえると、学級で冊数目標を運用する際に注意したい点が 3 つあります。
+エビデンスを踏まえると、学級で冊数目標を運用する際に注意したい点が 4 つあります。
 
 ### 落とし穴① 薄い本を何冊も
 
@@ -134,4 +134,4 @@ relatedStrategies: ["morning-reading", "school-library", "reading-comprehension"
 
 - [第 69 回学校読書調査](https://www.j-sla.or.jp/material/research/dokusyotyousa.html). 全国学校図書館協議会 (2024). — 小学生の月平均読書冊数は 13.8 冊で過去最高と報告。
 - Mol, S. E., & Bus, A. G. (2011). [To read or not to read: A meta-analysis of print exposure from infancy to early adulthood](https://pubmed.ncbi.nlm.nih.gov/21219054/). *Psychological Bulletin*, 137(2), 267–296. — 99 研究 (N=7,669) のメタ分析。家庭での本との接触と読解力・語彙力の間に一貫した正の相関を報告。
-- Abeberese, A. B., Kumler, T. J., & Linden, L. L. (2014). [Improving reading skills by encouraging children to read in school: A randomized evaluation of the Sa Aklat Sisikat reading program in the Philippines](https://onlinelibrary.wiley.com/doi/abs/10.1002/pam.22175). *Journal of Policy Analysis and Management*, 39(2). — タルラク州の 100 校・4 年生を対象とした RCT。読書スキル +0.13 SD(3 か月後 +0.06 SD)、他教科への波及は確認されず。
+- Abeberese, A. B., Kumler, T. J., & Linden, L. L. (2014). [Improving reading skills by encouraging children to read in school: A randomized evaluation of the Sa Aklat Sisikat reading program in the Philippines](https://doi.org/10.3368/jhr.49.3.611). *Journal of Human Resources*, 49(3), 611–633. — タルラク州の 100 校・4 年生を対象とした RCT。読書スキル +0.13 SD(3 か月後 +0.06 SD)、他教科への波及は確認されず。


### PR DESCRIPTION
## 概要

Issue #45 Group A 9 本の再点検 7 本目。Rule 1.2 / 1.9 / §8 で再監査。特に **Abeberese et al. (2014) の書誌情報が誤っていたため修正**、および **「3 つの落とし穴」と宣言しつつ項目が 4 つあった内部整合問題** を解消。

## Rule 1.2 書誌情報の修正

### Abeberese, Kumler, Linden (2014) Sa Aklat Sisikat

旧表記は誌名・巻号・DOI がすべて誤り。WebSearch で一次情報を複数経路(NBER / ideas.repec.org / Project MUSE / ResearchGate)で追認し、以下に修正。

| 項目 | 旧(誤) | 新(正) |
|---|---|---|
| 誌名 | *Journal of Policy Analysis and Management* | ***Journal of Human Resources*** |
| 巻号 | 39(2) | **49(3), 611–633** |
| DOI | `10.1002/pam.22175`(PAM の別論文 DOI) | `10.3368/jhr.49.3.611`(JHR 本論文の DOI) |

## Rule 1.9 整合性の修正

### 「落とし穴」数の不整合

見出し・導入では「**3 つ** の落とし穴」と宣言していたが、実際は ① 薄い本 / ② 集計負担 / ③ 外発的動機づけ / ④ 教育格差の増幅 の **4 項目** あり、Rule 1.9(内部整合)違反だった。

| 箇所 | 旧 | 新 |
|---|---|---|
| 見出し L64 | 冊数目標の **3 つ** の落とし穴 | 冊数目標の **4 つ** の落とし穴 |
| 導入 L66 | 注意したい点が **3 つ** あります | 注意したい点が **4 つ** あります |

まとめ(L127)は既に 4 項目全て列挙していたため変更なし。

### 内部リンクの活用

家庭読書 → 学校補完の説明文(L38 相当)で、具体戦略名を挙げず一般名詞「学校図書館と学校での読書時間」だったため、関連する本サイト戦略ページへのリンクを追加。

- 「学校図書館」→ **[学校図書館の活用](/strategies/school-library)**
- 「学校での読書時間」→ **[朝読書](/strategies/morning-reading)**

## metadata 突合(問題なし)

| 戦略 | 本文記述 | strategy title | 効果量 |
|---|---|---|---|
| morning-reading | +2ヶ月・★2 | 朝読書 | +2 ✓ |
| school-library | +1ヶ月 | 学校図書館の活用 | +1 ✓ |
| reading-comprehension | +7ヶ月・★5 | 読解戦略の指導 | +7 ✓ |

`npm run check:consistency` 通過。

## Rule 1.3 URL 到達性

- 全国学校図書館協議会: 200 ✓
- PubMed Mol & Bus 2011: 200 ✓
- JHR DOI 新規: 403(既知ボット対策、ブラウザで到達可能)

`npm run check:links:source`: 404 / 410 / network error **0** 件。

## 構造

- `lastVerified: 2026-04-19 → 2026-04-22`

Refs #45