### PR TITLE
feat(brand): strengthen leaf logo veins + currentColor implementation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,12 @@
 
 日本の小学校教員向け教育エビデンスポータル。Astro 6 + React 19 + Tailwind 4 + TypeScript。
 
+## ブランド
+
+- **モチーフ**: 成熟した葉(葉脈の通った 1 枚の葉)。姉妹サイト EduWatch JP の「双葉(cotyledon)」と対になり、「積み上げてきたエビデンス」を象徴する
+- **アクセント色**: 深緑 `#2b5d3a`(`--color-accent`)
+- **ロゴ実装**: `src/components/Logo.astro` が inline SVG + `currentColor` 継承。色を変えたい時は呼び出し側の `color:` / Tailwind の `text-` クラスを変えるだけで済み、SVG を直接編集する必要なし
+
 ## 環境
 
 Node.js のバージョンは `.tool-versions` で固定している(`nodejs 24.15.0`)。[mise](https://mise.jdx.dev/) を使う前提。

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,12 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
   <rect width="32" height="32" rx="6" fill="#2b5d3a"/>
-  <!-- Small leaf -->
+  <!-- EduEvidence JP favicon — 成熟した葉。葉脈を強調(太さと本数を favicon サイズ向けに最適化) -->
   <path d="M16 4 C9 9, 5 16, 7 24 C9 21, 12 18, 16 17 C20 18, 23 21, 25 24 C27 16, 23 9, 16 4Z" fill="#faf9f5"/>
-  <!-- Center vein -->
-  <line x1="16" y1="7" x2="16" y2="23" stroke="#2b5d3a" stroke-width="0.8" stroke-linecap="round"/>
-  <!-- Side veins -->
-  <line x1="16" y1="12" x2="11" y2="16" stroke="#2b5d3a" stroke-width="0.6" stroke-linecap="round"/>
-  <line x1="16" y1="16" x2="10.5" y2="19.5" stroke="#2b5d3a" stroke-width="0.6" stroke-linecap="round"/>
-  <line x1="16" y1="12" x2="21" y2="16" stroke="#2b5d3a" stroke-width="0.6" stroke-linecap="round"/>
-  <line x1="16" y1="16" x2="21.5" y2="19.5" stroke="#2b5d3a" stroke-width="0.6" stroke-linecap="round"/>
+  <line x1="16" y1="6" x2="16" y2="19" stroke="#2b5d3a" stroke-width="1.1" stroke-linecap="round"/>
+  <line x1="16" y1="10" x2="10.5" y2="14.5" stroke="#2b5d3a" stroke-width="0.9" stroke-linecap="round"/>
+  <line x1="16" y1="14" x2="9.5" y2="18.5" stroke="#2b5d3a" stroke-width="0.9" stroke-linecap="round"/>
+  <line x1="16" y1="10" x2="21.5" y2="14.5" stroke="#2b5d3a" stroke-width="0.9" stroke-linecap="round"/>
+  <line x1="16" y1="14" x2="22.5" y2="18.5" stroke="#2b5d3a" stroke-width="0.9" stroke-linecap="round"/>
 </svg>

--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,16 +1,13 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120">
-  <!-- Leaf shape -->
-  <path d="M60 10 C30 25, 15 55, 20 85 C25 75, 35 65, 60 58 C85 65, 95 75, 100 85 C105 55, 90 25, 60 10Z" fill="#2b5d3a"/>
-  <!-- Leaf vein (center) -->
-  <line x1="60" y1="18" x2="60" y2="82" stroke="#faf9f5" stroke-width="2" stroke-linecap="round"/>
-  <!-- Leaf veins (left) -->
-  <line x1="60" y1="38" x2="38" y2="52" stroke="#faf9f5" stroke-width="1.5" stroke-linecap="round"/>
-  <line x1="60" y1="52" x2="34" y2="64" stroke="#faf9f5" stroke-width="1.5" stroke-linecap="round"/>
-  <line x1="60" y1="64" x2="36" y2="76" stroke="#faf9f5" stroke-width="1.5" stroke-linecap="round"/>
-  <!-- Leaf veins (right) -->
-  <line x1="60" y1="38" x2="82" y2="52" stroke="#faf9f5" stroke-width="1.5" stroke-linecap="round"/>
-  <line x1="60" y1="52" x2="86" y2="64" stroke="#faf9f5" stroke-width="1.5" stroke-linecap="round"/>
-  <line x1="60" y1="64" x2="84" y2="76" stroke="#faf9f5" stroke-width="1.5" stroke-linecap="round"/>
-  <!-- Stem -->
-  <line x1="60" y1="82" x2="60" y2="110" stroke="#2b5d3a" stroke-width="3" stroke-linecap="round"/>
+  <!-- EduEvidence JP logo — 成熟した葉。外部公開用(OG 等)は色を #2b5d3a で固定。
+       サイト内のヘッダー/フッターは src/components/Logo.astro で currentColor 継承版を使う。 -->
+  <path d="M60 10 C25 28, 15 58, 22 88 C30 78, 42 68, 60 62 C78 68, 90 78, 98 88 C105 58, 95 28, 60 10Z" fill="#2b5d3a"/>
+  <line x1="60" y1="14" x2="60" y2="78" stroke="#faf9f5" stroke-width="2.5" stroke-linecap="round"/>
+  <line x1="60" y1="32" x2="36" y2="48" stroke="#faf9f5" stroke-width="2" stroke-linecap="round"/>
+  <line x1="60" y1="52" x2="30" y2="66" stroke="#faf9f5" stroke-width="2" stroke-linecap="round"/>
+  <line x1="60" y1="70" x2="38" y2="80" stroke="#faf9f5" stroke-width="2" stroke-linecap="round"/>
+  <line x1="60" y1="32" x2="84" y2="48" stroke="#faf9f5" stroke-width="2" stroke-linecap="round"/>
+  <line x1="60" y1="52" x2="90" y2="66" stroke="#faf9f5" stroke-width="2" stroke-linecap="round"/>
+  <line x1="60" y1="70" x2="82" y2="80" stroke="#faf9f5" stroke-width="2" stroke-linecap="round"/>
+  <line x1="60" y1="78" x2="60" y2="112" stroke="#2b5d3a" stroke-width="3" stroke-linecap="round"/>
 </svg>

--- a/src/components/Logo.astro
+++ b/src/components/Logo.astro
@@ -1,0 +1,46 @@
+---
+/**
+ * EduEvidence JP brand mark — 成熟した葉
+ *
+ * モチーフ: しっかり葉脈の通った成熟した葉は「積み上げてきたエビデンス」を
+ * 象徴。姉妹サイト EduWatch JP の「双葉(cotyledon)」モチーフと対になり、
+ * 両サイトで「学びを育む植物」の成長段階を表現する。
+ *
+ * 色は currentColor を継承するので、呼び出し側で `color:` / Tailwind の
+ * text- クラスを指定すれば反映される。
+ */
+interface Props {
+  class?: string;
+}
+const { class: className = "" } = Astro.props;
+---
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 120 120"
+  class={className}
+  aria-hidden="true"
+  fill="currentColor"
+>
+  <!-- 葉本体 -->
+  <path d="M60 10 C25 28, 15 58, 22 88 C30 78, 42 68, 60 62 C78 68, 90 78, 98 88 C105 58, 95 28, 60 10Z" />
+  <!-- 中央葉脈(強調) -->
+  <line
+    x1="60"
+    y1="14"
+    x2="60"
+    y2="78"
+    stroke="var(--color-bg, #faf9f5)"
+    stroke-width="2.5"
+    stroke-linecap="round"
+  />
+  <!-- 左葉脈 -->
+  <line x1="60" y1="32" x2="36" y2="48" stroke="var(--color-bg, #faf9f5)" stroke-width="2" stroke-linecap="round" />
+  <line x1="60" y1="52" x2="30" y2="66" stroke="var(--color-bg, #faf9f5)" stroke-width="2" stroke-linecap="round" />
+  <line x1="60" y1="70" x2="38" y2="80" stroke="var(--color-bg, #faf9f5)" stroke-width="2" stroke-linecap="round" />
+  <!-- 右葉脈 -->
+  <line x1="60" y1="32" x2="84" y2="48" stroke="var(--color-bg, #faf9f5)" stroke-width="2" stroke-linecap="round" />
+  <line x1="60" y1="52" x2="90" y2="66" stroke="var(--color-bg, #faf9f5)" stroke-width="2" stroke-linecap="round" />
+  <line x1="60" y1="70" x2="82" y2="80" stroke="var(--color-bg, #faf9f5)" stroke-width="2" stroke-linecap="round" />
+  <!-- 茎 -->
+  <line x1="60" y1="78" x2="60" y2="112" stroke="currentColor" stroke-width="3" stroke-linecap="round" />
+</svg>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,5 +1,6 @@
 ---
 import "../styles/global.css";
+import Logo from "../components/Logo.astro";
 interface Props {
   title?: string;
   description?: string;
@@ -73,7 +74,9 @@ const escapeLd = (obj: object): string => JSON.stringify(obj).replace(/</g, "\\u
         class="mx-auto max-w-6xl px-3 xs:px-4 sm:px-6 md:px-10 h-16 flex items-center justify-between gap-4"
       >
         <a href="/" class="font-black text-lg sm:text-xl tracking-tight flex items-center gap-2 whitespace-nowrap shrink-0">
-          <img src="/logo.svg" alt="" class="w-7 h-7 shrink-0" />
+          <span class="text-[var(--color-accent)] inline-flex shrink-0">
+            <Logo class="w-7 h-7" />
+          </span>
           EduEvidence <span class="text-[var(--color-accent)]">JP</span>
         </a>
         <nav class="hidden lg:flex text-xs gap-4 lg:gap-6 text-[var(--color-sub)]" aria-label="メインナビゲーション">
@@ -212,7 +215,9 @@ const escapeLd = (obj: object): string => JSON.stringify(obj).replace(/</g, "\\u
         <!-- Column 1: ブランド -->
         <div class="space-y-4">
           <div class="font-black text-base text-[var(--color-ink)] flex items-center gap-2">
-            <img src="/logo.svg" alt="" class="w-5 h-5" />
+            <span class="text-[var(--color-accent)] inline-flex">
+              <Logo class="w-5 h-5" />
+            </span>
             EduEvidence <span class="text-[var(--color-accent)]">JP</span>
           </div>
           <p class="leading-relaxed">


### PR DESCRIPTION
## 背景

姉妹サイト EduWatch JP でロゴを双葉(cotyledon)に切り替える PR が進行中(`edu-watch#4`)。これにより両サイトが「植物モチーフ」で揃うブランド体系 A 案が確定:

- **EduEvidence JP**(本 PR で強化) = 成熟した葉(積み上げたエビデンス)
- **EduWatch JP** = 双葉(日々の新しい芽吹き = 日次ニュース)

現行の葉ロゴをそのまま残すのではなく、成熟した葉としての「葉脈の通り」を明確に読み取れるよう強化する。併せてロゴの色管理を `currentColor` ベースにリファクタし、以後 `--color-accent` を変更するだけでロゴ色が追随する構造に変える(EduWatch JP 側と同じ規約)。

## 変更内容

### `src/components/Logo.astro`(新規)

- 葉本体 + 葉脈 + 茎を inline SVG で定義
- `fill="currentColor"` + 葉脈 stroke を `var(--color-bg)` 参照
- 呼び出し側で `color:` / Tailwind `text-[var(--color-accent)]` を指定すれば色が切り替わる

### 葉脈デザインの強化

葉の意味が一目で読み取れるよう、以下を調整:

| 要素 | 変更前 | 変更後 |
|---|---|---|
| 中央葉脈の太さ | `stroke-width=2` | **`2.5`** |
| 左右葉脈の太さ | `stroke-width=1.5` | **`2.0`** |
| 側脈の角度 | 外輪に届かずやや内側で途切れ | 葉のシルエット外郭まで届く再アンカー |

結果、ヘッダーサイズ(20〜28 px)でも葉脈が判読可能になり、遠目でも「葉」として成立する。

### `src/layouts/Layout.astro`

- `<img src="/logo.svg">` を `<Logo />` に置き換え(ヘッダー + フッター)
- ロゴを `<span class="text-[var(--color-accent)] inline-flex">` で包み、マーク自体はアクセント色、周囲の wordmark 「EduEvidence JP」の `JP` はアクセント色のまま、先頭「EduEvidence 」はベース色(ink)という現状の階層を維持

### `public/logo.svg`(更新)

- 外部共有(OG / RSS リーダー / シェアカード等)向けのスタンドアローン版
- アクセント色を `#2b5d3a` で固定色に埋め込み、inline SVG と同じ葉脈太さ

### `public/favicon.svg`(更新)

- 葉脈を favicon サイズ向けに太く・長く再調整(`0.6 → 0.9` stroke-width)
- 16〜32 px でも葉脈が視認できるよう最適化

### `CLAUDE.md`

- 「ブランド」セクションを新設し、モチーフ(成熟した葉)・アクセント色・`currentColor` 運用ルールを明文化

## 検証

- [x] `npm run check` : 0 errors / 0 warnings
- [x] `npm run build` : exit 0、Pagefind インデックス OK
- [x] ビルド後の HTML に inline SVG が 2 つ(ヘッダー + フッター)、`currentColor` 参照が 5 箇所含まれることを確認

## デザインの目視確認

GitHub の PR 画面で `public/logo.svg` と `public/favicon.svg` の "View file" をクリックすると、実際のレンダリング結果が見られます。

形状に違和感があれば本 PR 内の追加コミットで調整できます(葉の角度・茎の長さ・葉脈の本数 など)。

## 連動 PR(EduWatch JP 側)

- `edu-watch#4`: 双葉(cotyledon)ロゴ + currentColor 対応
- 両 PR が揃うと、両サイトで「植物モチーフによる姉妹ブランド体系」が完成する

## Test plan

- [x] 型チェック・本番ビルド通過
- [x] inline SVG / favicon / standalone logo の 3 パスで同じモチーフ(強化された葉)が出力される
- [ ] Cloudflare Pages デプロイ後、`https://edu-evidence.org/` のヘッダー・フッター・ブラウザタブアイコンを目視確認
- [ ] 形状に違和感があれば SVG の座標を調整する追加コミットを本 PR に積む