### PR TITLE
feat(content): table of contents for strategy and column pages

### DIFF
--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -188,3 +188,44 @@ test.describe("ナビゲーション", () => {
     await expect(page.locator("#reading-progress")).toHaveCount(0);
   });
 });
+
+test.describe("目次 (TOC)", () => {
+  test("長文ページに sidebar / mobile 両 variant の TOC が描画される", async ({ page }) => {
+    await page.goto("/strategies/feedback/");
+    await expect(page.locator('[data-toc][data-toc-variant="sidebar"]')).toHaveCount(1);
+    await expect(page.locator('[data-toc][data-toc-variant="mobile"]')).toHaveCount(1);
+    const links = page.locator("[data-toc-link]");
+    expect(await links.count()).toBeGreaterThan(0);
+  });
+
+  test("短文ページには TOC が描画されない", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.locator("[data-toc]")).toHaveCount(0);
+  });
+
+  test("スクロールに応じて aria-current が現在セクションに追従する", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto("/strategies/feedback/");
+    const sidebar = page.locator('[data-toc-variant="sidebar"]');
+    await expect(sidebar).toBeVisible();
+    const firstHeading = page.locator("article h2[id]").first();
+    await firstHeading.scrollIntoViewIfNeeded();
+    await page.evaluate(() => window.scrollBy(0, -50));
+    await page.waitForFunction(() => {
+      return document.querySelectorAll('[data-toc-link][aria-current="location"]').length > 0;
+    });
+    const current = sidebar.locator('[data-toc-link][aria-current="location"]');
+    expect(await current.count()).toBeGreaterThan(0);
+  });
+
+  test("モバイル TOC details の開閉で data-state が連動する", async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 812 });
+    await page.goto("/strategies/feedback/");
+    const mobileToc = page.locator('[data-toc-variant="mobile"]');
+    await expect(mobileToc).toHaveAttribute("data-state", "closed");
+    await mobileToc.locator("summary").click();
+    await expect(mobileToc).toHaveAttribute("data-state", "open");
+    await mobileToc.locator("summary").click();
+    await expect(mobileToc).toHaveAttribute("data-state", "closed");
+  });
+});

--- a/src/components/TableOfContents.astro
+++ b/src/components/TableOfContents.astro
@@ -65,7 +65,7 @@ const items = headings.filter((h) => h.depth === 2 || h.depth === 3);
             <li class={h.depth === 3 ? "pl-3" : ""}>
               <a
                 href={`#${h.slug}`}
-                class="toc-link block py-1 text-sm leading-snug text-[var(--color-sub)] hover:text-[var(--color-ink)] transition-colors"
+                class="toc-link inline-block py-1 text-sm leading-snug text-[var(--color-sub)] hover:text-[var(--color-ink)] transition-colors"
                 data-toc-link
               >
                 {h.text}

--- a/src/components/TableOfContents.astro
+++ b/src/components/TableOfContents.astro
@@ -1,0 +1,139 @@
+---
+interface Heading {
+  depth: number;
+  slug: string;
+  text: string;
+}
+interface Props {
+  headings: Heading[];
+  variant: "sidebar" | "mobile";
+}
+const { headings, variant } = Astro.props;
+const items = headings.filter((h) => h.depth === 2 || h.depth === 3);
+---
+
+{
+  items.length > 0 &&
+    (variant === "sidebar" ? (
+      <nav
+        class="toc toc-sidebar hidden lg:block"
+        aria-label="目次"
+        data-toc
+        data-toc-variant="sidebar"
+      >
+        <p class="font-mono text-[10px] uppercase tracking-widest text-[var(--color-sub)] mb-3">
+          目次
+        </p>
+        <ol class="space-y-1.5">
+          {items.map((h) => (
+            <li class={h.depth === 3 ? "pl-3" : ""}>
+              <a
+                href={`#${h.slug}`}
+                class="toc-link block text-sm leading-snug text-[var(--color-sub)] hover:text-[var(--color-ink)] transition-colors"
+                data-toc-link
+              >
+                {h.text}
+              </a>
+            </li>
+          ))}
+        </ol>
+      </nav>
+    ) : (
+      <details
+        class="toc toc-mobile lg:hidden border border-[var(--color-line)] rounded-md mb-8"
+        data-toc
+        data-toc-variant="mobile"
+        data-state="closed"
+      >
+        <summary class="cursor-pointer select-none flex items-center justify-between px-4 py-3 text-sm font-mono uppercase tracking-widest text-[var(--color-sub)]">
+          <span>目次({items.length})</span>
+          <svg
+            class="toc-chevron w-4 h-4"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <path d="m6 9 6 6 6-6" />
+          </svg>
+        </summary>
+        <ol class="space-y-1.5 px-4 pb-4 pt-1 border-t border-[var(--color-line)]">
+          {items.map((h) => (
+            <li class={h.depth === 3 ? "pl-3" : ""}>
+              <a
+                href={`#${h.slug}`}
+                class="toc-link block py-1 text-sm leading-snug text-[var(--color-sub)] hover:text-[var(--color-ink)] transition-colors"
+                data-toc-link
+              >
+                {h.text}
+              </a>
+            </li>
+          ))}
+        </ol>
+      </details>
+    ))
+}
+
+<script>
+  const tocs = document.querySelectorAll<HTMLElement>("[data-toc]");
+  if (tocs.length > 0) {
+    const links = document.querySelectorAll<HTMLAnchorElement>("[data-toc-link]");
+    const targets = new Map<string, HTMLAnchorElement[]>();
+    links.forEach((link) => {
+      const id = decodeURIComponent(link.hash.slice(1));
+      if (!id) return;
+      if (!targets.has(id)) targets.set(id, []);
+      targets.get(id)!.push(link);
+    });
+
+    const setCurrent = (id: string | null) => {
+      links.forEach((link) => link.removeAttribute("aria-current"));
+      if (!id) return;
+      const matched = targets.get(id);
+      matched?.forEach((link) => link.setAttribute("aria-current", "location"));
+    };
+
+    const headings = Array.from(targets.keys())
+      .map((id) => document.getElementById(id))
+      .filter((el): el is HTMLElement => Boolean(el));
+
+    if (headings.length > 0) {
+      const offset = 96;
+      let ticking = false;
+      const compute = () => {
+        ticking = false;
+        const scrollY = window.scrollY;
+        let currentId: string | null = null;
+        for (const h of headings) {
+          const top = h.getBoundingClientRect().top + scrollY;
+          if (top - offset <= scrollY) {
+            currentId = h.id;
+          } else {
+            break;
+          }
+        }
+        if (currentId === null && headings.length > 0) {
+          currentId = headings[0].id;
+        }
+        setCurrent(currentId);
+      };
+      const onScroll = () => {
+        if (ticking) return;
+        ticking = true;
+        window.requestAnimationFrame(compute);
+      };
+      window.addEventListener("scroll", onScroll, { passive: true });
+      window.addEventListener("resize", onScroll, { passive: true });
+      compute();
+    }
+
+    document.querySelectorAll<HTMLDetailsElement>('[data-toc-variant="mobile"]').forEach((d) => {
+      d.addEventListener("toggle", () => {
+        d.dataset.state = d.open ? "open" : "closed";
+      });
+    });
+  }
+</script>

--- a/src/pages/columns/[...slug].astro
+++ b/src/pages/columns/[...slug].astro
@@ -2,6 +2,7 @@
 import { getCollection, render } from "astro:content";
 import Layout from "../../layouts/Layout.astro";
 import RelatedStrategyCard from "../../components/RelatedStrategyCard.astro";
+import TableOfContents from "../../components/TableOfContents.astro";
 
 export async function getStaticPaths() {
   const columns = await getCollection("columns");
@@ -9,7 +10,7 @@ export async function getStaticPaths() {
 }
 
 const { entry } = Astro.props;
-const { Content } = await render(entry);
+const { Content, headings } = await render(entry);
 const d = entry.data;
 
 const allStrategies = await getCollection("strategies");
@@ -104,9 +105,17 @@ const breadcrumbJsonLd = {
     </div>
   </header>
 
-  <article class="prose-article py-16 max-w-2xl">
-    <Content />
-  </article>
+  <div class="lg:grid lg:grid-cols-[minmax(0,1fr)_220px] lg:gap-10">
+    <div class="min-w-0">
+      <article class="prose-article py-16 max-w-2xl">
+        <TableOfContents headings={headings} variant="mobile" />
+        <Content />
+      </article>
+    </div>
+    <aside class="lg:pt-16">
+      <TableOfContents headings={headings} variant="sidebar" />
+    </aside>
+  </div>
 
   {
     related.length > 0 && (

--- a/src/pages/strategies/[...slug].astro
+++ b/src/pages/strategies/[...slug].astro
@@ -2,6 +2,7 @@
 import { getCollection, render } from "astro:content";
 import Layout from "../../layouts/Layout.astro";
 import { annotateGlossaryTerms } from "../../lib/glossary-inline";
+import TableOfContents from "../../components/TableOfContents.astro";
 
 export async function getStaticPaths() {
   const strategies = await getCollection("strategies");
@@ -9,7 +10,7 @@ export async function getStaticPaths() {
 }
 
 const { entry } = Astro.props;
-const { Content } = await render(entry);
+const { Content, headings } = await render(entry);
 const d = entry.data;
 
 const allColumns = await getCollection("columns");
@@ -328,9 +329,17 @@ const effectNote =
     )
   }
 
-  <article class="prose-article py-16 max-w-2xl">
-    <Content />
-  </article>
+  <div class="lg:grid lg:grid-cols-[minmax(0,1fr)_220px] lg:gap-10">
+    <div class="min-w-0">
+      <article class="prose-article py-16 max-w-2xl">
+        <TableOfContents headings={headings} variant="mobile" />
+        <Content />
+      </article>
+    </div>
+    <aside class="lg:pt-16">
+      <TableOfContents headings={headings} variant="sidebar" />
+    </aside>
+  </div>
 
   {
     (d.sourceUrl || d.sourceTitle) && (

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -70,6 +70,44 @@ body[data-menu="open"] {
   }
 }
 
+.toc-sidebar {
+  position: sticky;
+  top: 5rem;
+  align-self: start;
+  max-height: calc(100vh - 6rem);
+  overflow-y: auto;
+  padding-left: 1rem;
+  border-left: 1px solid var(--color-line);
+}
+.toc-link {
+  position: relative;
+  padding-left: 0.25rem;
+}
+.toc-link[aria-current="location"] {
+  color: var(--color-accent);
+  font-weight: 700;
+}
+.toc-sidebar .toc-link[aria-current="location"]::before {
+  content: "";
+  position: absolute;
+  left: -1.0625rem;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: var(--color-accent);
+}
+.toc-mobile .toc-chevron {
+  transition: transform 200ms ease-out;
+}
+.toc-mobile[data-state="open"] .toc-chevron {
+  transform: rotate(180deg);
+}
+@media (prefers-reduced-motion: reduce) {
+  .toc-mobile .toc-chevron {
+    transition: none;
+  }
+}
+
 #reading-progress {
   position: absolute;
   left: 0;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -85,7 +85,6 @@ body[data-menu="open"] {
 }
 .toc-link[aria-current="location"] {
   color: var(--color-accent);
-  font-weight: 700;
 }
 .toc-sidebar .toc-link[aria-current="location"]::before {
   content: "";


### PR DESCRIPTION
## Summary

長文化が進んだ戦略 / コラムページに目次(TOC)を追加し、長文の構造を一目で把握できるようにする。PR #118(sticky ヘッダー)/ #119(戻るボタン + プログレスバー)に続く長文施策の完結編。

## 実装

### コンポーネント

`src/components/TableOfContents.astro` を新設。Astro 標準の `headings` API(`render(entry).headings`)から h2 / h3 のみ抽出し、h3 はインデントしてフラットに表示。

### 2 variant

| variant | 表示条件 | 形式 |
|---|---|---|
| `sidebar` | `lg:` 以上(>= 1024px) | 右サイドバー、`position: sticky; top: 5rem;` でスクロール追従 |
| `mobile` | `< lg:`(< 1024px) | 記事冒頭の `<details>` 折りたたみ、デフォルト closed |

戦略・コラム両ページで両 variant を同時にレンダー、CSS でビューポートに応じて出し分け。

### アクティブセクション追跡

- IntersectionObserver ではなく **rAF スロットル付きスクロール位置計算**(deterministic)を採用
- スクロール位置 + 96px(ヘッダー分のオフセット)を超えた最後の h2/h3 を current として `aria-current="location"` を付与
- どの見出しもまだ通過していない最上部では先頭見出しを current にフォールバック
- sidebar / mobile 両 variant の同 ID リンクに同時反映

### スタイル

- sidebar: 左ボーダー + アクセントカラーの縦バーで current 強調
- mobile: chevron アイコンが open 時に 180° 回転、`prefers-reduced-motion` で無効化
- すべて属性セレクタ駆動(`[aria-current="location"]`、`[data-state="open"]`)

## 状態フック早見表(本 PR 追加分)

| 要素 | 属性 | 値 | 用途 |
|---|---|---|---|
| `<nav data-toc>` / `<details data-toc>` | `data-toc` | 有 | 制御スクリプトの target |
| 同上 | `data-toc-variant` | `sidebar / mobile` | variant ごとの CSS / クエリ |
| `<details>` (mobile) | `data-state` | `open / closed` | 折りたたみ状態の CSS フック |
| `<a data-toc-link>` | `aria-current` | `location / なし` | アクティブセクションの a11y + CSS |
| `<nav>` (sidebar) | `aria-label` | `目次` | 支援技術への種別通知 |

ADR 0007 に準拠、修飾子クラスは追加しない。

## ページ統合

`src/pages/columns/[...slug].astro` と `src/pages/strategies/[...slug].astro` で:
- `render(entry)` から `headings` を取得
- `<article>` を `lg:grid lg:grid-cols-[minmax(0,1fr)_220px]` でラップ
- 内側に mobile TOC + `<Content />`、外側 aside に sidebar TOC

TOC が反映するのは markdown 本文の見出しのみ。記事末尾の関連戦略 / 出典セクションは別文脈のため TOC 対象外。

## Test plan

- [x] `npm run check`(0 errors, 0 warnings)
- [x] `npm run build`(248 ページビルド成功)
- [x] `npm run test:e2e`(24 / 24 通過、新規 4 件:両 variant 描画 / 短文ページ非表示 / aria-current 追従 / mobile 開閉)
- [x] 本番環境で `/strategies/feedback`(長尺)を 1024px 以上で開き、右サイドバーの sticky TOC と current 追従を目視
- [x] 同ページを < 1024px(モバイル / タブレット縦)で開き、記事冒頭の `<details>` 折りたたみが機能することを目視
- [x] TOC リンクをクリックして該当セクションにアンカー遷移、sticky ヘッダー直下に着地することを確認(scroll-padding-top と整合)
- [ ] `prefers-reduced-motion` で chevron 回転が抑制されることを目視