### PR TITLE
chore: rename package from edu-evidence-portal to edu-evidence

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "edu-evidence-portal",
+  "name": "edu-evidence",
   "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "edu-evidence-portal",
+      "name": "edu-evidence",
       "version": "0.0.1",
       "dependencies": {
         "@astrojs/react": "^5.0.3",
@@ -35,6 +35,9 @@
         "textlint-rule-prh": "^6.1.0",
         "tsx": "^4.21.0",
         "typescript": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=24.0.0"
       }
     },
     "node_modules/@astrojs/check": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "edu-evidence-portal",
+  "name": "edu-evidence",
   "type": "module",
   "version": "0.0.1",
   "engines": {


### PR DESCRIPTION
## 背景

ローカル作業ディレクトリ・リポジトリ名・ドメイン・姉妹サイトの命名を揃える:

| 対象 | 旧 | 新 |
|---|---|---|
| GitHub リポジトリ名 | `edu-evidence` | `edu-evidence`(変更なし) |
| 本番ドメイン | `edu-evidence.org` | `edu-evidence.org`(変更なし) |
| ローカル作業ディレクトリ | `~/edu-evidence-portal` | `~/edu-evidence` ✓ |
| `package.json` の `name` | `edu-evidence-portal` | **`edu-evidence`**(本 PR) |
| 姉妹サイト(PRD 策定中) | — | `edu-watch` |

`portal` サフィックスが残っていたのは命名の初期残滓。リポジトリ・ドメイン・姉妹サイトと揃えて認知負荷を下げる。

## 変更内容

- `package.json` の `name` を `edu-evidence` に変更
- `npm install` で `package-lock.json` も自動的に新しい名前に再生成

## 実行時の影響

- **実行時影響なし**。`package.json#name` は npm publish 用のフィールドで、このサイトは npm パッケージとして publish していないため、ビルドや CI に一切影響しない
- ローカル作業ディレクトリを `~/edu-evidence` に既にリネーム済み(`mv` のみ、git/node_modules/Astro は相対パス管理のため無傷)
- Cloudflare Pages / GitHub Actions はリポジトリルート相対で動くため、ローカルリネームの影響なし

## 検証

- [x] `npm run check` : 0 errors / 0 warnings
- [x] `npm install` でロックファイルの `name` が `edu-evidence` に更新されることを確認
- [x] 新ディレクトリ `~/edu-evidence` で全コマンド動作

## Test plan

- [x] 型チェック通過
- [x] ロックファイルの整合性確認
- [ ] Cloudflare Pages の次回デプロイが正常に通ること(影響なし想定だが確認)