### PR TITLE
feat(top): featured concerns CTA in first-view

### DIFF
--- a/src/data/concerns.ts
+++ b/src/data/concerns.ts
@@ -13,6 +13,24 @@ export interface ConcernCategory {
   concerns: Concern[];
 }
 
+export function getAllConcerns(
+  categories: readonly ConcernCategory[]
+): Concern[] {
+  return categories.flatMap((cat) => cat.concerns);
+}
+
+export function getConcernIndex(
+  categories: readonly ConcernCategory[]
+): Map<string, { concern: Concern; categoryTitle: string }> {
+  const index = new Map<string, { concern: Concern; categoryTitle: string }>();
+  for (const cat of categories) {
+    for (const c of cat.concerns) {
+      index.set(c.slug, { concern: c, categoryTitle: cat.title });
+    }
+  }
+  return index;
+}
+
 export const concernCategories: ConcernCategory[] = [
   {
     id: "classroom-management",

--- a/src/pages/concerns/index.astro
+++ b/src/pages/concerns/index.astro
@@ -68,7 +68,10 @@ function formatMonths(m: number): string {
 
           <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
             {cat.concerns.map((concern) => (
-              <article class="border border-[var(--color-line)] rounded-xl p-5 md:p-6 bg-[var(--color-card)] space-y-4">
+              <article
+                id={concern.slug}
+                class="border border-[var(--color-line)] rounded-xl p-5 md:p-6 bg-[var(--color-card)] space-y-4"
+              >
                 <h3 class="font-black text-lg md:text-xl leading-snug">
                   {concern.title}
                 </h3>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,6 +2,11 @@
 import { getCollection } from "astro:content";
 import Layout from "../layouts/Layout.astro";
 import StrategyRow from "../components/StrategyRow.astro";
+import {
+  concernCategories,
+  getAllConcerns,
+  getConcernIndex,
+} from "../data/concerns";
 const strategies = await getCollection("strategies");
 strategies.sort((a, b) => b.data.monthsGained - a.data.monthsGained);
 
@@ -11,6 +16,26 @@ const columnFreshnessDate = (c: typeof allColumns[number]) => c.data.lastVerifie
 const latestColumns = [...allColumns]
   .sort((a, b) => columnFreshnessDate(b).localeCompare(columnFreshnessDate(a)))
   .slice(0, 3);
+
+const totalConcerns = getAllConcerns(concernCategories).length;
+
+// 編集ピックアップ: 学級経営 / 授業(集中) / 授業(学力差) / 教員キャリア入門 の 4 件
+const featuredConcernSlugs = [
+  "classroom-unrest",
+  "passive-class",
+  "achievement-gap",
+  "beginner-entry",
+];
+const concernIndex = getConcernIndex(concernCategories);
+const featuredConcerns = featuredConcernSlugs.map((slug) => {
+  const entry = concernIndex.get(slug);
+  if (!entry) {
+    throw new Error(
+      `[index.astro] featuredConcernSlugs に存在しない slug: "${slug}". src/data/concerns.ts と同期してください`
+    );
+  }
+  return entry;
+});
 ---
 
 <Layout>
@@ -46,6 +71,96 @@ const latestColumns = [...allColumns]
         国内外の教育研究を「効果」「信頼性」「コスト」「出典」の4指標で整理し、日本の小学校の現場で使える形に翻案して公開しています。
       </p>
     </div>
+  </section>
+
+  <section
+    aria-labelledby="concerns-cta-heading"
+    class="border-t border-[var(--color-line)] py-8 xs:py-10 sm:py-14"
+  >
+    <div class="grid grid-cols-12 gap-6 mb-6">
+      <div class="col-span-12 min-[900px]:col-span-8 space-y-2">
+        <p
+          class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]"
+        >
+          Find by your concern
+        </p>
+        <h2
+          id="concerns-cta-heading"
+          class="font-black text-3xl md:text-4xl tracking-tight leading-[1.2]"
+        >
+          現場の<span class="text-[var(--color-accent)]">悩み</span>から、エビデンスを探す。
+        </h2>
+        <p class="text-sm text-[var(--color-sub)] leading-relaxed pt-1">
+          指導法の一覧から入る前に、まず日々の悩みから関連するエビデンスをたどれます。
+        </p>
+      </div>
+      <div
+        class="col-span-12 min-[900px]:col-span-4 flex min-[900px]:items-end min-[900px]:justify-end"
+      >
+        <a
+          href="/concerns"
+          class="group inline-flex items-center justify-between gap-3 rounded-full border border-[var(--color-accent)] bg-[var(--color-accent)] px-5 py-3 text-sm font-bold text-white motion-safe:transition hover:bg-[var(--color-accent)]/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg)]"
+        >
+          <span>全{totalConcerns}件の悩みを見る</span>
+          <span class="motion-safe:transition group-hover:translate-x-0.5" aria-hidden="true">→</span>
+        </a>
+      </div>
+    </div>
+
+    <ul class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+      {
+        featuredConcerns.map(({ concern, categoryTitle }) => {
+          const strategyCount = concern.strategies.length;
+          const columnCount = concern.columns?.length ?? 0;
+          const titleId = `featured-${concern.slug}-title`;
+          return (
+            <li>
+              <a
+                href={`/concerns#${concern.slug}`}
+                aria-labelledby={titleId}
+                data-concern-card
+                class="group relative block h-full rounded-xl border border-[var(--color-line)] bg-[var(--color-card)] p-5 motion-safe:transition hover:border-[var(--color-accent)] focus-visible:border-[var(--color-accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg)]"
+              >
+                <span
+                  aria-hidden="true"
+                  class="pointer-events-none absolute inset-y-3 left-0 w-[3px] origin-center scale-y-0 rounded-full bg-[var(--color-accent)] motion-safe:transition-transform motion-safe:duration-200 group-hover:scale-y-100 group-focus-visible:scale-y-100"
+                />
+                <div class="space-y-3 pl-2">
+                  <div class="font-mono text-[10px] tracking-widest uppercase text-[var(--color-sub)]">
+                    {categoryTitle}
+                  </div>
+                  <h3
+                    id={titleId}
+                    class="font-black text-base leading-snug text-[var(--color-ink)] motion-safe:transition group-hover:text-[var(--color-accent)] group-focus-visible:text-[var(--color-accent)]"
+                  >
+                    {concern.title}
+                  </h3>
+                  <p class="text-xs text-[var(--color-sub)] leading-relaxed line-clamp-3">
+                    {concern.diagnosis}
+                  </p>
+                  <div class="flex items-center gap-3 pt-1 text-[11px] text-[var(--color-sub)]">
+                    <span>
+                      <span class="font-bold text-[var(--color-ink)]">
+                        {strategyCount}
+                      </span>
+                      件の指導法
+                    </span>
+                    {columnCount > 0 && (
+                      <span>
+                        <span class="font-bold text-[var(--color-ink)]">
+                          {columnCount}
+                        </span>
+                        件のコラム
+                      </span>
+                    )}
+                  </div>
+                </div>
+              </a>
+            </li>
+          );
+        })
+      }
+    </ul>
   </section>
 
   <section class="border-t border-[var(--color-line)] py-5 xs:py-7 sm:py-10">
@@ -189,12 +304,6 @@ const latestColumns = [...allColumns]
 
   <section class="pt-6 xs:pt-8 sm:pt-12 pb-10 xs:pb-14 sm:pb-20 space-y-8">
     <div class="flex flex-wrap gap-3">
-      <a
-        href="/concerns"
-        class="border border-[var(--color-accent)] bg-[var(--color-accent)]/5 rounded-full px-4 py-2 text-sm hover:bg-[var(--color-accent)]/10 transition"
-      >
-        <span class="font-bold text-[var(--color-accent)]">悩み</span><span class="text-[var(--color-sub)] ml-1">から探す</span>
-      </a>
       <a
         href="/subjects"
         class="border border-[var(--color-line)] rounded-full px-4 py-2 text-sm hover:border-[var(--color-accent)] hover:bg-[var(--color-card)] transition"

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -101,8 +101,8 @@ const featuredConcerns = featuredConcernSlugs.map((slug) => {
           href="/concerns"
           class="group inline-flex items-center justify-between gap-3 rounded-full border border-[var(--color-accent)] bg-[var(--color-accent)] px-5 py-3 text-sm font-bold text-white motion-safe:transition hover:bg-[var(--color-accent)]/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg)]"
         >
-          <span>全{totalConcerns}件の悩みを見る</span>
-          <span class="motion-safe:transition group-hover:translate-x-0.5" aria-hidden="true">→</span>
+          <span class="text-white">全{totalConcerns}件の悩みを見る</span>
+          <span class="text-white motion-safe:transition group-hover:translate-x-0.5" aria-hidden="true">→</span>
         </a>
       </div>
     </div>
@@ -119,41 +119,35 @@ const featuredConcerns = featuredConcernSlugs.map((slug) => {
                 href={`/concerns#${concern.slug}`}
                 aria-labelledby={titleId}
                 data-concern-card
-                class="group relative block h-full rounded-xl border border-[var(--color-line)] bg-[var(--color-card)] p-5 motion-safe:transition hover:border-[var(--color-accent)] focus-visible:border-[var(--color-accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg)]"
+                class="group block h-full rounded-xl border border-[var(--color-line)] bg-[var(--color-card)] p-5 space-y-3 motion-safe:transition hover:border-[var(--color-accent)] focus-visible:border-[var(--color-accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg)]"
               >
-                <span
-                  aria-hidden="true"
-                  class="pointer-events-none absolute inset-y-3 left-0 w-[3px] origin-center scale-y-0 rounded-full bg-[var(--color-accent)] motion-safe:transition-transform motion-safe:duration-200 group-hover:scale-y-100 group-focus-visible:scale-y-100"
-                />
-                <div class="space-y-3 pl-2">
-                  <div class="font-mono text-[10px] tracking-widest uppercase text-[var(--color-sub)]">
-                    {categoryTitle}
-                  </div>
-                  <h3
-                    id={titleId}
-                    class="font-black text-base leading-snug text-[var(--color-ink)] motion-safe:transition group-hover:text-[var(--color-accent)] group-focus-visible:text-[var(--color-accent)]"
-                  >
-                    {concern.title}
-                  </h3>
-                  <p class="text-xs text-[var(--color-sub)] leading-relaxed line-clamp-3">
-                    {concern.diagnosis}
-                  </p>
-                  <div class="flex items-center gap-3 pt-1 text-[11px] text-[var(--color-sub)]">
+                <div class="font-mono text-[10px] tracking-widest uppercase text-[var(--color-sub)]">
+                  {categoryTitle}
+                </div>
+                <h3
+                  id={titleId}
+                  class="font-black text-base leading-snug motion-safe:transition group-hover:text-[var(--color-accent)] group-focus-visible:text-[var(--color-accent)]"
+                >
+                  {concern.title}
+                </h3>
+                <p class="text-xs text-[var(--color-sub)] leading-relaxed line-clamp-3">
+                  {concern.diagnosis}
+                </p>
+                <div class="flex items-center gap-3 pt-1 text-[11px] text-[var(--color-sub)]">
+                  <span>
+                    <span class="font-bold text-[var(--color-ink)]">
+                      {strategyCount}
+                    </span>
+                    件の指導法
+                  </span>
+                  {columnCount > 0 && (
                     <span>
                       <span class="font-bold text-[var(--color-ink)]">
-                        {strategyCount}
+                        {columnCount}
                       </span>
-                      件の指導法
+                      件のコラム
                     </span>
-                    {columnCount > 0 && (
-                      <span>
-                        <span class="font-bold text-[var(--color-ink)]">
-                          {columnCount}
-                        </span>
-                        件のコラム
-                      </span>
-                    )}
-                  </div>
+                  )}
                 </div>
               </a>
             </li>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -99,7 +99,7 @@ const featuredConcerns = featuredConcernSlugs.map((slug) => {
       >
         <a
           href="/concerns"
-          class="group inline-flex items-center justify-between gap-3 rounded-full border border-[var(--color-accent)] bg-[var(--color-accent)] px-5 py-3 text-sm font-bold text-white motion-safe:transition hover:bg-[var(--color-accent)]/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg)]"
+          class="group inline-flex items-center justify-between gap-3 rounded-full border border-[var(--color-accent)] bg-[var(--color-accent)] px-5 py-3 text-sm font-bold text-white motion-safe:transition motion-safe:duration-200 motion-safe:ease-out hover:bg-[var(--color-accent-hover)] hover:border-[var(--color-accent-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg)]"
         >
           <span class="text-white">全{totalConcerns}件の悩みを見る</span>
           <span class="text-white motion-safe:transition group-hover:translate-x-0.5" aria-hidden="true">→</span>
@@ -119,7 +119,7 @@ const featuredConcerns = featuredConcernSlugs.map((slug) => {
                 href={`/concerns#${concern.slug}`}
                 aria-labelledby={titleId}
                 data-concern-card
-                class="group block h-full rounded-xl border border-[var(--color-line)] bg-[var(--color-card)] p-5 space-y-3 motion-safe:transition hover:border-[var(--color-accent)] focus-visible:border-[var(--color-accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg)]"
+                class="group block h-full rounded-xl border border-[var(--color-line)] bg-[var(--color-card)] p-5 space-y-3 motion-safe:transition motion-safe:duration-200 motion-safe:ease-out hover:border-[var(--color-accent)] focus-visible:border-[var(--color-accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg)]"
               >
                 <div class="font-mono text-[10px] tracking-widest uppercase text-[var(--color-sub)]">
                   {categoryTitle}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -13,6 +13,7 @@
   --color-line: #e5e3da;
   --color-card: #ffffff;
   --color-accent: #2b5d3a;
+  --color-accent-hover: color-mix(in oklab, var(--color-accent) 85%, black);
 
   /* チャート系列の対比色(アクセント深緑と視認性を確保するため) */
   --color-chart-red: #c0392b;
@@ -159,7 +160,7 @@ body[data-menu="open"] {
   pointer-events: auto;
 }
 #back-to-top[data-state="visible"]:hover {
-  background: color-mix(in oklab, var(--color-accent) 85%, black);
+  background: var(--color-accent-hover);
   box-shadow: 0 6px 16px rgba(0, 0, 0, 0.2);
   transform: translateY(-2px);
 }


### PR DESCRIPTION
## 概要

トップページのファーストビュー直下に「悩みから探す」セクションを追加し、サイトの主要な入口経路を主役 CTA として明示化する。同時に、ページ末尾のピル群から重複する「悩み」リンクを削除する。あわせて、サイト全体の accent ボタンの hover 表現を統一する。

## 変更点

### トップページ FV セクション

- hero 直下に新セクションを追加
  - 見出し + メイン CTA「全 13 件の悩みを見る」(緑背景 + 白文字を明示)
  - 編集ピックアップ 4 件: `classroom-unrest` / `passive-class` / `achievement-gap` / `beginner-entry`
  - 各カードはカテゴリ・タイトル・診断文(line-clamp-3)・関連件数(指導法 / コラム)を表示
  - hover 表現はコラムカードと統一(border が緑 + h3 が緑)
- ページ末尾のピル群から重複する「悩み」リンクを削除
- `src/pages/concerns/index.astro` の各悩み `<article>` に `id={concern.slug}` を付与し、トップからのアンカー遷移を有効化

### データレイヤー

- `src/data/concerns.ts` に `getAllConcerns()` / `getConcernIndex()` ヘルパーを追加し、index ページとの重複ロジックを解消
- `featuredConcernSlugs` に存在しない slug が含まれる場合はビルド失敗(fail-fast)

### accent ボタンの hover 統一

- `global.css` に `--color-accent-hover: color-mix(in oklab, var(--color-accent) 85%, black)` トークンを追加
- 既存の back-to-top ボタンと新 CTA「全 13 件の悩みを見る」の両方で同じトークンを参照
- 半透明(`bg/90`)→ 暗化に統一し、accent ボタンの押下感を共通化
- カードと CTA の `motion-safe:transition` に `duration-200 ease-out` を明示

## アクセシビリティ

- ADR 0007 準拠(状態は `aria-*` / `data-*` で管理、修飾子クラス不使用)
- カードリンクは `aria-labelledby` で accessible name を悩みタイトルに絞り、SC 2.5.3 (Label in Name) に対応
- フォーカスリングのオフセット色を `var(--color-bg)` に明示
- 装飾モーションを `motion-safe:` variant でラップし、`prefers-reduced-motion` を尊重
- アンカーオフセットは global の `scroll-padding-top: 4rem` に一本化

## 検証

- `npm run check` — 0 errors / 0 warnings
- `npm run build` — 248 ページ成功
- `npm run test:e2e` — 29/29 合格
- fail-fast 型ガード — 存在しない slug を入れて build が落ちることを確認