### PR TITLE
refactor(content): school-lunch-free — add internal links (Group A 8/9)

### DIFF
--- a/src/content/columns/school-lunch-free.md
+++ b/src/content/columns/school-lunch-free.md
@@ -2,7 +2,7 @@
 title: 給食無償化は何を変えるのか — 政策目的とエビデンスを整理する
 summary: 2026年4月、公立小学校の給食が全国一律で無償化された。この政策は何を目的としているのか、そして研究は何を示しているのか。自治体の政策目的と先行研究のエビデンスを整理する。
 date: "2026-04-14"
-lastVerified: "2026-04-19"
+lastVerified: "2026-04-22"
 tags: ["給食", "政策", "格差"]
 relatedStrategies: ["breakfast-skipping", "early-years-intervention"]
 ---
@@ -39,7 +39,7 @@ relatedStrategies: ["breakfast-skipping", "early-years-intervention"]
 | 指標 | 結果 | 証拠の確実性 |
 |---|---|---|
 | 昼食参加率 | 有意に増加(3 研究) | 中程度 |
-| 朝食参加率 | 有意に増加(1 研究のみ) | 非常に低い |
+| [朝食](/strategies/breakfast-skipping) 参加率 | 有意に増加(1 研究のみ) | 非常に低い |
 | 出席率 | 変化なし〜わずかに改善 | 低い |
 | 肥満有病率 | 減少 | 非常に低い |
 | 停学率 | 減少 | 非常に低い |
@@ -67,7 +67,7 @@ relatedStrategies: ["breakfast-skipping", "early-years-intervention"]
 
 [Ayllón & Lado (2025) の先進国 42 研究・2,821 推定値のメタ分析(IZA DP 18042)](https://www.iza.org/publications/dp/18042/the-causal-impact-of-school-meal-programmes-on-children-in-developed-economies-a-meta-analysis) は、**「先進国における給食プログラムは、行動・健康・教育への影響が最小限」** と結論しました。
 
-なお同論文の下位分析では、**所得制限型(means-tested)の給食プログラムと朝食プログラムが最も効果を生む** とも報告されています。普遍的な無償化そのものより、支援対象を絞ったプログラムのほうが効果が大きい、という示唆です。
+なお同論文の下位分析では、**所得制限型(means-tested)の給食プログラムと [朝食](/strategies/breakfast-skipping) プログラムが最も効果を生む** とも報告されています。普遍的な無償化そのものより、支援対象を絞ったプログラムのほうが効果が大きい、という示唆です。
 
 ### 中室牧子氏の指摘との整合
 


### PR DESCRIPTION
## 概要

Issue #45 Group A 9 本の再点検 8 本目。本コラムは過去の Full Rewrite(Issue #45 task 17)で一次ソース検証を完了済みのため、今回は **Rule 1.9 内部リンクの追加** を中心に軽量な監査。

## Rule 1.9 内部リンクの追加

本コラムの `relatedStrategies` に `breakfast-skipping` が含まれているが、本文中で「朝食」に言及している箇所に内部リンクがなかった。以下に追加。

| 箇所 | 新 |
|---|---|
| L42 指標表「**朝食** 参加率」 | [朝食](/strategies/breakfast-skipping) へのリンク |
| L70 「所得制限型(means-tested)の給食プログラムと **朝食** プログラム」 | [朝食](/strategies/breakfast-skipping) へのリンク |

`early-years-intervention` については、L74 の中室牧子氏の指摘が「幼児教育無償化(保育料無償化)」を指すのに対し、戦略ページ「就学前教育への介入」は Perry Preschool などの介入プログラムを扱うもので概念が異なるため、誤誘導を避けて内部リンクは付けない判断。

## 他の監査項目(現状維持)

- **Rule 1.2 書誌情報**: Schwartz & Rothbart (2020) 含む 5 本の参考文献はすべて正確(誌名・巻号・DOI 確認済み)
- **Rule 1.8 主張強度**: 「効果量は小の範囲」「効果は最小限」など、原典の結論を忠実に反映
- **§8 参考資料書式**: 政府資料 → メタ分析 → 系統的レビュー → 準実験研究の並び順で整備済み
- **§9 表現の明瞭性**: 翻訳調・ビジネス用語の混入なし

## metadata 突合

| 戦略 | strategy title | 効果量 |
|---|---|---|
| breakfast-skipping | 朝食と学力の関係 | +1 ✓ |
| early-years-intervention | 就学前教育への介入 | +6 ✓ |

`npm run check:consistency` 通過。

## Rule 1.3 URL 到達性

- 文科省給食無償化資料: 200 ✓
- IZA DP 18042: 200 ✓
- 日立財団(中室講演): 200 ✓
- JAMA / Wiley / PMC: 既知ボット対策(サマリ収納)

`npm run check:links:source`: 404 / 410 / network error **0** 件。

## 構造

- `lastVerified: 2026-04-19 → 2026-04-22`

Refs #45