### PR TITLE
docs(about): add 3 books and remove unread note entry

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -74,7 +74,7 @@ import Layout from "../layouts/Layout.astro";
             </div>
             <div class="text-sm text-[var(--color-sub)]">
               本サイトの改善にご協力いただける教員・研究者の方を募集しています。<br />
-              お問い合わせ: <a href="mailto:info@edu-evidence.org" class="link-underline text-[var(--color-ink)]">info@edu-evidence.org</a>
+              お問い合わせ: <a href="mailto:info@edu-evidence.org" class="link-underline text-[var(--color-accent)]">info@edu-evidence.org</a>
             </div>
           </div>
         </div>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -257,7 +257,13 @@ import Layout from "../layouts/Layout.astro";
                 『<a href="https://www.kadokawa.co.jp/product/322310000993/" target="_blank" rel="noopener noreferrer" class="link-underline text-[var(--color-accent)]">科学的根拠に基づく最高の勉強法</a>』 安川康介 (2024), KADOKAWA. — アクティブ・リコール(検索練習)、分散学習など、本サイトの戦略ページと重なる認知科学的学習法を平易にまとめた一冊。
               </li>
               <li>
-                「<a href="https://note.com/junsakamoto/n/n7847cbdae8d7" target="_blank" rel="noopener noreferrer" class="link-underline text-[var(--color-accent)]">デジタル・シティズンシップとは何か</a>」 坂本旬 (2020), note. — 法政大学キャリアデザイン学部教授による概念整理の寄稿。情報モラル教育との違いを明確化し、日本における普及の基盤となった。AI・SNS・ゲームなどデジタル関連の論点で参照。
+                『<a href="https://www.kobunsha.com/shelf/book/isbn/9784334046545" target="_blank" rel="noopener noreferrer" class="link-underline text-[var(--color-accent)]">東大生、教育格差を学ぶ</a>』 松岡亮二・髙橋史子・中村高康 編著 (2023), 光文社新書. — 東京大学のゼミで松岡『教育格差』をテキストに議論した記録を編集した一冊。学生が自身の教育体験を格差論と突き合わせる構成が、教員研修の素材としても使える。
+              </li>
+              <li>
+                『<a href="https://www.diamond.co.jp/book/9784478039472.html" target="_blank" rel="noopener noreferrer" class="link-underline text-[var(--color-accent)]">「原因と結果」の経済学 — データから真実を見抜く思考法</a>』 中室牧子・津川友介 (2017), ダイヤモンド社. — 因果推論の入門書。RCT・自然実験など本サイトで頻出する概念を、数式を使わず教育・健康・経済の具体例で解説。エビデンスを読むリテラシーの土台。
+              </li>
+              <li>
+                『<a href="https://www.sbcr.jp/product/4815633417/" target="_blank" rel="noopener noreferrer" class="link-underline text-[var(--color-accent)]">ハーバード、スタンフォード、オックスフォード… 科学的に証明された すごい習慣大百科 — 人生が変わるテクニック112個集めました</a>』 堀田秀吾 (2025), SB クリエイティブ. — 心理学・行動科学・脳科学の研究に基づく習慣を 112 項目に整理。各項目に引用元研究が明記されており、一次ソースを辿る起点として使える。
               </li>
             </ul>
           </div>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -53,10 +53,10 @@ import Layout from "../layouts/Layout.astro";
               小学校一種免許・中学校一種免許(理科)・高等学校一種免許(理科)保持。
             </p>
             <p class="text-sm text-[var(--color-sub)] leading-relaxed pt-2">
-              教員時代に中室牧子氏の『「学力」の経済学』に出会い、エビデンスに基づく教育に興味を持つ。
+              教員時代に中室牧子氏の『<a href="https://d21.co.jp/book/9784799317327" target="_blank" rel="noopener noreferrer" class="link-underline text-[var(--color-accent)]">「学力」の経済学</a>』に出会い、エビデンスに基づく教育に興味を持つ。
               現在は退職し、フリーランスのウェブエンジニアとして活動。
               <a href="https://youtu.be/O1y8BTmGvDA" target="_blank" rel="noopener" class="link-underline text-[var(--color-accent)]">「フィンランド教育の失敗：日本の詰め込み教育はそこまで悪いのか？」</a>という動画をきっかけに、改めてエビデンスを伴った教育について学び始める（関連コラム: <a href="/columns/finland-education-myth" class="link-underline text-[var(--color-accent)]">フィンランド教育神話を冷静に見る</a>）。
-              その中で松岡亮二氏の『教育格差』に出会い、データに基づく教育への学びを深めている。
+              その中で松岡亮二氏の『<a href="https://www.chikumashobo.co.jp/product/9784480072375/" target="_blank" rel="noopener noreferrer" class="link-underline text-[var(--color-accent)]">教育格差</a>』に出会い、データに基づく教育への学びを深めている。
               本サイトは、現場で得た実感と研究の知見をつなぎたいという思いから立ち上げた。
             </p>
           </div>
@@ -257,7 +257,7 @@ import Layout from "../layouts/Layout.astro";
                 『<a href="https://www.kadokawa.co.jp/product/322310000993/" target="_blank" rel="noopener noreferrer" class="link-underline text-[var(--color-accent)]">科学的根拠に基づく最高の勉強法</a>』 安川康介 (2024), KADOKAWA. — アクティブ・リコール(検索練習)、分散学習など、本サイトの戦略ページと重なる認知科学的学習法を平易にまとめた一冊。
               </li>
               <li>
-                『<a href="https://www.kobunsha.com/shelf/book/isbn/9784334046545" target="_blank" rel="noopener noreferrer" class="link-underline text-[var(--color-accent)]">東大生、教育格差を学ぶ</a>』 松岡亮二・髙橋史子・中村高康 編著 (2023), 光文社新書. — 東京大学のゼミで松岡『教育格差』をテキストに議論した記録を編集した一冊。学生が自身の教育体験を格差論と突き合わせる構成が、教員研修の素材としても使える。
+                『<a href="https://www.kobunsha.com/shelf/book/isbn/9784334046545" target="_blank" rel="noopener noreferrer" class="link-underline text-[var(--color-accent)]">東大生、教育格差を学ぶ</a>』 松岡亮二・髙橋史子・中村高康 編著 (2023), 光文社新書. — 東京大学のゼミで松岡『<a href="https://www.chikumashobo.co.jp/product/9784480072375/" target="_blank" rel="noopener noreferrer" class="link-underline text-[var(--color-accent)]">教育格差</a>』をテキストに議論した記録を編集した一冊。学生が自身の教育体験を格差論と突き合わせる構成が、教員研修の素材としても使える。
               </li>
               <li>
                 『<a href="https://www.diamond.co.jp/book/9784478039472.html" target="_blank" rel="noopener noreferrer" class="link-underline text-[var(--color-accent)]">「原因と結果」の経済学 — データから真実を見抜く思考法</a>』 中室牧子・津川友介 (2017), ダイヤモンド社. — 因果推論の入門書。RCT・自然実験など本サイトで頻出する概念を、数式を使わず教育・健康・経済の具体例で解説。エビデンスを読むリテラシーの土台。

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -57,6 +57,7 @@ a {
 }
 
 .link-underline {
+  color: var(--color-accent);
   text-decoration: none;
   background-image: linear-gradient(var(--color-accent), var(--color-accent));
   background-size: 0% 1px;


### PR DESCRIPTION
## 概要

About ページの書籍リスト整備と、ページ内のリンク色の統一。

Rule 1.2 の精神(引用内容は一次情報で確認)を About の書籍紹介にも適用し、「About に並ぶ書籍 = 執筆者が読んで内容を保証しているもの」という方針を徹底する。あわせて、リンクの視認性を上げるためスタイル修正。

## 変更内容

### 1. 読書リストの更新

**追加する 3 冊**(写真から特定 → WebSearch で書誌確認 → 出版社公式 URL):

| 書籍 | 著者 | 年 | 出版社 | URL |
|---|---|---|---|---|
| 東大生、教育格差を学ぶ | 松岡亮二・髙橋史子・中村高康 編著 | 2023 | 光文社新書 | [kobunsha.com](https://www.kobunsha.com/shelf/book/isbn/9784334046545) |
| 「原因と結果」の経済学 — データから真実を見抜く思考法 | 中室牧子・津川友介 | 2017 | ダイヤモンド社 | [diamond.co.jp](https://www.diamond.co.jp/book/9784478039472.html) |
| ハーバード、スタンフォード、オックスフォード… 科学的に証明された すごい習慣大百科 — 人生が変わるテクニック112個集めました | 堀田秀吾 | 2025 | SB クリエイティブ | [sbcr.jp](https://www.sbcr.jp/product/4815633417/) |

一言補足は執筆者の視点で本サイトとの接点(因果推論・教育格差・習慣化のエビデンス等)を明示。

**削除**:

```
「デジタル・シティズンシップとは何か」坂本旬 (2020), note.
```

執筆者が未読のため、Rule 1.2(引用は一次情報で確認)の精神に合わず削除。デジタル関連の論点は本サイト内の複数コラム(`brainrot-classroom-response` / `generative-ai-education` / `giga-school-evidence` / `chatgpt-cognitive-crutch`)で執筆者自身の整理に置き換え済み。

### 2. 自己紹介・補足文内の書名をリンク化

本文中の既出書名がプレーンテキストのままでリンクになっていなかったため、対応する書籍リストと同じ出版社公式 URL に内部一致でリンク化:

| 行 | 書名 | リンク先 |
|---|---|---|
| L56 自己紹介 | 『「学力」の経済学』 | ディスカヴァー公式 |
| L59 自己紹介 | 『教育格差』 | 筑摩書房公式 |
| L260 書籍補足文内 | 松岡『教育格差』 | 筑摩書房公式 |

### 3. リンク色の統一(サイト全体の挙動修正)

`.link-underline` クラスに **`color: var(--color-accent)` をデフォルト適用**。

これまで `.link-underline` 自体に color 指定がなく、親要素の color を inherit していたため、`text-sm text-[var(--color-sub)]` のようなサブカラー段落内の書籍リンクがアクセント色で表示されず「色がついていない」状態になっていた(ユーザー指摘)。デフォルトでアクセント色を当てることで、個別クラス指定なしでも色付きリンクとして表示されるようになる。

あわせて About ページの mailto リンク(`text-[var(--color-ink)]`)も他のリンクと同じ `text-[var(--color-accent)]` に統一。

## 変更ファイル

- `src/pages/about.astro`: 書籍 3 冊追加 / 坂本旬削除 / 書名 3 箇所リンク化 / mailto 色統一
- `src/styles/global.css`: `.link-underline` のデフォルト color をアクセントに

## 検証

- 新規の書籍 URL 3 件を `curl -sI -L` で確認 → 全て **200** ✓
- 既存の書籍リストと同じ HTML 構造・Tailwind クラスに揃えている

## 関連 Issue

- Issue #77 参考資料の未読書籍整理(坂本旬削除はその最初の適用)
- Issue #78 About に読書リストを掲載(3 冊追加はその最初の実装ステップ)

Refs #77 #78