### PR TITLE
feat(search): redesign Pagefind UI to match site editorial style

### DIFF
--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -153,7 +153,7 @@ import Layout from "../layouts/Layout.astro";
       padding-left: 10px;
     }
 
-    /* Result title link */
+    /* Result title link — matches .prose-article a underline animation */
     .pagefind-ui .pagefind-ui__result-title {
       font-size: 1.25rem;
       font-weight: 800;
@@ -162,16 +162,31 @@ import Layout from "../layouts/Layout.astro";
     }
     .pagefind-ui .pagefind-ui__result-link {
       color: var(--color-ink);
-      transition: color 150ms ease-out;
+      text-decoration: none;
+      background-image: linear-gradient(var(--color-accent), var(--color-accent));
+      background-size: 0% 1px;
+      background-position: left bottom;
+      background-repeat: no-repeat;
+      padding-bottom: 2px;
+      transition:
+        color 150ms ease-out,
+        background-size 0.3s ease;
     }
     .pagefind-ui .pagefind-ui__result-link:hover,
-    .pagefind-ui .pagefind-ui__result:hover .pagefind-ui__result-link {
+    .pagefind-ui .pagefind-ui__result:hover .pagefind-ui__result-link,
+    .pagefind-ui .pagefind-ui__result-link:focus-visible {
       color: var(--color-accent);
+      background-size: 100% 1px;
     }
     .pagefind-ui .pagefind-ui__result-link:focus-visible {
       outline: 2px solid var(--color-accent);
       outline-offset: 4px;
       border-radius: 2px;
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .pagefind-ui .pagefind-ui__result-link {
+        transition: none;
+      }
     }
 
     /* Excerpt — body color */

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -162,7 +162,7 @@ import Layout from "../layouts/Layout.astro";
     }
     .pagefind-ui .pagefind-ui__result-link {
       color: var(--color-ink);
-      text-decoration: none;
+      text-decoration: none !important;
       background-image: linear-gradient(var(--color-accent), var(--color-accent));
       background-size: 0% 1px;
       background-position: left bottom;
@@ -177,7 +177,6 @@ import Layout from "../layouts/Layout.astro";
     .pagefind-ui .pagefind-ui__result-link:focus-visible,
     .pagefind-ui .pagefind-ui__result:hover .pagefind-ui__result-link {
       color: var(--color-accent);
-      text-decoration: none;
       background-size: 100% 1px;
     }
     .pagefind-ui .pagefind-ui__result-link:focus-visible {

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -150,8 +150,7 @@ import Layout from "../layouts/Layout.astro";
     }
     .pagefind-ui .pagefind-ui__result-inner {
       gap: 0.5rem;
-      padding-left: 0;
-      margin-left: 0;
+      padding-left: 10px;
     }
 
     /* Result title link */

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -58,17 +58,188 @@ import Layout from "../layouts/Layout.astro";
     })();
   </script>
 
-  <style>
+  <style is:global>
     :root {
-      --pagefind-ui-scale: 0.9;
-      --pagefind-ui-primary: #2b5d3a;
-      --pagefind-ui-text: #1a1a1a;
-      --pagefind-ui-background: #faf9f5;
-      --pagefind-ui-border: #e5e3da;
-      --pagefind-ui-tag: #2b5d3a;
+      --pagefind-ui-scale: 1;
+      --pagefind-ui-primary: var(--color-accent);
+      --pagefind-ui-text: var(--color-ink);
+      --pagefind-ui-background: var(--color-bg);
+      --pagefind-ui-border: var(--color-line);
+      --pagefind-ui-tag: var(--color-accent);
       --pagefind-ui-border-width: 1px;
-      --pagefind-ui-border-radius: 8px;
-      --pagefind-ui-font: "Noto Sans JP", sans-serif;
+      --pagefind-ui-border-radius: 0.5rem;
+      --pagefind-ui-font: var(--font-sans);
+    }
+
+    /* Search input — match the mobile menu search bar style */
+    .pagefind-ui .pagefind-ui__search-input {
+      padding: 0.875rem 1rem 0.875rem 1rem;
+      font-size: 1rem;
+      background: var(--color-card);
+      border: 1px solid var(--color-line);
+      border-radius: 0.5rem;
+      color: var(--color-ink);
+      box-shadow: none;
+      transition:
+        border-color 200ms ease-out,
+        box-shadow 200ms ease-out;
+    }
+    .pagefind-ui .pagefind-ui__search-input:focus {
+      border-color: var(--color-accent);
+      box-shadow: 0 0 0 3px color-mix(in oklab, var(--color-accent) 20%, transparent);
+      outline: none;
+    }
+    .pagefind-ui .pagefind-ui__search-clear {
+      color: var(--color-sub);
+    }
+    .pagefind-ui .pagefind-ui__search-clear:hover {
+      color: var(--color-accent);
+    }
+
+    /* Result count + filters label */
+    .pagefind-ui .pagefind-ui__message {
+      font-family: var(--font-mono);
+      font-size: 0.7rem;
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+      color: var(--color-sub);
+      padding: 1.5rem 0 0.75rem;
+      border-bottom: 1px solid var(--color-line);
+      margin-bottom: 0.5rem;
+    }
+
+    /* Hide thumbnails — pages do not carry meaningful images */
+    .pagefind-ui .pagefind-ui__result-thumb,
+    .pagefind-ui .pagefind-ui__result-image {
+      display: none !important;
+    }
+
+    /* Result row — editorial layout, hover accent matches StrategyRow */
+    .pagefind-ui .pagefind-ui__result {
+      position: relative;
+      padding: 1.25rem 1rem 1.25rem 1.25rem;
+      border-bottom: 1px solid var(--color-line);
+      border-top: none;
+      transition: background-color 200ms ease-out;
+    }
+    .pagefind-ui .pagefind-ui__result::before {
+      content: "";
+      position: absolute;
+      left: 0;
+      top: 0;
+      bottom: 0;
+      width: 3px;
+      background: var(--color-accent);
+      transform: scaleY(0);
+      transform-origin: top center;
+      transition: transform 250ms ease-out;
+      pointer-events: none;
+    }
+    .pagefind-ui .pagefind-ui__result:hover {
+      background: var(--color-card);
+    }
+    .pagefind-ui .pagefind-ui__result:hover::before {
+      transform: scaleY(1);
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .pagefind-ui .pagefind-ui__result::before {
+        transition: none;
+      }
+    }
+    .pagefind-ui .pagefind-ui__result-inner {
+      gap: 0.5rem;
+    }
+
+    /* Result title link */
+    .pagefind-ui .pagefind-ui__result-title {
+      font-size: 1.25rem;
+      font-weight: 800;
+      line-height: 1.4;
+      letter-spacing: -0.01em;
+    }
+    .pagefind-ui .pagefind-ui__result-link {
+      color: var(--color-ink);
+      transition: color 150ms ease-out;
+    }
+    .pagefind-ui .pagefind-ui__result-link:hover,
+    .pagefind-ui .pagefind-ui__result:hover .pagefind-ui__result-link {
+      color: var(--color-accent);
+    }
+    .pagefind-ui .pagefind-ui__result-link:focus-visible {
+      outline: 2px solid var(--color-accent);
+      outline-offset: 4px;
+      border-radius: 2px;
+    }
+
+    /* Excerpt — body color */
+    .pagefind-ui .pagefind-ui__result-excerpt {
+      font-size: 0.875rem;
+      line-height: 1.7;
+      color: var(--color-sub);
+    }
+
+    /* Highlighted search term */
+    .pagefind-ui .pagefind-ui__result-excerpt mark,
+    .pagefind-ui mark {
+      background: color-mix(in oklab, var(--color-accent) 18%, transparent);
+      color: var(--color-accent);
+      font-weight: 700;
+      padding: 0 0.15em;
+      border-radius: 2px;
+    }
+
+    /* Tags / metadata row */
+    .pagefind-ui .pagefind-ui__result-tags {
+      font-family: var(--font-mono);
+      font-size: 0.65rem;
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+      color: var(--color-sub);
+      gap: 0.5rem 1rem;
+    }
+
+    /* Sub-results — visually subordinate */
+    .pagefind-ui .pagefind-ui__result-nested {
+      margin-left: 0;
+      padding-left: 1rem;
+      border-left: 2px solid var(--color-line);
+      margin-top: 0.75rem;
+    }
+    .pagefind-ui .pagefind-ui__result-nested .pagefind-ui__result-title {
+      font-size: 0.95rem;
+      font-weight: 600;
+    }
+    .pagefind-ui .pagefind-ui__result-nested .pagefind-ui__result-excerpt {
+      font-size: 0.8rem;
+    }
+
+    /* Filter chips — mono caps to match site convention */
+    .pagefind-ui .pagefind-ui__filter-name,
+    .pagefind-ui .pagefind-ui__filter-value-label {
+      font-family: var(--font-mono);
+      font-size: 0.75rem;
+      letter-spacing: 0.1em;
+    }
+
+    /* Load more button */
+    .pagefind-ui .pagefind-ui__button {
+      background: var(--color-card);
+      border: 1px solid var(--color-line);
+      color: var(--color-ink);
+      font-family: var(--font-mono);
+      font-size: 0.7rem;
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+      padding: 0.75rem 1.5rem;
+      border-radius: 0.5rem;
+      transition:
+        border-color 200ms ease-out,
+        color 200ms ease-out;
+      cursor: pointer;
+    }
+    .pagefind-ui .pagefind-ui__button:hover {
+      border-color: var(--color-accent);
+      color: var(--color-accent);
     }
   </style>
 </Layout>

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -98,10 +98,11 @@ import Layout from "../layouts/Layout.astro";
 
     /* Result count + filters label */
     .pagefind-ui .pagefind-ui__message {
-      font-family: var(--font-mono);
-      font-size: 0.7rem;
-      letter-spacing: 0.18em;
-      text-transform: uppercase;
+      font-family: var(--font-sans);
+      font-size: 0.875rem;
+      font-weight: 500;
+      letter-spacing: 0.02em;
+      text-transform: none;
       color: var(--color-sub);
       padding: 1.5rem 0 0.75rem;
       border-bottom: 1px solid var(--color-line);
@@ -239,25 +240,34 @@ import Layout from "../layouts/Layout.astro";
       letter-spacing: 0.1em;
     }
 
-    /* Load more button */
+    /* Load more button — Japanese-friendly */
     .pagefind-ui .pagefind-ui__button {
       background: var(--color-card);
       border: 1px solid var(--color-line);
       color: var(--color-ink);
-      font-family: var(--font-mono);
-      font-size: 0.7rem;
-      letter-spacing: 0.18em;
-      text-transform: uppercase;
-      padding: 0.75rem 1.5rem;
+      font-family: var(--font-sans);
+      font-size: 0.9375rem;
+      font-weight: 500;
+      letter-spacing: 0.02em;
+      text-transform: none;
+      padding: 0.875rem 1.5rem;
       border-radius: 0.5rem;
+      width: 100%;
       transition:
         border-color 200ms ease-out,
-        color 200ms ease-out;
+        color 200ms ease-out,
+        background-color 200ms ease-out;
       cursor: pointer;
+      margin-top: 1.5rem;
     }
     .pagefind-ui .pagefind-ui__button:hover {
       border-color: var(--color-accent);
       color: var(--color-accent);
+      background: var(--color-bg);
+    }
+    .pagefind-ui .pagefind-ui__button:focus-visible {
+      outline: 2px solid var(--color-accent);
+      outline-offset: 2px;
     }
   </style>
 </Layout>

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -173,9 +173,11 @@ import Layout from "../layouts/Layout.astro";
         background-size 0.3s ease;
     }
     .pagefind-ui .pagefind-ui__result-link:hover,
-    .pagefind-ui .pagefind-ui__result:hover .pagefind-ui__result-link,
-    .pagefind-ui .pagefind-ui__result-link:focus-visible {
+    .pagefind-ui .pagefind-ui__result-link:focus,
+    .pagefind-ui .pagefind-ui__result-link:focus-visible,
+    .pagefind-ui .pagefind-ui__result:hover .pagefind-ui__result-link {
       color: var(--color-accent);
+      text-decoration: none;
       background-size: 100% 1px;
     }
     .pagefind-ui .pagefind-ui__result-link:focus-visible {

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -174,8 +174,7 @@ import Layout from "../layouts/Layout.astro";
     }
     .pagefind-ui .pagefind-ui__result-link:hover,
     .pagefind-ui .pagefind-ui__result-link:focus,
-    .pagefind-ui .pagefind-ui__result-link:focus-visible,
-    .pagefind-ui .pagefind-ui__result:hover .pagefind-ui__result-link {
+    .pagefind-ui .pagefind-ui__result-link:focus-visible {
       color: var(--color-accent);
       background-size: 100% 1px;
     }

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -117,7 +117,7 @@ import Layout from "../layouts/Layout.astro";
     /* Result row — editorial layout, hover accent matches StrategyRow */
     .pagefind-ui .pagefind-ui__result {
       position: relative;
-      padding: 1.25rem 1rem 1.25rem 1.25rem;
+      padding: 1.25rem 1rem 1.25rem 2rem;
       border-bottom: 1px solid var(--color-line);
       border-top: none;
       transition: background-color 200ms ease-out;
@@ -125,7 +125,7 @@ import Layout from "../layouts/Layout.astro";
     .pagefind-ui .pagefind-ui__result::before {
       content: "";
       position: absolute;
-      left: 0;
+      left: 0.5rem;
       top: 0;
       bottom: 0;
       width: 3px;
@@ -148,6 +148,8 @@ import Layout from "../layouts/Layout.astro";
     }
     .pagefind-ui .pagefind-ui__result-inner {
       gap: 0.5rem;
+      padding-left: 0;
+      margin-left: 0;
     }
 
     /* Result title link */

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -114,10 +114,12 @@ import Layout from "../layouts/Layout.astro";
       display: none !important;
     }
 
-    /* Result row — editorial layout, hover accent on the trailing edge */
+    /* Result row — editorial layout, hover accent on the leading edge
+       (matches StrategyRow on the top page: bar at left:0 + generous
+       left padding so content has clear breathing room from the bar) */
     .pagefind-ui .pagefind-ui__result {
       position: relative;
-      padding: 1.25rem 2rem 1.25rem 1.25rem;
+      padding: 1.25rem 1rem 1.25rem 2.5rem;
       border-bottom: 1px solid var(--color-line);
       border-top: none;
       transition: background-color 200ms ease-out;
@@ -125,7 +127,7 @@ import Layout from "../layouts/Layout.astro";
     .pagefind-ui .pagefind-ui__result::before {
       content: "";
       position: absolute;
-      right: 0.5rem;
+      left: 0;
       top: 0;
       bottom: 0;
       width: 3px;

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -114,10 +114,10 @@ import Layout from "../layouts/Layout.astro";
       display: none !important;
     }
 
-    /* Result row — editorial layout, hover accent matches StrategyRow */
+    /* Result row — editorial layout, hover accent on the trailing edge */
     .pagefind-ui .pagefind-ui__result {
       position: relative;
-      padding: 1.25rem 1rem 1.25rem 2rem;
+      padding: 1.25rem 2rem 1.25rem 1.25rem;
       border-bottom: 1px solid var(--color-line);
       border-top: none;
       transition: background-color 200ms ease-out;
@@ -125,7 +125,7 @@ import Layout from "../layouts/Layout.astro";
     .pagefind-ui .pagefind-ui__result::before {
       content: "";
       position: absolute;
-      left: 0.5rem;
+      right: 0.5rem;
       top: 0;
       bottom: 0;
       width: 3px;


### PR DESCRIPTION
## Summary

検索結果ページ(`/search`)の Pagefind UI を、サイト全体のエディトリアルなデザイン言語(PR #118 sticky / #119 戻るボタン / #122 戦略カード / #123 モバイルメニュー)と整合させる。

スクショで確認された問題点:
- 壊れたサムネイルプレースホルダ(黄/青/グレーの色帯)
- 蛍光黄色のハイライト(蛍光ペン色、本サイトの落ち着いたトーンと不整合)
- メタ情報のクランチ
- 結果カード全体の視覚的階層が散漫(タイトル / 抜粋 / メタが同じ重み)

## 変更点(`src/pages/search.astro`)

`<style is:global>` で Pagefind UI の既存クラスフックを直接スタイル(API ラップ作り直しは過大スコープ):

### サムネイル非表示
- `.pagefind-ui__result-thumb` / `__result-image` に `display: none !important`
- 本サイトはページ単位の代表画像を持たないため、装飾的に破綻していた表示を抑止

### 結果カード
- StrategyRow と同じ hover 演出:背景色変化 + 3px の緑左アクセントバー(`::before` + `scaleY`)、`prefers-reduced-motion` で transition 無効化
- タイトル: `var(--color-ink)` → hover で `var(--color-accent)`
- 抜粋: `var(--color-sub)` + `line-height: 1.7`
- タグ行: モノキャプス + tracking-widest(サイト共通)

### ハイライト(`mark`)
- 蛍光黄 → `color-mix(in oklab, var(--color-accent) 18%, transparent)` の薄緑背景 + 緑文字 bold
- 可読性を保ちつつブランドトーンに統一

### サブ結果(`showSubResults: true`)
- 左ボーダーでインデント、タイトル / 抜粋を一段小さく → 視覚的従属を明示

### 検索入力欄
- モバイルメニューの検索バーと同じデザイン(rounded 0.5rem、カード背景、アクセント緑のフォーカスリング)
- 結果ページ単独で開いた時もモバイルメニューから来た時も視覚連続性

### メッセージ・フィルタ・ロードモアボタン
- 「N 件の結果が見つかりました」「フィルター」「もっと表示」をモノキャプス + tracking-widest に統一

## 状態フックへの影響

新規属性は導入せず、Pagefind UI の既存 `.pagefind-ui__*` クラスフックを利用。ADR 0007 の属性駆動契約は無影響。

## 既知の制約

- 結果カードの thumbnail コンテナ自体は DOM に残る(Pagefind ランタイムが生成)が、`display: none` で非表示。devtools で「Role: generic / Keyboard-focusable: ⊘」と表示される空コンテナだが、視覚的にも操作的にも影響なし
- フィルタ機能(`filters_label`)は現状 Pagefind 側でフィルタ設定をしていないため UI 上は表示されないことが多い。フィルタ追加は別件

## Test plan

- [x] `npm run check`(0 errors, 0 warnings)
- [x] `npm run build`(248 ページビルド成功)
- [x] `npm run test:e2e`(29 / 29 通過、回帰なし)
- [x] 本番で `/search` ページを開き、検索入力欄の角丸・フォーカスリングがアクセント緑で表示されることを目視
- [x] 「働きかけ」等で検索し、ハイライト(`<mark>`)が蛍光黄ではなく薄緑+緑文字になっていることを目視
- [x] 結果カードに hover した時、背景が薄まり左に 3px 緑バーが上→下にアニメーションすることを目視
- [x] サムネイルプレースホルダが消えていることを目視
- [x] サブ結果が左ボーダー付きでインデント表示されることを目視
- [x] モバイル幅で検索メニューから直接検索 → /search?q=… で検索結果が同じデザインで表示されることを確認
- [x] `prefers-reduced-motion` で hover の左バーアニメーションが無効化されることを目視