### PR TITLE
feat(layout): full-screen mobile menu with categorized nav + persistent search

### DIFF
--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -162,6 +162,8 @@ test.describe("ナビゲーション", () => {
     const menu = page.locator("#mobile-menu");
     await expect(menu).not.toHaveAttribute("inert");
     await expect(menu).toHaveAttribute("data-state", "open");
+    await expect(menu).toHaveAttribute("role", "dialog");
+    await expect(menu).toHaveAttribute("aria-modal", "true");
     await expect(toggle).toHaveAttribute("aria-expanded", "true");
     await expect(page.locator("body")).toHaveAttribute("data-menu", "open");
     await toggle.click();
@@ -169,6 +171,38 @@ test.describe("ナビゲーション", () => {
     await expect(menu).toHaveAttribute("data-state", "closed");
     await expect(toggle).toHaveAttribute("aria-expanded", "false");
     await expect(page.locator("body")).toHaveAttribute("data-menu", "closed");
+  });
+
+  test("モバイルメニューに 3 つのセクション(Explore / Learn / About)が表示される", async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 812 });
+    await page.goto("/");
+    await page.locator("#menu-toggle").click();
+    const titles = page.locator(".mobile-menu-section-title");
+    await expect(titles).toHaveCount(3);
+    await expect(titles.nth(0)).toContainText("Explore");
+    await expect(titles.nth(1)).toContainText("Learn");
+    await expect(titles.nth(2)).toContainText("About");
+  });
+
+  test("モバイルメニューを開くと検索 input にフォーカスが移る", async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 812 });
+    await page.goto("/");
+    await page.locator("#menu-toggle").click();
+    await page.waitForTimeout(120);
+    const focusedId = await page.evaluate(() => document.activeElement?.id);
+    expect(focusedId).toBe("mobile-menu-search-input");
+  });
+
+  test("検索 input から submit すると /search?q= に遷移する", async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 812 });
+    await page.goto("/");
+    await page.locator("#menu-toggle").click();
+    const input = page.locator("#mobile-menu-search-input");
+    await input.fill("メタ認知");
+    await input.press("Enter");
+    await page.waitForURL(/\/search\?q=/);
+    expect(page.url()).toContain("/search");
+    expect(page.url()).toContain("q=%E3%83%A1%E3%82%BF%E8%AA%8D%E7%9F%A5");
   });
 
   test("ヘッダーが sticky で表示される", async ({ page }) => {

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -105,23 +105,81 @@ const escapeLd = (obj: object): string => JSON.stringify(obj).replace(/</g, "\\u
           <span class="block w-6 h-[2px] bg-[var(--color-ink)] transition-transform duration-200 origin-center"></span>
         </button>
       </div>
-      <nav
+      <div
         id="mobile-menu"
         data-state="closed"
-        class="lg:hidden absolute left-0 right-0 top-full z-50 border-t border-b border-[var(--color-line)] bg-[var(--color-bg)] shadow-lg transition duration-200 ease-out motion-reduce:transition-none opacity-0 -translate-y-2 pointer-events-none data-[state=open]:opacity-100 data-[state=open]:translate-y-0 data-[state=open]:pointer-events-auto"
+        class="mobile-menu lg:hidden"
+        role="dialog"
+        aria-modal="true"
         aria-label="モバイルナビゲーション"
         inert
       >
-        <ul class="mx-auto max-w-6xl px-6 py-2 flex flex-col text-sm text-[var(--color-sub)]">
-          <li><a href="/" class="block py-3 hover:text-[var(--color-ink)] transition">ホーム</a></li>
-          <li><a href="/concerns" class="block py-3 hover:text-[var(--color-ink)] transition">悩みから探す</a></li>
-          <li><a href="/#strategy-list" class="block py-3 hover:text-[var(--color-ink)] transition">指導法から探す</a></li>
-          <li><a href="/columns" class="block py-3 hover:text-[var(--color-ink)] transition">コラム</a></li>
-          <li><a href="/guide" class="block py-3 hover:text-[var(--color-ink)] transition">ガイド</a></li>
-          <li><a href="/about" class="block py-3 hover:text-[var(--color-ink)] transition">サイトについて</a></li>
-          <li><a href="/search" class="block py-3 hover:text-[var(--color-ink)] transition">検索</a></li>
-        </ul>
-      </nav>
+        <div class="mobile-menu-inner">
+          <form
+            class="mobile-menu-search"
+            action="/search"
+            method="get"
+            role="search"
+          >
+            <label for="mobile-menu-search-input" class="sr-only">検索</label>
+            <svg
+              class="mobile-menu-search-icon"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <circle cx="11" cy="11" r="8" />
+              <path d="m21 21-4.3-4.3" />
+            </svg>
+            <input
+              id="mobile-menu-search-input"
+              type="search"
+              name="q"
+              placeholder="指導法・コラム・用語を検索…"
+              autocomplete="off"
+              enterkeyhint="search"
+            />
+          </form>
+
+          <nav class="mobile-menu-nav" aria-label="サイトナビゲーション">
+            <section class="mobile-menu-section">
+              <h2 class="mobile-menu-section-title">Explore — 探す</h2>
+              <ul>
+                <li><a href="/concerns">悩みから探す</a></li>
+                <li><a href="/#strategy-list">指導法一覧</a></li>
+                <li><a href="/subjects">教科から探す</a></li>
+                <li><a href="/grades">学年から探す</a></li>
+                <li><a href="/cost">コストから探す</a></li>
+                <li><a href="/tags">タグから探す</a></li>
+              </ul>
+            </section>
+
+            <section class="mobile-menu-section">
+              <h2 class="mobile-menu-section-title">Learn — 学ぶ・読む</h2>
+              <ul>
+                <li><a href="/columns">コラム</a></li>
+                <li><a href="/guide">ガイド</a></li>
+                <li><a href="/policy-evidence">政策とエビデンス</a></li>
+                <li><a href="/voices">現場の声</a></li>
+                <li><a href="/faq">よくある質問</a></li>
+              </ul>
+            </section>
+
+            <section class="mobile-menu-section">
+              <h2 class="mobile-menu-section-title">About — サイトについて</h2>
+              <ul>
+                <li><a href="/about">このサイトについて</a></li>
+                <li><a href="/support">運営を支援する</a></li>
+                <li><a href="/changelog">更新履歴</a></li>
+              </ul>
+            </section>
+          </nav>
+        </div>
+      </div>
       {longForm && (
         <div
           id="reading-progress"
@@ -155,6 +213,7 @@ const escapeLd = (obj: object): string => JSON.stringify(obj).replace(/</g, "\\u
         const menu = document.getElementById("mobile-menu");
         if (!toggle || !menu) return;
         const bars = toggle.querySelectorAll("span");
+        const searchInput = document.getElementById("mobile-menu-search-input");
         let isOpen = false;
         const setOpen = (open) => {
           isOpen = open;
@@ -169,13 +228,18 @@ const escapeLd = (obj: object): string => JSON.stringify(obj).replace(/</g, "\\u
             bars[1].style.opacity = open ? "0" : "";
             bars[2].style.transform = open ? "translateY(-8px) rotate(-45deg)" : "";
           }
+          if (open && searchInput) {
+            window.setTimeout(() => searchInput.focus({ preventScroll: true }), 50);
+          } else if (!open) {
+            toggle.focus({ preventScroll: true });
+          }
         };
         toggle.addEventListener("click", () => setOpen(!isOpen));
         document.addEventListener("keydown", (e) => {
           if (e.key === "Escape" && isOpen) setOpen(false);
         });
         window.addEventListener("resize", () => {
-          if (window.innerWidth >= 640 && isOpen) setOpen(false);
+          if (window.innerWidth >= 1024 && isOpen) setOpen(false);
         });
       })();
     </script>

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -47,6 +47,14 @@ import Layout from "../layouts/Layout.astro";
           clear_search: "クリア",
         },
       });
+      var q = new URLSearchParams(window.location.search).get("q");
+      if (q) {
+        var input = el.querySelector(".pagefind-ui__search-input");
+        if (input) {
+          input.value = q;
+          input.dispatchEvent(new Event("input", { bubbles: true }));
+        }
+      }
     })();
   </script>
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -185,6 +185,128 @@ a {
   text-decoration: none;
 }
 
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.mobile-menu {
+  position: fixed;
+  top: 4rem;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 50;
+  background: var(--color-bg);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(-0.5rem);
+  transition:
+    opacity 200ms ease-out,
+    transform 200ms ease-out;
+}
+.mobile-menu[data-state="open"] {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateY(0);
+}
+@media (prefers-reduced-motion: reduce) {
+  .mobile-menu {
+    transition: opacity 100ms linear;
+    transform: none;
+  }
+  .mobile-menu[data-state="open"] {
+    transform: none;
+  }
+}
+
+.mobile-menu-inner {
+  max-width: 32rem;
+  margin: 0 auto;
+  padding: 2rem 1.5rem 4rem;
+}
+
+.mobile-menu-search {
+  position: relative;
+  margin-bottom: 2.5rem;
+}
+.mobile-menu-search-icon {
+  position: absolute;
+  left: 0.875rem;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 1.125rem;
+  height: 1.125rem;
+  color: var(--color-sub);
+  pointer-events: none;
+}
+.mobile-menu-search input {
+  width: 100%;
+  padding: 0.875rem 1rem 0.875rem 2.75rem;
+  font-size: 1rem;
+  background: var(--color-card);
+  border: 1px solid var(--color-line);
+  border-radius: 0.5rem;
+  color: var(--color-ink);
+  outline: none;
+  transition:
+    border-color 200ms ease-out,
+    box-shadow 200ms ease-out;
+}
+.mobile-menu-search input:focus {
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 3px color-mix(in oklab, var(--color-accent) 20%, transparent);
+}
+.mobile-menu-search input::placeholder {
+  color: var(--color-sub);
+}
+
+.mobile-menu-nav {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+.mobile-menu-section ul {
+  display: flex;
+  flex-direction: column;
+}
+.mobile-menu-section-title {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  font-weight: 500;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--color-sub);
+  margin-bottom: 0.75rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid var(--color-line);
+}
+.mobile-menu-section a {
+  display: block;
+  padding: 0.75rem 0;
+  font-size: 1rem;
+  color: var(--color-ink);
+  transition: color 150ms ease-out;
+}
+.mobile-menu-section a:hover,
+.mobile-menu-section a:focus-visible {
+  color: var(--color-accent);
+}
+.mobile-menu-section a:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 4px;
+  border-radius: 2px;
+}
+
 .strategy-row {
   position: relative;
   transition: background-color 200ms ease-out;


### PR DESCRIPTION
## Summary

モバイル流入向けに、現状 7 項目フラットなドロップダウン式メニューを廃止し、フルスクリーンオーバーレイ + カテゴリ分類 + 検索バー常設のメニューに作り直す。217 ページサイトに対し、情報設計を一段階引き上げる。

## 変更点

### マークアップ(Layout.astro)

`<nav>` を `<div role="dialog" aria-modal="true">` に変え、ヘッダー直下(`top: 4rem`)から画面下端まで占めるオーバーレイへ。`max-w-2xl` で中央寄せ、上から:

```
[🔍 検索…]                          ← 常設の検索フォーム

EXPLORE — 探す
  悩みから探す / 指導法一覧 / 教科 / 学年 / コスト / タグ

LEARN — 学ぶ・読む
  コラム / ガイド / 政策とエビデンス / 現場の声 / よくある質問

ABOUT — サイトについて
  このサイトについて / 運営を支援する / 更新履歴
```

セクション見出しは `font-mono uppercase tracking-widest` で footer と一貫。

### 検索バー

- `<form action="/search" method="get">` に `<input name="q">` の単純構成。`enterkeyhint="search"` でモバイルキーボードの Return キーが「検索」表示
- `:focus` で `--color-accent` のリングアウトライン
- 既存の `/search` ページ(Pagefind UI)が URL の `?q=` を読み取り、初期化後に input に値を流して `input` イベントを dispatch することで検索を自動実行

### JS の調整

- `setOpen(true)` 時に `#mobile-menu-search-input` を 50ms 遅延でフォーカス(オープンアニメ完了後)
- `setOpen(false)` 時にハンバーガーボタンへフォーカスを戻す(キーボードユーザー向け)
- リサイズ自動クローズの閾値を `>= 640` から `>= 1024` に修正(`lg:` ブレークポイントとの整合)

## 状態フック

| 要素 | 属性 | 値 | 用途 |
|---|---|---|---|
| `#mobile-menu` | `data-state` | `open / closed` | オーバーレイ表示・遷移(既存) |
| 同上 | `role` / `aria-modal` / `aria-label` | dialog / true / モバイルナビゲーション | 支援技術通知(新規) |
| 同上 | `inert` | 有 / 無 | 閉時のフォーカス除外(既存) |
| `#menu-toggle` | `aria-expanded` | `true / false` | 既存 |
| `<body>` | `data-menu` | `open / closed` | 背景スクロール固定(既存) |

ADR 0007 準拠、修飾子クラスなし。

## E2E(+3 件、計 29 テスト)

- `role="dialog"` + `aria-modal="true"` の assert を既存テストに追記
- 3 セクション見出し(Explore / Learn / About)が描画される
- メニューオープン時に検索 input が focus を得る
- 検索 input から Enter 送信で `/search?q=<urlencoded>` に遷移する

## Test plan

- [x] `npm run check`(0 errors, 0 warnings)
- [x] `npm run build`(248 ページビルド成功)
- [x] `npm run test:e2e`(29 / 29 通過、新規 3 件含む)
- [x] 本番でモバイル(< 1024px)からハンバーガータップ → フルスクリーンメニュー出現を目視
- [x] メニュー開時に検索 input にフォーカス、ソフトキーボードが立ち上がることを確認
- [x] 検索ワードを入れて Enter → /search ページで検索結果が自動表示されることを確認
- [x] 各セクションのリンクをタップ → 該当ページへ遷移、戻るとメニューは閉じている
- [x] Esc キーで閉じる(キーボード接続環境)、リサイズで >= 1024px に拡大した瞬間にメニューが閉じる
- [x] ハンバーガーが X に morph、もう一度タップで閉じる
- [x] `prefers-reduced-motion` でフェードアニメが短時間に切り替わることを目視