### PR TITLE
chore: suppress Zod v4 namespace deprecation warnings via ignoreDeprecations

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
   "exclude": ["dist"],
   "compilerOptions": {
     "jsx": "react-jsx",
-    "jsxImportSource": "react"
+    "jsxImportSource": "react",
+    "ignoreDeprecations": "5.0"
   }
 }


### PR DESCRIPTION
## 背景

`npm run check` が **78 件の ts(6385) 警告** を出していた。すべて `src/content.config.ts` 内の `z.xxx` 呼び出しで発生。

### 原因

Zod v4(`zod@4.3.6`)は、v3 の namespace 形式(`z.string()`, `z.array()` 等)を **deprecated** にマーク済み。TypeScript は `z` 自体に `@deprecated` JSDoc を検出して、**あらゆる `z.xxx` 参照ごとに ts(6385) 警告** を出す。

### 検討した対応

1. **`z.string().url()` → `z.url()` 等、個別 API の書き換え** — × 効果なし。`z` namespace 全体が deprecated なので、個別プロパティを新 API にしても警告は残る
2. **Zod の直接 import(`import { z } from "zod/v4"`)** — × Astro の `astro:content` が内部的に `z` を再エクスポートしている設計のため、外部から置き換えできない
3. **`tsconfig.json` の `ignoreDeprecations: "5.0"` で抑制** — ○ 最小変更、Astro 側対応待ちまでの暫定対応

## 変更

`tsconfig.json` の `compilerOptions` に `"ignoreDeprecations": "5.0"` を追加。

## 検証

- [x] `npm run check` : **0 errors / 0 warnings**(従来 78 warnings)
- [x] `npm run build` : exit 0、Pagefind インデックス OK

## 将来の戻し条件

Astro が `astro:content` の zod ラッパーを Zod v4 個別 export 方式に更新したら、`ignoreDeprecations` を削除して警告ゼロを再検証する。

## Test plan

- [x] 型チェックがゼロ警告で通る
- [x] ビルドに影響なし
- [ ] Cloudflare Pages デプロイ確認