### PR TITLE
refactor(style): split body-text and nav link colors

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -161,19 +161,21 @@ a {
 }
 
 .link-underline {
-  color: var(--color-accent);
   text-decoration: none;
   background-image: linear-gradient(var(--color-accent), var(--color-accent));
   background-size: 0% 1px;
   background-position: left bottom;
   background-repeat: no-repeat;
-  transition: background-size 0.3s ease;
+  transition:
+    color 0.2s ease,
+    background-size 0.3s ease;
   padding-bottom: 2px;
 }
 
 .link-underline:hover,
 .link-underline:active,
 .link-underline:focus-visible {
+  color: var(--color-accent);
   background-size: 100% 1px;
 }
 


### PR DESCRIPTION
## Summary

`.link-underline` クラスが本文中リンク(`.prose-article a`)と同じ緑色をデフォルトで適用しており、ヘッダー / フッター / ページ内 CTA のリンクすべてが本文リンクと同じ「強い緑」で表示されていた。「緑 = 本文中のリンク」という視覚的役割が薄まっていたため、コンテキストごとに色を分離する。

## 変更点

`src/styles/global.css` の `.link-underline` ルール:

- **デフォルトの `color: var(--color-accent)` を削除** — 親要素の色を継承(ナビ / フッターでは `var(--color-sub)` グレー)
- **`:hover` / `:active` / `:focus-visible` で `color: var(--color-accent)` を新規追加** — グレー → 緑へ遷移
- transition に `color 0.2s ease` を追加してスムーズに

下線アニメーション(`background-image: linear-gradient(var(--color-accent), ...)`)は引き続き緑のまま、hover で 0% → 100% に伸びる挙動を維持。

## 影響範囲

`.link-underline` を使用している全 90 箇所(16 ファイル)が「グレー → hover で緑+下線」に統一される:

- ヘッダーナビ(6 リンク)
- フッターナビ(各列のリンク群)
- ページ内 CTA(「← コラム一覧へ戻る」「← 指導法一覧へ戻る」など)

`.prose-article a:not(.glossary-tip)`(本文中の inline リンク)は無変更で、引き続き「緑 + 下線アニメーション」のまま。`.link-underline text-[var(--color-accent)]` のように Tailwind で明示的に緑色を指定している箇所(about.astro の書籍リンク等)も、Tailwind 側の `text-*` が活きるため緑のまま維持される。

## 視覚的方針

| コンテキスト | 標準 | hover |
|---|---|---|
| 本文中のリンク(`.prose-article a`) | 緑 + 下線アニメーション | 下線 100% |
| ナビ / CTA / footer(`.link-underline`) | 親要素の色を継承(主にグレー) | 緑 + 下線 |

「緑 = 別ページへ誘導するもの」「グレー = ナビゲーションの構造的要素」という意味が一貫する。

## 既知の dead code

Layout.astro のヘッダーナビには `hover:text-[var(--color-ink)]` Tailwind クラスが残っているが、`.link-underline:hover { color: var(--color-accent) }` がソース順で勝つため上書きされ、見た目には影響しない。次の clean-up で削除予定(別 PR)。

## Test plan

- [x] `npm run build`(248 ページビルド成功)
- [x] `npm run test:e2e`(24 / 24 通過、回帰なし)
- [ ] 本番環境でヘッダーナビがデフォルトでグレー、hover で緑 + 下線になることを目視
- [ ] フッターのリンクが同様にグレー → 緑遷移することを目視
- [ ] 本文中の inline リンク(コラム / 戦略の本文)が引き続き緑 + 下線アニメーションになっていることを確認
- [ ] about ページの書籍リンク群(`link-underline text-[var(--color-accent)]`)が引き続き緑表示になっていることを確認