### PR TITLE
feat(strategy-row): effect bar visualization + hover accent + nav dead code cleanup

### DIFF
--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -40,6 +40,33 @@ test.describe("トップページ", () => {
     }
     expect(found).toBe(true);
   });
+
+  test("各戦略行に効果量バーが描画される", async ({ page }) => {
+    await page.goto("/");
+    const rows = page.locator("#strategy-list > a");
+    const rowCount = await rows.count();
+    const bars = page.locator("[data-effect-bar]");
+    expect(await bars.count()).toBe(rowCount);
+    const firstSign = await bars.first().getAttribute("data-effect-sign");
+    expect(["positive", "negative", "neutral"]).toContain(firstSign);
+  });
+
+  test("負の効果量を持つ戦略のバーは negative として描画される", async ({ page }) => {
+    await page.goto("/");
+    const rows = page.locator('#strategy-list > a[data-months]');
+    const count = await rows.count();
+    let foundNegative = false;
+    for (let i = 0; i < count; i++) {
+      const months = Number(await rows.nth(i).getAttribute("data-months"));
+      if (months < 0) {
+        const sign = await rows.nth(i).locator("[data-effect-bar]").getAttribute("data-effect-sign");
+        expect(sign).toBe("negative");
+        foundNegative = true;
+        break;
+      }
+    }
+    expect(foundNegative).toBe(true);
+  });
 });
 
 test.describe("戦略詳細ページ", () => {

--- a/src/components/StrategyRow.astro
+++ b/src/components/StrategyRow.astro
@@ -46,6 +46,11 @@ const effectColor =
     : monthsGained === 0
       ? "text-[var(--color-sub)]"
       : "text-red-600";
+
+const effectBarMax = 9;
+const effectBarPct = Math.min(Math.abs(monthsGained), effectBarMax) / effectBarMax * 100;
+const effectBarSign =
+  monthsGained > 0 ? "positive" : monthsGained < 0 ? "negative" : "neutral";
 ---
 
 <a
@@ -53,7 +58,7 @@ const effectColor =
   data-category={category ?? "指導法"}
   data-months={monthsGained}
   data-evidence={evidenceStrength}
-  class="group block border-t border-[var(--color-line)] py-4 sm:py-8 md:py-10 transition hover:bg-[var(--color-card)]"
+  class="strategy-row group block border-t border-[var(--color-line)] py-4 sm:py-8 md:py-10"
 >
   <div class="grid grid-cols-12 gap-4 md:gap-6 items-center px-4 sm:px-2">
     <div
@@ -66,7 +71,7 @@ const effectColor =
     <div class="col-span-10 md:col-span-7 space-y-2">
       <div class="flex flex-wrap items-center gap-2">
         <h2
-          class="text-2xl md:text-3xl font-black tracking-tight leading-tight group-hover:text-[var(--color-accent)] transition"
+          class="text-2xl md:text-3xl font-black tracking-tight leading-tight group-hover:text-[var(--color-accent)] transition-colors"
         >
           {title}
         </h2>
@@ -79,11 +84,13 @@ const effectColor =
         ))}
       </div>
       <div
-        class="font-mono text-[11px] uppercase tracking-widest text-[var(--color-sub)] flex flex-wrap gap-x-4 gap-y-1"
+        class="font-mono text-[11px] uppercase tracking-widest text-[var(--color-sub)] flex flex-wrap items-center gap-x-4 gap-y-1"
       >
         <span>{subjects.join(" · ")}</span>
         <span>{grades.join(" · ")}</span>
-        <span class="text-amber-600">{stars}</span>
+        <span class="text-amber-600 tracking-normal" aria-label={`エビデンスの強さ ${evidenceStrength} / 5`}>
+          {stars}
+        </span>
       </div>
     </div>
 
@@ -96,5 +103,15 @@ const effectColor =
         >→</span
       >
     </div>
+  </div>
+
+  <div
+    class="effect-bar mt-3 md:mt-4 mx-4 sm:mx-2"
+    data-effect-bar
+    data-effect-sign={effectBarSign}
+    style={`--effect-bar-width: ${effectBarPct}%`}
+    aria-hidden="true"
+  >
+    <div class="effect-bar-fill"></div>
   </div>
 </a>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -82,12 +82,12 @@ const escapeLd = (obj: object): string => JSON.stringify(obj).replace(/</g, "\\u
           EduEvidence <span class="text-[var(--color-accent)]">JP</span>
         </a>
         <nav class="hidden lg:flex text-xs gap-4 lg:gap-6 text-[var(--color-sub)]" aria-label="メインナビゲーション">
-          <a href="/" class="link-underline hover:text-[var(--color-ink)] transition">ホーム</a>
-          <a href="/concerns" class="link-underline hover:text-[var(--color-ink)] transition">悩みから探す</a>
-          <a href="/#strategy-list" class="link-underline hover:text-[var(--color-ink)] transition">指導法から探す</a>
-          <a href="/columns" class="link-underline hover:text-[var(--color-ink)] transition">コラム</a>
-          <a href="/guide" class="link-underline hover:text-[var(--color-ink)] transition">ガイド</a>
-          <a href="/about" class="link-underline hover:text-[var(--color-ink)] transition">サイトについて</a>
+          <a href="/" class="link-underline">ホーム</a>
+          <a href="/concerns" class="link-underline">悩みから探す</a>
+          <a href="/#strategy-list" class="link-underline">指導法から探す</a>
+          <a href="/columns" class="link-underline">コラム</a>
+          <a href="/guide" class="link-underline">ガイド</a>
+          <a href="/about" class="link-underline">サイトについて</a>
           <a href="/search" class="hover:text-[var(--color-ink)] transition" aria-label="検索">
             <svg class="w-4 h-4 inline-block" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
           </a>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -185,6 +185,60 @@ a {
   text-decoration: none;
 }
 
+.strategy-row {
+  position: relative;
+  transition: background-color 200ms ease-out;
+}
+.strategy-row::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 3px;
+  background: var(--color-accent);
+  transform: scaleY(0);
+  transform-origin: top center;
+  transition: transform 250ms ease-out;
+  pointer-events: none;
+}
+.strategy-row:hover {
+  background: var(--color-card);
+}
+.strategy-row:hover::before {
+  transform: scaleY(1);
+}
+@media (prefers-reduced-motion: reduce) {
+  .strategy-row::before {
+    transition: none;
+  }
+}
+
+.effect-bar {
+  height: 2px;
+  background: var(--color-line);
+  border-radius: 1px;
+  overflow: hidden;
+}
+.effect-bar-fill {
+  height: 100%;
+  width: var(--effect-bar-width, 0%);
+  background: var(--color-accent);
+  transform-origin: left center;
+  transition: width 300ms ease-out;
+}
+.effect-bar[data-effect-sign="negative"] .effect-bar-fill {
+  background: var(--color-chart-red);
+}
+.effect-bar[data-effect-sign="neutral"] .effect-bar-fill {
+  background: var(--color-sub);
+}
+@media (prefers-reduced-motion: reduce) {
+  .effect-bar-fill {
+    transition: none;
+  }
+}
+
 .font-serif {
   font-family: var(--font-serif);
 }


### PR DESCRIPTION
## Summary

トップページ・科目別・学年別・コスト別・タグ別の戦略一覧で使われている `StrategyRow` を視覚的階層を上げる方向で改修。73 戦略を一覧スクロールしたとき、効果量と効果の方向(正 / ゼロ / 負)が一目で把握できるようにする。あわせて PR #121 後に dead code となったヘッダーナビの Tailwind hover クラスを掃除。

## 追加要素

### A. 効果量バー(全戦略行に追加)

各行の下端に 2px の水平バー。`width: clamp(0, |monthsGained|/9, 100%)` でゲージ表現。色は効果の方向で出し分け:

| 方向 | 色 | 用途 |
|---|---|---|
| `positive`(monthsGained > 0) | `var(--color-accent)`(緑) | 効果あり |
| `negative`(monthsGained < 0) | `var(--color-chart-red)`(赤) | 学力低下の警告(corporal-punishment 等) |
| `neutral`(monthsGained === 0) | `var(--color-sub)`(グレー) | 0% 幅で実質非表示 |

`<div data-effect-bar data-effect-sign="positive|negative|neutral" style="--effect-bar-width: ...%">` で属性駆動(ADR 0007 準拠)。

### B. hover 時の左アクセントバー

`::before` 疑似要素で 3px の縦緑バーが上から下へ `scaleY()` でアニメーション。`<a>` 自体の幅は変わらないので **レイアウトシフトなし**。`prefers-reduced-motion` で transition 無効化。

### C. 細部の整え

- `<span class="text-amber-600">{stars}</span>` に `aria-label="エビデンスの強さ N / 5"` を追加(★ の連続をスクリーンリーダーが「ホシホシ…」と読み上げる問題を緩和)
- `tracking-widest` を ★ 部分だけ外す(`tracking-normal`)— ★ 文字の自然な間隔を維持

## Dead code 掃除(Layout.astro)

PR #121 で `.link-underline:hover { color: var(--color-accent) }` を導入し、ソース順で勝つようになったため、ヘッダー desktop nav 6 リンクの `hover:text-[var(--color-ink)] transition` Tailwind クラスは無効。挙動は変わらないがコードリーディングを誤らせるので削除。

before:
```html
<a href="/" class="link-underline hover:text-[var(--color-ink)] transition">ホーム</a>
```

after:
```html
<a href="/" class="link-underline">ホーム</a>
```

## 状態フック早見表(本 PR 追加分)

| 要素 | 属性 | 値 | 用途 |
|---|---|---|---|
| `<div data-effect-bar>` | `data-effect-sign` | `positive / negative / neutral` | 色出し分けの CSS フック |
| 同上 | `style="--effect-bar-width"` | `0% .. 100%` | 幅の CSS カスタムプロパティ |

## Test plan

- [x] `npm run build`(248 ページビルド成功)
- [x] `npm run test:e2e`(26 / 26 通過、新規 2 件:バー描画 / 負の効果量に negative sign)
- [x] 本番でトップページの戦略一覧スクロール時、緑バーの長さが効果量と整合し、赤バーが負の効果量(corporal-punishment / repeating-a-year など)に正しく出ることを目視
- [x] 行 hover 時に左 3px 緑バーが上→下にアニメーションすることを目視
- [x] モバイル幅でバーがレイアウト崩れせず描画されることを目視
- [x] `prefers-reduced-motion` でバーアニメーションが無効化されることを目視
- [x] ヘッダーナビのホバー挙動が PR #121 と同様(グレー → 緑 + 下線)に維持されていることを目視