### PR TITLE
chore(seo): normalize JSON-LD author.name to Isagawa Hayato

### DIFF
--- a/src/pages/columns/[...slug].astro
+++ b/src/pages/columns/[...slug].astro
@@ -27,7 +27,7 @@ const articleJsonLd = {
   description: d.summary,
   datePublished: d.date,
   dateModified: d.lastVerified ?? d.date,
-  author: { "@type": "Person", name: "伊差川隼人" },
+  author: { "@type": "Person", name: "Isagawa Hayato" },
   publisher: {
     "@type": "Organization",
     name: "EduEvidence JP",

--- a/src/pages/strategies/[...slug].astro
+++ b/src/pages/strategies/[...slug].astro
@@ -27,7 +27,7 @@ const articleJsonLd = {
   description: d.summary,
   datePublished: dateModified,
   dateModified,
-  author: { "@type": "Person", name: "伊差川隼人" },
+  author: { "@type": "Person", name: "Isagawa Hayato" },
   publisher: {
     "@type": "Organization",
     name: "EduEvidence JP",


### PR DESCRIPTION
## 背景

戦略詳細 / コラム詳細ページの Article JSON-LD に埋め込んでいる `author.name` が日本語フルネーム表記になっていた。**Public に露出するバイライン** は GitHub ハンドル(`Hayato-Isagawa`)と整合する英名 + 姓名順にする方針で統一する。

## 変更内容

| ファイル | 変更 |
|---|---|
| `src/pages/strategies/[...slug].astro` | `author.name` を **`Isagawa Hayato`** に置換 |
| `src/pages/columns/[...slug].astro` | 同上 |

`Isagawa Hayato`(family-name-first)を採用した理由:

- GitHub ハンドル `Hayato-Isagawa` と単語構成が一致
- Google Scholar など学術系の byline 慣習(family name first)に整合
- JSON-LD の国際的な消費者(Google リッチ結果、SNS プレビュー、Search Console)に対して読みやすい

## 表示への影響

現状、サイト内にバイライン表示はなく、**JSON-LD の構造化データのみ** に埋め込まれている。マージしても視覚的な変化はない。Google / 他の構造化データ消費者が読む `author.name` の値が切り替わる。

## 検証

- [x] `npm run check` : 0 errors / 0 warnings
- [x] `npm run build` : exit 0、Pagefind OK
- [x] ビルド後 HTML の JSON-LD を grep で確認: `"author":{"@type":"Person","name":"Isagawa Hayato"}`

## 関連する追加対応(別 PR)

- **PR #105** のエージェント定義(`.claude/agents/edu-content-reviewer.md`)も同方針で追従コミットを追加済
- edu-watch 側(`docs/PRD.md` / `docs/sprint-2-design.md`)は edu-watch リポジトリで別 PR を発行済(`Hayato-Isagawa/edu-watch#11`)

## Test plan

- [x] 型チェック・ビルド通過
- [x] JSON-LD 出力を目視確認
- [ ] Cloudflare Pages デプロイ後、本番ページの構造化データを Google リッチリザルトテストで確認