### PR TITLE
feat(layout): sticky header + scroll lock + ADR 0007 (semantic attribute state)

### DIFF
--- a/docs/decisions/0007-semantic-attribute-state-management.md
+++ b/docs/decisions/0007-semantic-attribute-state-management.md
@@ -1,0 +1,79 @@
+# 0007. UI 状態はセマンティック属性(aria-* / data-*)で管理する
+
+- 状態: 採用
+- 日付: 2026-04-27
+- 関連 PR: #(本 ADR と同一 PR で確定)
+
+## 背景
+
+ヘッダーを sticky 化し、モバイルメニュー展開時に背景スクロールを固定する改修(PR `feat/sticky-header-and-scroll-lock`)を実施するにあたり、UI の状態(メニュー開閉、スクロール固定など)をどう表現するかを決める必要があった。
+
+選択肢として、
+
+- **A) スタイル駆動の修飾子クラス**(例: `is-open` / `--open` / `menu-open`)
+- **B) HTML 標準のセマンティック属性**(`aria-expanded` / `data-state` など)
+
+がある。既存実装(`src/layouts/Layout.astro`)は既に B 寄りで、ハンバーガーボタンに `aria-expanded` 、モバイルナビに `data-state="open|closed"` を持たせ、Tailwind 4 の属性セレクタ variant(`data-[state=open]:opacity-100`)で見た目を制御していた。
+
+新しく追加する状態(`<body>` のスクロール固定)を `body.menu-open` のようなクラスで表すと、既存の属性駆動方針と混在し、状態の真実(source of truth)が二重化する。
+
+## 検討した選択肢
+
+### A) スタイル駆動の修飾子クラス(例: `body.menu-open`, `.header--sticky`)
+
+- 利点: BEM などの命名規約に沿う、CSS 側の可読性が高い場合がある
+- 欠点:
+  - 状態がクラス名で表現されるためスクリーンリーダーや支援技術には伝わらない
+  - JS が「状態を更新する」のではなく「クラス名を付け替える」関心になり、状態管理と視覚表現が結合する
+  - 同一の状態を別の文脈で参照したい場合(例: テストでメニュー開閉を assert)に名前ベースのフックに依存する
+
+### B) HTML 標準のセマンティック属性(`aria-expanded` / `data-state` / `inert` / カスタム `data-*`)
+
+- 利点:
+  - `aria-expanded` などは支援技術が既定で解釈する。a11y と視覚状態が一致する
+  - JS の関心は「属性を更新する」だけで、見た目は CSS 属性セレクタが追従する
+  - 同一属性が DOM 検査・テスト・CSS の共通フックになる
+  - Tailwind 4 はネイティブで `data-[state=open]:` `aria-expanded:` などの variant をサポートしている
+- 欠点:
+  - 属性セレクタは複数値の表現にやや冗長(`data-state="open"` vs クラス `.open`)
+  - 既存メンバーが BEM 流派なら学習コストがある(本プロジェクトは個人運営のため該当なし)
+
+## 決定
+
+**B) を採用。本リポジトリの DOM 駆動 UI 状態は HTML セマンティック属性で表現する。**
+
+### 具体ルール
+
+1. **開閉/可視性のような状態**: `aria-expanded` を支援技術向けの真実の値とし、CSS フック(`data-state="open|closed"`)を併設する
+2. **フォーカス制御**: 閉じている領域には `inert` を付与する
+3. **複数要素にまたがる状態**(例: メニューが開いているとき body のスクロールを止めたい): スコープに最も近い祖先要素(典型的には `<body>` または `<html>`)に `data-*` を付ける(本件では `<body data-menu="open|closed">`)。命名規約は `data-<scope>` で短く保つ
+4. **スタイルは属性セレクタで参照**: Tailwind の `data-[state=open]:`、`aria-expanded:`、生 CSS の `body[data-menu="open"]` を使う。`is-open` / `--open` 等の修飾子クラスは追加しない
+5. **JS の責務**: 状態の更新(`element.dataset.menu = "open"`、`element.setAttribute("aria-expanded", "true")`)のみ。CSS クラスの付け外しで見た目を制御しない
+6. **初期値**: クライアント JS 実行前から正しい初期 DOM が得られるよう、サーバー側(Astro)で初期属性を出力する(例: `<body data-menu="closed">`、`<nav data-state="closed" inert>`)
+
+### 既存コードとの整合
+
+- 既存の `<button id="menu-toggle" aria-expanded>` と `<nav data-state="open|closed">` は本ルールにそのまま準拠している
+- 本 PR で追加した `<body data-menu="open|closed">` も同じ流儀
+- 修飾子クラス(`is-*`, `--*`)を新たに追加しない
+
+## 帰結
+
+### 良い帰結
+
+- 状態の真実が DOM 属性に一元化される(JS / CSS / 支援技術 / E2E テストが同じ属性を見る)
+- a11y が「視覚状態に追従する追加実装」ではなく既定で成立する
+- `prefers-reduced-motion` のようなメディアクエリと組み合わせやすい(状態 × メディア の二軸で表現できる)
+- ADR として明文化することで、将来コラボレータが入った際の規約が明確になる
+
+### トレードオフ
+
+- 「複数値の状態」を表すとき `data-state="closed"` のような書き方になり、`.closed` クラス比 1〜2 文字長い
+- CSS 側で属性セレクタの specificity を意識する必要がある(クラスと同じ 0,1,0 なので実用上は問題なし)
+- BEM ベースの素材を移植する際、命名の翻訳工程が増える
+
+## 撤回 / 再検討の条件
+
+- 将来、属性セレクタが Tailwind / 主要ブラウザでサポート低下した場合(現状の見通しでは発生しない)
+- 共同開発者が増え、BEM/CSS Modules 流派の方針を全体採用したほうが学習コストを下げられると判断された場合
+- React/Vue のクライアント主導 UI に大きく舵を切り、属性ではなく state hook 主導の表現に移行する場合

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -44,3 +44,4 @@
 - [0004. 公開氏名表記を Isagawa Hayato に統一](0004-public-byline-isagawa-hayato.md)
 - [0005. 本体は非営利維持、収益化は別ブランド SaaS に分離](0005-non-commercial-with-saas-separation.md)
 - [0006. 反論型コラムを解説型に差し替える(前提検証ルール)](0006-rebuttal-column-replaced-with-explainer.md)
+- [0007. UI 状態はセマンティック属性(aria-* / data-*)で管理する](0007-semantic-attribute-state-management.md)

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -134,7 +134,25 @@ test.describe("ナビゲーション", () => {
     await toggle.click();
     const menu = page.locator("#mobile-menu");
     await expect(menu).not.toHaveAttribute("inert");
+    await expect(menu).toHaveAttribute("data-state", "open");
+    await expect(toggle).toHaveAttribute("aria-expanded", "true");
+    await expect(page.locator("body")).toHaveAttribute("data-menu", "open");
     await toggle.click();
     await expect(menu).toHaveAttribute("inert", "");
+    await expect(menu).toHaveAttribute("data-state", "closed");
+    await expect(toggle).toHaveAttribute("aria-expanded", "false");
+    await expect(page.locator("body")).toHaveAttribute("data-menu", "closed");
+  });
+
+  test("ヘッダーが sticky で表示される", async ({ page }) => {
+    await page.goto("/");
+    const header = page.locator("header.site-header");
+    await expect(header).toBeVisible();
+    const position = await header.evaluate((el) => getComputedStyle(el).position);
+    expect(position).toBe("sticky");
+    await page.evaluate(() => window.scrollTo(0, 1500));
+    await page.waitForTimeout(100);
+    const headerBox = await header.boundingBox();
+    expect(headerBox?.y ?? 999).toBeLessThanOrEqual(0.5);
   });
 });

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -68,8 +68,8 @@ const escapeLd = (obj: object): string => JSON.stringify(obj).replace(/</g, "\\u
       <script type="application/ld+json" set:html={escapeLd(breadcrumbJsonLd)} />
     )}
   </head>
-  <body class="bg-[var(--color-bg)] text-[var(--color-ink)]">
-    <header class="relative border-b border-[var(--color-line)]">
+  <body class="bg-[var(--color-bg)] text-[var(--color-ink)]" data-menu="closed">
+    <header class="site-header">
       <div
         class="mx-auto max-w-6xl px-3 xs:px-4 sm:px-6 md:px-10 h-16 flex items-center justify-between gap-4"
       >
@@ -132,6 +132,7 @@ const escapeLd = (obj: object): string => JSON.stringify(obj).replace(/</g, "\\u
         const setOpen = (open) => {
           isOpen = open;
           menu.dataset.state = open ? "open" : "closed";
+          document.body.dataset.menu = open ? "open" : "closed";
           if (open) menu.removeAttribute("inert");
           else menu.setAttribute("inert", "");
           toggle.setAttribute("aria-expanded", String(open));

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -30,6 +30,8 @@ html {
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
   scroll-behavior: smooth;
+  scroll-padding-top: 4rem;
+  scrollbar-gutter: stable;
 }
 @media (prefers-reduced-motion: reduce) {
   html {
@@ -40,6 +42,32 @@ html {
 body {
   min-height: 100vh;
   line-height: 1.8;
+}
+
+body[data-menu="open"] {
+  overflow: hidden;
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 40;
+  background: color-mix(in oklab, var(--color-bg) 85%, transparent);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  border-bottom: 1px solid var(--color-line);
+}
+@supports not (backdrop-filter: blur(8px)) {
+  .site-header {
+    background: var(--color-bg);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .site-header {
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+    background: var(--color-bg);
+  }
 }
 
 a {


### PR DESCRIPTION
## Summary

長文化したコラム / 戦略ページの導線改善として、サイトヘッダーを sticky 化し、モバイルメニュー展開時の背景スクロールを止める。あわせて UI 状態を `--open` 修飾子クラスではなく HTML セマンティック属性(`aria-*` / `data-*`)で管理する方針を ADR 0007 として明文化。

## 変更点

- `src/styles/global.css`
  - `html { scroll-padding-top: 4rem; scrollbar-gutter: stable; }` を追加(アンカー遷移でヘッダー直下に着地、クラシックスクロールバー環境でのレイアウトシフト抑止)
  - `.site-header` を新設(`position: sticky; top: 0; backdrop-filter: blur(8px)`、`backdrop-filter` 非対応環境と `prefers-reduced-motion` で不透明背景にフォールバック)
  - `body[data-menu="open"] { overflow: hidden; }` を追加(背景スクロール固定)
- `src/layouts/Layout.astro`
  - `<body>` に `data-menu="closed"` を初期値で出力
  - `<header>` のクラスを `relative border-b border-[var(--color-line)]` から `site-header` に置換
  - メニュー開閉 JS に `document.body.dataset.menu = open ? "open" : "closed"` を 1 行追加
- `docs/decisions/0007-semantic-attribute-state-management.md`(新規)
  - UI 状態は `aria-*` / `data-*` で表現する規約を ADR 化
- `docs/decisions/README.md`
  - 索引に 0007 を追加
- `e2e/smoke.spec.ts`
  - モバイルメニューテストに `aria-expanded` / `data-state` / `body[data-menu]` の assert を追加
  - sticky ヘッダーテストを新規追加(computed `position: sticky` と、スクロール 1500px 後にヘッダーが viewport 上端に張り付くことを確認)

## 状態フック早見表

| 要素 | 属性 | 値 | 用途 |
|---|---|---|---|
| `<button id="menu-toggle">` | `aria-expanded` | `true / false` | 支援技術への状態通知 |
| `<nav id="mobile-menu">` | `data-state` | `open / closed` | メニュー本体の Tailwind 属性 variant フック |
| `<nav id="mobile-menu">` | `inert` | 有 / 無 | 閉時のフォーカス抑制 |
| `<body>` | `data-menu` | `open / closed` | 背景スクロール固定の CSS フック(本 PR 追加) |

`is-open` / `--open` 等の修飾子クラスは追加しない方針(ADR 0007)。

## 採用しなかった選択肢

- **スクロール方向で隠す/出すヘッダー**: Safari の画面下部タブ要素が同タイミングで現れ消えする UX が見にくくなるため不採用
- **`body.menu-open` クラスでのスクロール固定**: 既存の属性駆動方針と二重化するため不採用(ADR 0007)

## Test plan

- [x] `npm run check`(0 errors, 0 warnings)
- [x] `npm run build`(248 ページビルド成功)
- [x] `npm run test:e2e`(17 / 17 通過、新規 2 件含む)
- [x] 本番環境で `/strategies/feedback` 等の長尺ページをスクロールし、ヘッダーが追従し続けることを目視
- [x] モバイル(< 1024px)でハンバーガー → 背景スクロール停止 → 閉じる → 復帰、を目視
- [x] `prefers-reduced-motion` を有効にして、ヘッダー背景が不透明・blur 無しになることを目視