### PR TITLE
feat(seo): add Article + BreadcrumbList JSON-LD schemas to strategy and column pages

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -4,15 +4,21 @@ interface Props {
   title?: string;
   description?: string;
   ogImagePath?: string;
+  articleJsonLd?: object;
+  breadcrumbJsonLd?: object;
 }
 const {
   title = "EduEvidence JP — 小学校エビデンスポータル",
   description = "日本の小学校教員のための教育エビデンスまとめサイト。国内外の研究から得られた知見を「効果」「信頼性」「コスト」「出典」の4指標で整理し、現場で使える形に翻案して公開。",
   ogImagePath,
+  articleJsonLd,
+  breadcrumbJsonLd,
 } = Astro.props;
 const siteUrl = "https://edu-evidence.org";
 const canonicalUrl = new URL(Astro.url.pathname, siteUrl).href;
 const ogImage = ogImagePath ? `${siteUrl}${ogImagePath}` : `${siteUrl}/og-image.png`;
+
+const escapeLd = (obj: object): string => JSON.stringify(obj).replace(/</g, "\\u003c");
 ---
 
 <!doctype html>
@@ -46,14 +52,20 @@ const ogImage = ogImagePath ? `${siteUrl}${ogImagePath}` : `${siteUrl}/og-image.
     <link rel="alternate" type="application/rss+xml" title="EduEvidence JP — エビデンスで考える" href="/rss.xml" />
 
     <!-- Structured Data -->
-    <script type="application/ld+json" set:html={JSON.stringify({
+    <script type="application/ld+json" set:html={escapeLd({
       "@context": "https://schema.org",
       "@type": "WebSite",
       "name": "EduEvidence JP",
       "url": siteUrl,
       "description": description,
       "inLanguage": "ja",
-    }).replace(/</g, "\\u003c")} />
+    })} />
+    {articleJsonLd && (
+      <script type="application/ld+json" set:html={escapeLd(articleJsonLd)} />
+    )}
+    {breadcrumbJsonLd && (
+      <script type="application/ld+json" set:html={escapeLd(breadcrumbJsonLd)} />
+    )}
   </head>
   <body class="bg-[var(--color-bg)] text-[var(--color-ink)]">
     <header class="relative border-b border-[var(--color-line)]">

--- a/src/pages/columns/[...slug].astro
+++ b/src/pages/columns/[...slug].astro
@@ -17,9 +17,44 @@ const strategyById = new Map(allStrategies.map((s) => [s.id, s]));
 const related = (d.relatedStrategies ?? [])
   .map((id) => strategyById.get(id))
   .filter((s): s is (typeof allStrategies)[number] => Boolean(s));
+
+const siteUrl = "https://edu-evidence.org";
+const pageUrl = `${siteUrl}/columns/${entry.id}`;
+const articleJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "Article",
+  headline: d.title,
+  description: d.summary,
+  datePublished: d.date,
+  dateModified: d.lastVerified ?? d.date,
+  author: { "@type": "Person", name: "伊差川隼人" },
+  publisher: {
+    "@type": "Organization",
+    name: "EduEvidence JP",
+    url: siteUrl,
+  },
+  mainEntityOfPage: pageUrl,
+  url: pageUrl,
+  inLanguage: "ja",
+  keywords: d.tags.join(", "),
+};
+const breadcrumbJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  itemListElement: [
+    { "@type": "ListItem", position: 1, name: "ホーム", item: `${siteUrl}/` },
+    { "@type": "ListItem", position: 2, name: "コラム", item: `${siteUrl}/columns` },
+    { "@type": "ListItem", position: 3, name: d.title, item: pageUrl },
+  ],
+};
 ---
 
-<Layout title={`${d.title} — EduEvidence JP`} description={d.summary}>
+<Layout
+  title={`${d.title} — EduEvidence JP`}
+  description={d.summary}
+  articleJsonLd={articleJsonLd}
+  breadcrumbJsonLd={breadcrumbJsonLd}
+>
   <div class="pt-10 pb-6">
     <a
       href="/columns"

--- a/src/pages/strategies/[...slug].astro
+++ b/src/pages/strategies/[...slug].astro
@@ -17,6 +17,38 @@ const referringColumns = allColumns
   .filter((c) => (c.data.relatedStrategies ?? []).includes(entry.id))
   .sort((a, b) => (b.data.date || "").localeCompare(a.data.date || ""));
 
+const siteUrl = "https://edu-evidence.org";
+const pageUrl = `${siteUrl}/strategies/${entry.id}`;
+const dateModified = d.lastVerified ?? "2026-04-01";
+const articleJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "Article",
+  headline: d.title,
+  description: d.summary,
+  datePublished: dateModified,
+  dateModified,
+  author: { "@type": "Person", name: "伊差川隼人" },
+  publisher: {
+    "@type": "Organization",
+    name: "EduEvidence JP",
+    url: siteUrl,
+  },
+  image: `${siteUrl}/og/${entry.id}.png`,
+  mainEntityOfPage: pageUrl,
+  url: pageUrl,
+  inLanguage: "ja",
+  keywords: d.tags.join(", "),
+};
+const breadcrumbJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  itemListElement: [
+    { "@type": "ListItem", position: 1, name: "ホーム", item: `${siteUrl}/` },
+    { "@type": "ListItem", position: 2, name: "指導法一覧", item: `${siteUrl}/#strategy-list` },
+    { "@type": "ListItem", position: 3, name: d.title, item: pageUrl },
+  ],
+};
+
 const stars = "★".repeat(d.evidenceStrength) + "☆".repeat(5 - d.evidenceStrength);
 const yen = "¥".repeat(d.cost) + "·".repeat(5 - d.cost);
 
@@ -46,7 +78,13 @@ const effectNote =
       : `3月時点で、通常より約${Math.abs(d.monthsGained)}ヶ月分学力が低下する傾向`;
 ---
 
-<Layout title={`${d.title} — EduEvidence JP`} description={d.summary} ogImagePath={`/og/${entry.id}.png`}>
+<Layout
+  title={`${d.title} — EduEvidence JP`}
+  description={d.summary}
+  ogImagePath={`/og/${entry.id}.png`}
+  articleJsonLd={articleJsonLd}
+  breadcrumbJsonLd={breadcrumbJsonLd}
+>
   <div class="pt-10 pb-6">
     <a
       href="/"


### PR DESCRIPTION
## 背景

現状 `src/layouts/Layout.astro` には WebSite スキーマの JSON-LD のみ実装されており、戦略・コラム詳細ページには構造化データがない。Google リッチスニペット対応と、edu-watch(姉妹サイト)からの SEO 流入強化のため Article と BreadcrumbList を追加する。

## 変更内容

### `src/layouts/Layout.astro`

- `articleJsonLd?: object` と `breadcrumbJsonLd?: object` を Props に追加
- 共通ヘルパー `escapeLd()` で `<` → `\u003c` エスケープを 1 箇所に集約(既存の WebSite スキーマも同じヘルパーを使う形に統一)
- 既存の WebSite `<script type="application/ld+json">` の直後に条件付きで追加ブロックを出力

### `src/pages/strategies/[...slug].astro`

- Article スキーマを frontmatter から組み立て:
  - headline: `title` / description: `summary` / keywords: `tags.join(", ")`
  - datePublished / dateModified: `lastVerified`(未設定時のフォールバックあり)
  - image: `/og/<slug>.png` の絶対 URL
  - author: 伊差川隼人 / publisher: EduEvidence JP
- BreadcrumbList: **ホーム → 指導法一覧(/#strategy-list) → 個別戦略**

### `src/pages/columns/[...slug].astro`

- Article スキーマを frontmatter から組み立て:
  - datePublished: `date` / dateModified: `lastVerified ?? date`
  - keywords: `tags.join(", ")`
  - image は未指定(コラムは OG 画像を持たないため)
- BreadcrumbList: **ホーム → コラム(/columns) → 個別コラム**

## 検証

- [x] `npm run check` : 0 errors / 0 warnings
- [x] `npm run build` : exit 0、Pagefind インデックス OK
- [x] 戦略ページの HTML に `Article / BreadcrumbList / ListItem×3 / Organization / Person / WebSite` の全スキーマが出力されることを確認(`dist/strategies/feedback/index.html` 他)
- [x] コラムページの HTML でも同様に出力される
- [x] 実サンプル:
  - `"headline":"フィードバック"`
  - `"name":"ホーム","item":"https://edu-evidence.org/"`
  - `"name":"いじめ認知76万件 — 「認知が増えた」は本当に悪いことなのか？","item":"https://edu-evidence.org/columns/bullying-recognition-paradox"`

## マージ後の検証計画

- [Google リッチリザルトテスト](https://search.google.com/test/rich-results) で本番 URL を数件検証
- Search Console で 1〜2 週間後にリッチスニペット / パンくず表示の反映を確認

## Test plan

- [x] 型チェック
- [x] 本番ビルド
- [x] JSON-LD が期待通り出力されていること(grep で確認)
- [x] Cloudflare Pages 本番での Google Rich Results テスト