### PR TITLE
feat(tags): unify /tags page to cover strategies and columns, link tag chips

### DIFF
--- a/src/pages/columns/[...slug].astro
+++ b/src/pages/columns/[...slug].astro
@@ -55,9 +55,12 @@ const related = (d.relatedStrategies ?? [])
         d.tags.length > 0 && (
           <div class="flex flex-wrap gap-2">
             {d.tags.map((tag) => (
-              <span class="font-mono text-[11px] uppercase tracking-widest text-[var(--color-sub)] border border-[var(--color-line)] rounded-full px-3 py-1">
+              <a
+                href={`/tags/${encodeURIComponent(tag)}`}
+                class="font-mono text-[11px] uppercase tracking-widest text-[var(--color-sub)] border border-[var(--color-line)] rounded-full px-3 py-1 hover:border-[var(--color-accent)] hover:text-[var(--color-accent)] transition"
+              >
                 {tag}
-              </span>
+              </a>
             ))}
           </div>
         )

--- a/src/pages/strategies/[...slug].astro
+++ b/src/pages/strategies/[...slug].astro
@@ -85,6 +85,20 @@ const effectNote =
       >
         {d.summary}
       </p>
+      {
+        d.tags.length > 0 && (
+          <div class="flex flex-wrap gap-2 pt-2">
+            {d.tags.map((tag) => (
+              <a
+                href={`/tags/${encodeURIComponent(tag)}`}
+                class="font-mono text-[11px] uppercase tracking-widest text-[var(--color-sub)] border border-[var(--color-line)] rounded-full px-3 py-1 hover:border-[var(--color-accent)] hover:text-[var(--color-accent)] transition"
+              >
+                {tag}
+              </a>
+            ))}
+          </div>
+        )
+      }
     </div>
 
     <div

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -5,11 +5,13 @@ import StrategyRow from "../../components/StrategyRow.astro";
 
 export async function getStaticPaths() {
   const strategies = await getCollection("strategies");
+  const columns = await getCollection("columns");
   const tagSet = new Set<string>();
   for (const s of strategies) {
-    for (const tag of s.data.tags) {
-      tagSet.add(tag);
-    }
+    for (const tag of s.data.tags) tagSet.add(tag);
+  }
+  for (const c of columns) {
+    for (const tag of c.data.tags) tagSet.add(tag);
   }
   return [...tagSet].map((tag) => ({
     params: { tag },
@@ -19,9 +21,17 @@ export async function getStaticPaths() {
 
 const { tag } = Astro.props;
 const allStrategies = await getCollection("strategies");
+const allColumns = await getCollection("columns");
+
 const strategies = allStrategies
   .filter((s) => s.data.tags.includes(tag))
   .sort((a, b) => b.data.monthsGained - a.data.monthsGained);
+
+const columns = allColumns
+  .filter((c) => c.data.tags.includes(tag))
+  .sort((a, b) => (b.data.date || "").localeCompare(a.data.date || ""));
+
+const totalCount = strategies.length + columns.length;
 ---
 
 <Layout title={`${tag} — EduEvidence JP`}>
@@ -43,36 +53,95 @@ const strategies = allStrategies
     </div>
     <div class="col-span-12 md:col-span-4 md:pt-6 text-[var(--color-sub)] leading-loose text-sm">
       <p>
-        「{tag}」に関連する指導法<br />
-        <span class="text-xs">{strategies.length}件</span>
+        「{tag}」に関連するコンテンツ<br />
+        <span class="text-xs">
+          指導法 {strategies.length}件 / コラム {columns.length}件
+        </span>
       </p>
     </div>
   </section>
 
-  <section class="pb-24 space-y-8">
-    <div class="border-b border-[var(--color-line)]">
-      {
-        strategies.map((s, i) => (
-          <StrategyRow
-            index={i + 1}
-            href={`/strategies/${s.id}`}
-            title={s.data.title}
-            monthsGained={s.data.monthsGained}
-            evidenceStrength={s.data.evidenceStrength}
-            evidence={s.data.evidence}
-            subjects={s.data.subjects}
-            grades={s.data.grades}
-          />
-        ))
-      }
-    </div>
-    <div>
-      <a
-        href="/tags"
-        class="link-underline font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]"
-      >
-        ← タグ一覧へ戻る
-      </a>
-    </div>
+  {
+    strategies.length > 0 && (
+      <section class="pb-16 space-y-6">
+        <div class="space-y-1">
+          <div class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]">
+            Strategies
+          </div>
+          <h2 class="text-2xl font-black tracking-tight">関連する指導法</h2>
+        </div>
+        <div class="border-b border-[var(--color-line)]">
+          {strategies.map((s, i) => (
+            <StrategyRow
+              index={i + 1}
+              href={`/strategies/${s.id}`}
+              title={s.data.title}
+              monthsGained={s.data.monthsGained}
+              evidenceStrength={s.data.evidenceStrength}
+              evidence={s.data.evidence}
+              subjects={s.data.subjects}
+              grades={s.data.grades}
+            />
+          ))}
+        </div>
+      </section>
+    )
+  }
+
+  {
+    columns.length > 0 && (
+      <section class="pb-16 space-y-6">
+        <div class="space-y-1">
+          <div class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]">
+            Columns
+          </div>
+          <h2 class="text-2xl font-black tracking-tight">関連するコラム</h2>
+        </div>
+        <ul class="space-y-3">
+          {columns.map((c) => (
+            <li>
+              <a
+                href={`/columns/${c.id}`}
+                class="group block border border-[var(--color-line)] rounded-xl p-5 transition hover:border-[var(--color-accent)] hover:bg-[var(--color-card)]"
+              >
+                <div class="flex items-start justify-between gap-4">
+                  <div class="flex-1 min-w-0 space-y-2">
+                    <h3 class="text-lg md:text-xl font-black tracking-tight leading-snug group-hover:text-[var(--color-accent)] transition">
+                      {c.data.title}
+                    </h3>
+                    <p class="text-sm text-[var(--color-sub)] leading-relaxed line-clamp-2">
+                      {c.data.summary}
+                    </p>
+                    <div class="font-mono text-[10px] uppercase tracking-widest text-[var(--color-sub)]">
+                      {c.data.date}
+                    </div>
+                  </div>
+                  <span class="shrink-0 text-[var(--color-sub)] transition group-hover:translate-x-1">→</span>
+                </div>
+              </a>
+            </li>
+          ))}
+        </ul>
+      </section>
+    )
+  }
+
+  {
+    totalCount === 0 && (
+      <section class="pb-24 max-w-2xl">
+        <p class="text-[var(--color-sub)] leading-relaxed">
+          このタグに対応するコンテンツはまだありません。
+        </p>
+      </section>
+    )
+  }
+
+  <section class="pb-24">
+    <a
+      href="/tags"
+      class="link-underline font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]"
+    >
+      ← タグ一覧へ戻る
+    </a>
   </section>
 </Layout>

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -3,10 +3,16 @@ import { getCollection } from "astro:content";
 import Layout from "../../layouts/Layout.astro";
 
 const strategies = await getCollection("strategies");
+const columns = await getCollection("columns");
 
 const tagMap = new Map<string, number>();
 for (const s of strategies) {
   for (const tag of s.data.tags) {
+    tagMap.set(tag, (tagMap.get(tag) ?? 0) + 1);
+  }
+}
+for (const c of columns) {
+  for (const tag of c.data.tags) {
     tagMap.set(tag, (tagMap.get(tag) ?? 0) + 1);
   }
 }
@@ -30,9 +36,9 @@ const tags = [...tagMap.entries()].sort((a, b) => b[1] - a[1]);
     </div>
     <div class="col-span-12 md:col-span-4 md:pt-6 text-[var(--color-sub)] leading-loose text-sm">
       <p>
-        指導法を関心のあるテーマから<br />
+        指導法とコラムを関心のあるテーマから<br />
         探すことができます。<br />
-        <span class="text-xs">{tags.length}タグ / {strategies.length}件の指導法</span>
+        <span class="text-xs">{tags.length}タグ / 指導法 {strategies.length}件 / コラム {columns.length}件</span>
       </p>
     </div>
   </section>


### PR DESCRIPTION
## 背景

いじめコラム等のタグチップ(いじめ / 生徒指導 / 政策)が `<span>` のまま表示されており、クリックできない状態だった。さらに `/tags/[tag]` ページは戦略側の tags のみからパス生成していたため、仮にリンク化しても 404 になるタグが多数(いじめ・不登校・PISA・SES 等)。

## 変更内容

### `/tags/[tag]`(統合タグページ化)

- `getStaticPaths` で戦略 + コラム両方の tags を集める
- ページ本体に「関連する指導法」+「関連するコラム」の 2 セクション
- 総件数(指導法 N 件 / コラム M 件)を右カラムに表示
- 両方ゼロの場合は "このタグに対応するコンテンツはまだありません" を出す(ただし実データでは発生しない)

### `/tags/index`

- 集計を戦略 + コラムの両コレクションに拡張
- ヘッダー下の件数表示に "指導法 N 件 / コラム M 件" を追加

### コラム詳細(`src/pages/columns/[...slug].astro`)

- タグチップを `<span>` → `<a href="/tags/[tag]">` に変換
- ホバー時にアクセント色で強調

### 戦略詳細(`src/pages/strategies/[...slug].astro`)

- これまでタグ表示が無かった(frontmatter にはあった)
- summary 直下に同じタグチップブロックを追加
- 一貫性と回遊性の向上

## 検証

- [x] `npm run check` 0 errors / 0 warnings
- [x] `npm run build` exit 0、217 ページ + **116 タグページ** 生成(従来より大幅増)
- [x] `/tags/いじめ/` で「関連するコラム」セクションと bullying-recognition-paradox への参照を目視確認
- [x] コラム・戦略両方でタグリンク生成確認(URL エンコード済み)

## 効果

- コラム特有のタグ(いじめ / 不登校 / 政策 / PISA / SES / GIGA 等)が初めてナビゲート可能に
- 戦略⇔コラムの横断回遊がタグ経由でも可能に
- edu-watch 連携時、タグ共有により双方向の記事リストが成立する土台

## Test plan

- [x] 型チェック通過
- [x] 本番ビルド通過
- [x] 主要タグページ生成確認
- [ ] Cloudflare Pages デプロイ後、本番での目視確認