### PR TITLE
feat(layout): back-to-top button and reading progress bar

### DIFF
--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -155,4 +155,36 @@ test.describe("ナビゲーション", () => {
     const headerBox = await header.boundingBox();
     expect(headerBox?.y ?? 999).toBeLessThanOrEqual(0.5);
   });
+
+  test("ページ上部へ戻るボタンが 600px スクロール後に表示される", async ({ page }) => {
+    await page.goto("/strategies/feedback/");
+    const btn = page.locator("#back-to-top");
+    await expect(btn).toHaveAttribute("data-state", "hidden");
+    await expect(btn).toHaveAttribute("aria-hidden", "true");
+    await page.evaluate(() => window.scrollTo(0, 800));
+    await expect(btn).toHaveAttribute("data-state", "visible");
+    await expect(btn).toHaveAttribute("aria-hidden", "false");
+    await btn.click();
+    await page.waitForFunction(() => window.scrollY < 10);
+    await expect(btn).toHaveAttribute("data-state", "hidden");
+  });
+
+  test("長文ページに読了プログレスバーが表示される", async ({ page }) => {
+    await page.goto("/strategies/feedback/");
+    const bar = page.locator("#reading-progress");
+    await expect(bar).toHaveAttribute("role", "progressbar");
+    await expect(bar).toHaveAttribute("aria-valuenow", "0");
+    await page.evaluate(() => window.scrollTo(0, document.documentElement.scrollHeight));
+    await page.waitForFunction(() => {
+      const el = document.getElementById("reading-progress");
+      return el && Number(el.getAttribute("aria-valuenow")) >= 90;
+    });
+    const finalValue = await bar.getAttribute("aria-valuenow");
+    expect(Number(finalValue)).toBeGreaterThanOrEqual(90);
+  });
+
+  test("短文ページにはプログレスバーが表示されない", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.locator("#reading-progress")).toHaveCount(0);
+  });
 });

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -7,6 +7,7 @@ interface Props {
   ogImagePath?: string;
   articleJsonLd?: object;
   breadcrumbJsonLd?: object;
+  longForm?: boolean;
 }
 const {
   title = "EduEvidence JP — 小学校エビデンスポータル",
@@ -14,6 +15,7 @@ const {
   ogImagePath,
   articleJsonLd,
   breadcrumbJsonLd,
+  longForm = false,
 } = Astro.props;
 const siteUrl = "https://edu-evidence.org";
 const canonicalUrl = new URL(Astro.url.pathname, siteUrl).href;
@@ -120,7 +122,32 @@ const escapeLd = (obj: object): string => JSON.stringify(obj).replace(/</g, "\\u
           <li><a href="/search" class="block py-3 hover:text-[var(--color-ink)] transition">検索</a></li>
         </ul>
       </nav>
+      {longForm && (
+        <div
+          id="reading-progress"
+          role="progressbar"
+          aria-label="ページの読了率"
+          aria-valuemin="0"
+          aria-valuemax="100"
+          aria-valuenow="0"
+          data-progress="0"
+        ></div>
+      )}
     </header>
+
+    <button
+      id="back-to-top"
+      type="button"
+      data-state="hidden"
+      aria-label="ページ上部へ戻る"
+      aria-hidden="true"
+      tabindex="-1"
+    >
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <path d="M12 19V5" />
+        <path d="m5 12 7-7 7 7" />
+      </svg>
+    </button>
 
     <script is:inline>
       (function () {
@@ -150,6 +177,50 @@ const escapeLd = (obj: object): string => JSON.stringify(obj).replace(/</g, "\\u
         window.addEventListener("resize", () => {
           if (window.innerWidth >= 640 && isOpen) setOpen(false);
         });
+      })();
+    </script>
+
+    <script is:inline>
+      (function () {
+        const backToTop = document.getElementById("back-to-top");
+        const progress = document.getElementById("reading-progress");
+        if (!backToTop && !progress) return;
+        const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+        let ticking = false;
+        const update = () => {
+          ticking = false;
+          const y = window.scrollY;
+          if (backToTop) {
+            const visible = y > 600;
+            const next = visible ? "visible" : "hidden";
+            if (backToTop.dataset.state !== next) {
+              backToTop.dataset.state = next;
+              backToTop.setAttribute("aria-hidden", String(!visible));
+              backToTop.setAttribute("tabindex", visible ? "0" : "-1");
+            }
+          }
+          if (progress) {
+            const max = document.documentElement.scrollHeight - window.innerHeight;
+            const ratio = max > 0 ? Math.min(1, Math.max(0, y / max)) : 0;
+            const pct = Math.round(ratio * 100);
+            progress.dataset.progress = String(pct);
+            progress.setAttribute("aria-valuenow", String(pct));
+            progress.style.transform = "scaleX(" + ratio + ")";
+          }
+        };
+        const onScroll = () => {
+          if (ticking) return;
+          ticking = true;
+          window.requestAnimationFrame(update);
+        };
+        if (backToTop) {
+          backToTop.addEventListener("click", () => {
+            window.scrollTo({ top: 0, behavior: reduceMotion ? "auto" : "smooth" });
+          });
+        }
+        window.addEventListener("scroll", onScroll, { passive: true });
+        window.addEventListener("resize", onScroll, { passive: true });
+        update();
       })();
     </script>
 

--- a/src/pages/columns/[...slug].astro
+++ b/src/pages/columns/[...slug].astro
@@ -54,6 +54,7 @@ const breadcrumbJsonLd = {
   description={d.summary}
   articleJsonLd={articleJsonLd}
   breadcrumbJsonLd={breadcrumbJsonLd}
+  longForm
 >
   <div class="pt-10 pb-6">
     <a

--- a/src/pages/strategies/[...slug].astro
+++ b/src/pages/strategies/[...slug].astro
@@ -84,6 +84,7 @@ const effectNote =
   ogImagePath={`/og/${entry.id}.png`}
   articleJsonLd={articleJsonLd}
   breadcrumbJsonLd={breadcrumbJsonLd}
+  longForm
 >
   <div class="pt-10 pb-6">
     <a

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -102,11 +102,14 @@ body[data-menu="open"] {
   background: var(--color-accent);
   color: var(--color-bg);
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  cursor: pointer;
   opacity: 0;
   transform: translateY(0.5rem);
   transition:
     opacity 200ms ease-out,
-    transform 200ms ease-out;
+    transform 200ms ease-out,
+    background-color 200ms ease-out,
+    box-shadow 200ms ease-out;
   pointer-events: none;
 }
 #back-to-top svg {
@@ -118,8 +121,10 @@ body[data-menu="open"] {
   transform: translateY(0);
   pointer-events: auto;
 }
-#back-to-top:hover {
+#back-to-top[data-state="visible"]:hover {
   background: color-mix(in oklab, var(--color-accent) 85%, black);
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.2);
+  transform: translateY(-2px);
 }
 #back-to-top:focus-visible {
   outline: 2px solid var(--color-accent);
@@ -127,10 +132,13 @@ body[data-menu="open"] {
 }
 @media (prefers-reduced-motion: reduce) {
   #back-to-top {
-    transition: opacity 100ms linear;
+    transition:
+      opacity 100ms linear,
+      background-color 100ms linear;
     transform: none;
   }
-  #back-to-top[data-state="visible"] {
+  #back-to-top[data-state="visible"],
+  #back-to-top[data-state="visible"]:hover {
     transform: none;
   }
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -70,6 +70,71 @@ body[data-menu="open"] {
   }
 }
 
+#reading-progress {
+  position: absolute;
+  left: 0;
+  bottom: -1px;
+  width: 100%;
+  height: 2px;
+  background: var(--color-accent);
+  transform-origin: left center;
+  transform: scaleX(0);
+  transition: transform 80ms linear;
+  pointer-events: none;
+}
+@media (prefers-reduced-motion: reduce) {
+  #reading-progress {
+    transition: none;
+  }
+}
+
+#back-to-top {
+  position: fixed;
+  right: clamp(0.75rem, 2vw, 1.5rem);
+  bottom: clamp(1rem, 3vw, 2rem);
+  z-index: 30;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.75rem;
+  height: 2.75rem;
+  border-radius: 9999px;
+  background: var(--color-accent);
+  color: var(--color-bg);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  opacity: 0;
+  transform: translateY(0.5rem);
+  transition:
+    opacity 200ms ease-out,
+    transform 200ms ease-out;
+  pointer-events: none;
+}
+#back-to-top svg {
+  width: 1.25rem;
+  height: 1.25rem;
+}
+#back-to-top[data-state="visible"] {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+#back-to-top:hover {
+  background: color-mix(in oklab, var(--color-accent) 85%, black);
+}
+#back-to-top:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 3px;
+}
+@media (prefers-reduced-motion: reduce) {
+  #back-to-top {
+    transition: opacity 100ms linear;
+    transform: none;
+  }
+  #back-to-top[data-state="visible"] {
+    transform: none;
+  }
+}
+
 a {
   color: inherit;
   text-decoration: none;


### PR DESCRIPTION
## Summary

長文化が進んだ戦略 / コラムページの読みやすさを底上げする 2 つの UI 要素を追加。PR #118 で導入した sticky ヘッダーと組み合わせ、長文ページでの読書体験を一段階引き上げる。

## 追加要素

### A. ページ上部へ戻るボタン

- 全ページで 600px 以上スクロールした時点で右下に表示
- `<button id="back-to-top" data-state="hidden|visible" aria-label="ページ上部へ戻る">` で属性駆動(ADR 0007 準拠)
- 非表示時は `aria-hidden="true"` + `tabindex="-1"` でフォーカス順序からも除外
- クリックで `window.scrollTo({ top: 0, behavior: "smooth" })`、`prefers-reduced-motion` 時は instant
- 配色はアクセント深緑、`focus-visible` でアウトライン表示
- `cursor: pointer` を明示。hover で `background-color` / `box-shadow` / `transform: translateY(-2px)` を 200ms ease-out で滑らかに遷移

### B. 読了プログレスバー(長文ページのみ)

- sticky ヘッダーの下端に 2px のアクセントカラーバー
- `<div role="progressbar" aria-valuenow="0..100" data-progress>` で属性駆動
- `transform: scaleX()` のみで描画(layout を引き起こさない compositor-friendly)
- `Layout` コンポーネントに `longForm?: boolean` prop を新設し、戦略 / コラムの slug ページで `longForm` を渡したときだけレンダー
- トップページなど短文ページには出さない(余計な視覚ノイズを避けるため)

## 実装上の工夫

- 単一の rAF スロットル付きスクロールハンドラで両者を同時更新(`window.scrollY` を 1 回読むだけ)
- `prefers-reduced-motion: reduce` の場合: ボタンの translateY 演出を無効化、スクロールを `auto` に切替、プログレスバーの transition も無効化
- z-index は header (40) 未満、tooltip (9999) 未満。モバイルメニュー (50) には干渉しない位置(右下 fixed)

## 状態フック早見表(本 PR 追加分)

| 要素 | 属性 | 値 | 用途 |
|---|---|---|---|
| `<button id="back-to-top">` | `data-state` | `hidden / visible` | 表示状態の CSS フック |
| `<button id="back-to-top">` | `aria-hidden` | `true / false` | 非表示時の支援技術通知 |
| `<button id="back-to-top">` | `tabindex` | `-1 / 0` | 非表示時のフォーカス順序除外 |
| `<div id="reading-progress">` | `role="progressbar"` | — | 支援技術への種別通知 |
| `<div id="reading-progress">` | `aria-valuenow` | `0..100` | 進捗値(支援技術が読み上げ可能) |
| `<div id="reading-progress">` | `data-progress` | `0..100` | CSS フック |

`is-visible` / `--shown` 等の修飾子クラスは追加せず、ADR 0007 のセマンティック属性方針を継続。

## Test plan

- [x] `npm run check`(0 errors, 0 warnings)
- [x] `npm run build`(248 ページビルド成功)
- [x] `npm run test:e2e`(20 / 20 通過、新規 3 件含む: back-to-top 表示・クリック / progress bar 進捗 / 短文ページ非表示)
- [x] 本番環境で `/strategies/feedback`(長尺)を最後までスクロールし、プログレスバーが 100% に達することを目視
- [x] 同ページで右下のボタンをクリックして上部に戻ることを目視
- [x] hover 時に色・影・浮き上がりが滑らかに遷移することを目視(cursor が pointer になっているか含む)
- [x] トップページ・検索ページ等でプログレスバーが出ないことを目視
- [x] `prefers-reduced-motion` を有効にして、スクロールが instant、ボタン演出が抑制されることを目視