### PR TITLE
feat(relations): display related strategies on columns and back-references on strategies

### DIFF
--- a/src/components/RelatedStrategyCard.astro
+++ b/src/components/RelatedStrategyCard.astro
@@ -1,0 +1,85 @@
+---
+interface EefEvidence {
+  monthsGained?: number;
+  strength?: number;
+  note?: string;
+}
+interface JapanEvidence {
+  monthsGained?: number;
+  strength?: number;
+  note?: string;
+  researcher?: string;
+}
+interface HattieEvidence {
+  cohensD?: number;
+  note?: string;
+}
+interface Props {
+  href: string;
+  title: string;
+  summary: string;
+  monthsGained: number;
+  evidenceStrength: number;
+  evidence?: {
+    eef?: EefEvidence;
+    japan?: JapanEvidence;
+    hattie?: HattieEvidence;
+  };
+}
+const { href, title, summary, monthsGained, evidenceStrength, evidence } = Astro.props;
+
+const badgeConfig = {
+  eef: { label: "EEF", color: "text-sky-800 border-sky-800/40 bg-sky-50" },
+  japan: { label: "日本", color: "text-rose-700 border-rose-700/40 bg-rose-50" },
+  hattie: { label: "Hattie", color: "text-amber-800 border-amber-800/40 bg-amber-50" },
+} as const;
+type BadgeKey = keyof typeof badgeConfig;
+const badges: BadgeKey[] = [];
+if (evidence?.eef) badges.push("eef");
+if (evidence?.japan) badges.push("japan");
+if (evidence?.hattie) badges.push("hattie");
+if (badges.length === 0) badges.push("eef");
+
+const stars = "★".repeat(evidenceStrength) + "☆".repeat(5 - evidenceStrength);
+const effectSign = monthsGained > 0 ? "+" : monthsGained === 0 ? "±" : "";
+const effectColor =
+  monthsGained > 0
+    ? "text-[var(--color-accent)]"
+    : monthsGained === 0
+      ? "text-[var(--color-sub)]"
+      : "text-red-600";
+---
+
+<a
+  href={href}
+  class="group block border border-[var(--color-line)] rounded-xl p-5 transition hover:border-[var(--color-accent)] hover:bg-[var(--color-card)]"
+>
+  <div class="flex items-start justify-between gap-4">
+    <div class="flex-1 min-w-0 space-y-2">
+      <div class="flex flex-wrap items-center gap-2">
+        <h3 class="text-lg md:text-xl font-black tracking-tight leading-tight group-hover:text-[var(--color-accent)] transition">
+          {title}
+        </h3>
+        {badges.map((key) => (
+          <span
+            class={`font-mono text-[10px] tracking-widest uppercase border rounded-full px-2 py-0.5 leading-none inline-flex items-center h-5 ${badgeConfig[key].color}`}
+          >
+            {badgeConfig[key].label}
+          </span>
+        ))}
+      </div>
+      <p class="text-sm text-[var(--color-sub)] leading-relaxed line-clamp-2">
+        {summary}
+      </p>
+      <div class="font-mono text-[10px] uppercase tracking-widest text-amber-600">
+        {stars}
+      </div>
+    </div>
+    <div class={`text-right shrink-0 font-black tabular-nums ${effectColor}`}>
+      <div class="text-2xl md:text-3xl leading-none">
+        {effectSign}{monthsGained}<span class="text-xs font-sans ml-0.5">ヶ月</span>
+      </div>
+      <div class="mt-1 text-[var(--color-sub)] text-sm transition group-hover:translate-x-1 inline-block">→</div>
+    </div>
+  </div>
+</a>

--- a/src/pages/columns/[...slug].astro
+++ b/src/pages/columns/[...slug].astro
@@ -1,6 +1,7 @@
 ---
 import { getCollection, render } from "astro:content";
 import Layout from "../../layouts/Layout.astro";
+import RelatedStrategyCard from "../../components/RelatedStrategyCard.astro";
 
 export async function getStaticPaths() {
   const columns = await getCollection("columns");
@@ -10,6 +11,12 @@ export async function getStaticPaths() {
 const { entry } = Astro.props;
 const { Content } = await render(entry);
 const d = entry.data;
+
+const allStrategies = await getCollection("strategies");
+const strategyById = new Map(allStrategies.map((s) => [s.id, s]));
+const related = (d.relatedStrategies ?? [])
+  .map((id) => strategyById.get(id))
+  .filter((s): s is (typeof allStrategies)[number] => Boolean(s));
 ---
 
 <Layout title={`${d.title} — EduEvidence JP`} description={d.summary}>
@@ -62,7 +69,35 @@ const d = entry.data;
     <Content />
   </article>
 
-  <div class="pt-8 border-t border-[var(--color-line)] max-w-2xl">
+  {
+    related.length > 0 && (
+      <section class="pt-10 border-t border-[var(--color-line)] max-w-2xl space-y-6">
+        <div class="space-y-1">
+          <div class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]">
+            Related Strategies
+          </div>
+          <h2 class="text-2xl font-black tracking-tight">関連する指導法</h2>
+          <p class="text-sm text-[var(--color-sub)]">
+            本コラムで言及した指導法の詳細ページ。エビデンスの強さと効果量を確認できます。
+          </p>
+        </div>
+        <div class="grid grid-cols-1 gap-4">
+          {related.map((s) => (
+            <RelatedStrategyCard
+              href={`/strategies/${s.id}`}
+              title={s.data.title}
+              summary={s.data.summary}
+              monthsGained={s.data.monthsGained}
+              evidenceStrength={s.data.evidenceStrength}
+              evidence={s.data.evidence}
+            />
+          ))}
+        </div>
+      </section>
+    )
+  }
+
+  <div class="pt-10 mt-10 border-t border-[var(--color-line)] max-w-2xl">
     <a
       href="/columns"
       class="link-underline font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]"

--- a/src/pages/strategies/[...slug].astro
+++ b/src/pages/strategies/[...slug].astro
@@ -12,6 +12,11 @@ const { entry } = Astro.props;
 const { Content } = await render(entry);
 const d = entry.data;
 
+const allColumns = await getCollection("columns");
+const referringColumns = allColumns
+  .filter((c) => (c.data.relatedStrategies ?? []).includes(entry.id))
+  .sort((a, b) => (b.data.date || "").localeCompare(a.data.date || ""));
+
 const stars = "★".repeat(d.evidenceStrength) + "☆".repeat(5 - d.evidenceStrength);
 const yen = "¥".repeat(d.cost) + "·".repeat(5 - d.cost);
 
@@ -292,6 +297,47 @@ const effectNote =
         ) : (
           <p class="text-[var(--color-ink)]">{d.sourceTitle}</p>
         )}
+      </section>
+    )
+  }
+
+  {
+    referringColumns.length > 0 && (
+      <section class="pt-10 mt-10 border-t border-[var(--color-line)] max-w-2xl space-y-6">
+        <div class="space-y-1">
+          <div class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]">
+            Mentioned in Columns
+          </div>
+          <h2 class="text-2xl font-black tracking-tight">この指導法を扱っているコラム</h2>
+          <p class="text-sm text-[var(--color-sub)]">
+            本指導法を論点として取り上げたコラム。現場の文脈や政策との関係を読むことができます。
+          </p>
+        </div>
+        <ul class="space-y-3">
+          {referringColumns.map((c) => (
+            <li>
+              <a
+                href={`/columns/${c.id}`}
+                class="group block border border-[var(--color-line)] rounded-xl p-4 transition hover:border-[var(--color-accent)] hover:bg-[var(--color-card)]"
+              >
+                <div class="flex items-start justify-between gap-4">
+                  <div class="flex-1 min-w-0 space-y-1">
+                    <h3 class="text-base md:text-lg font-black tracking-tight leading-snug group-hover:text-[var(--color-accent)] transition">
+                      {c.data.title}
+                    </h3>
+                    <p class="text-sm text-[var(--color-sub)] leading-relaxed line-clamp-2">
+                      {c.data.summary}
+                    </p>
+                    <div class="font-mono text-[10px] uppercase tracking-widest text-[var(--color-sub)]">
+                      {c.data.date}
+                    </div>
+                  </div>
+                  <span class="shrink-0 text-[var(--color-sub)] transition group-hover:translate-x-1">→</span>
+                </div>
+              </a>
+            </li>
+          ))}
+        </ul>
       </section>
     )
   }


### PR DESCRIPTION
## Summary

コラム frontmatter の `relatedStrategies` はこれまで **データは存在するが画面出力されていない** 状態だった。2 方向の表示を追加して、コラム ↔ 戦略の相互回遊を可能にした。

## 変更内容

### コラム詳細ページ(`src/pages/columns/[...slug].astro`)

- 本文末尾に **「関連する指導法」セクション** を追加
- frontmatter の `relatedStrategies` を辿って戦略データを解決
- `RelatedStrategyCard` コンポーネントでカード表示(タイトル / サマリ / 効果量 / エビデンスバッジ)

### 戦略詳細ページ(`src/pages/strategies/[...slug].astro`)

- 「参考情報源」の後ろに **「この指導法を扱っているコラム」セクション** を追加
- 全コラムから当該戦略を `relatedStrategies` に含むものを逆引き
- 日付降順でコラムを一覧表示

### 新規コンポーネント(`src/components/RelatedStrategyCard.astro`)

- StrategyRow のコンパクト版(番号なし、サマリ 2 行省略、効果量強調)
- EvidenceSource 型は戦略 frontmatter の各出典(EEF / 日本 / Hattie)に合わせて分離

## データカバレッジ

- **コラム側**: 20 コラム中 19 件で関連戦略セクションが出力される(1 件のみ `relatedStrategies: []`)
- **戦略側**: 73 戦略中 36 件でコラム参照セクションが出力される
- 上位参照: metacognition(9 コラム)/ feedback(9 コラム)/ social-emotional-learning(7 コラム)
- 孤立参照(存在しない戦略 ID への参照)は **0 件**

## 検証

- [x] `npm run check` 0 errors / 0 warnings
- [x] `npm run build` exit 0、217 pages、Pagefind インデックス OK
- [x] dev server でコラム・戦略の両セクションが目視確認済み
  - `/columns/brainrot-classroom-response/` で関連指導法カード 7 枚
  - `/strategies/metacognition/` で「この指導法を扱っているコラム」セクション表示

## 意図

- **edu-watch(姉妹サイト)からの相互リンクを受け入れる土台** となる
- コラムから戦略、戦略から関連コラムへの回遊率向上(UX ギャップ分析で High 優先と判定された項目)
- frontmatter データが既に整備済みだったため、表示ロジック追加のみで済んだ

## Test plan

- [x] 型チェック通過
- [x] 本番ビルド通過
- [x] 主要ページで表示確認
- [ ] Cloudflare Pages デプロイ後、本番での目視確認