### PR TITLE
feat(policy-evidence): link 5 policies to corresponding columns

### DIFF
--- a/src/pages/changelog.astro
+++ b/src/pages/changelog.astro
@@ -3,6 +3,15 @@ import Layout from "../layouts/Layout.astro";
 
 const entries = [
   {
+    date: "2026-04-30",
+    items: [
+      {
+        type: "update",
+        text: "「政策とエビデンス」ページに、関連コラムへの導線を 5 件追加。主体的・対話的で深い学び / 習熟度別指導 / 不登校 / AIドリル / 教員働き方改革 の各政策から、対応するコラムにそのまま読み進められる",
+      },
+    ],
+  },
+  {
     date: "2026-04-29",
     items: [
       {

--- a/src/pages/policy-evidence.astro
+++ b/src/pages/policy-evidence.astro
@@ -61,6 +61,7 @@ const comparisons = [
       { name: "協同学習", href: "/strategies/cooperative-learning" },
       { name: "探究学習", href: "/strategies/inquiry-based-learning" },
     ],
+    column: { name: "「主体的・対話的で深い学び」は本当に効果があるのか？", href: "/columns/active-deep-learning-evidence" },
     alignment: "mostly",
   },
   {
@@ -100,6 +101,7 @@ const comparisons = [
     evidence:
       "効果は+1ヶ月と非常に小さい。上位は伸びるが下位は停滞し、格差が拡大する構造。固定化を避け流動的に運用することが重要。",
     strategies: [{ name: "習熟度別グループ編成", href: "/strategies/setting-streaming" }],
+    column: { name: "教育格差はエビデンスでどこまで見えるのか", href: "/columns/education-inequality-evidence" },
     alignment: "partial",
   },
   {
@@ -123,6 +125,7 @@ const comparisons = [
       { name: "SEL(社会性と情動の学習)", href: "/strategies/social-emotional-learning" },
       { name: "保護者との連携", href: "/strategies/parental-engagement" },
     ],
+    column: { name: "不登校35万人時代 — エビデンスで考える「学びの保障」", href: "/columns/school-refusal-crisis" },
     alignment: "limited",
   },
   {
@@ -135,6 +138,7 @@ const comparisons = [
       { name: "ICT活用", href: "/strategies/digital-technology" },
       { name: "AIを活用した教育", href: "/strategies/ai-in-education" },
     ],
+    column: { name: "生成AIは教育をどう変えるか？ — エビデンスはまだ追いついていない", href: "/columns/generative-ai-education" },
     alignment: "partial",
   },
   {
@@ -157,6 +161,7 @@ const comparisons = [
       { name: "補助スタッフの活用", href: "/strategies/teaching-assistants" },
       { name: "形成的評価とフィードバック", href: "/strategies/feedback" },
     ],
+    column: { name: "教員不足の現在地 — 年度初の欠員、学期途中の穴、悪循環のエビデンス", href: "/columns/teacher-shortage-evidence" },
     alignment: "partial",
   },
 ];


### PR DESCRIPTION
## Summary

`/policy-evidence` の各政策エントリに、対応する既存コラムへの導線を追加する。コラム紐付けは現状 3/15 で、本 PR で 8/15 まで拡充する。

| # | 政策 | 紐付けコラム |
|---|---|---|
| 6 | 「主体的・対話的で深い学び」の推進 | active-deep-learning-evidence |
| 10 | 習熟度別指導(算数等) | education-inequality-evidence |
| 12 | 不登校児童生徒への教育機会確保 | school-refusal-crisis |
| 13 | AIドリル・アダプティブ学習による個別最適化 | generative-ai-education |
| 15 | 教員の働き方改革 | teacher-shortage-evidence |

紐付け不可(対応コラム未執筆): #4 教科担任制 / #5 プログラミング / #7 道徳 / #8 補助スタッフ / #9 個別最適 / #11 道徳記述評価 / #14 コミュニティ・スクール。これらは将来コラムが書かれた時点で追加する。

## Changelog

`src/pages/changelog.astro` に 2026-04-30 のエントリを追加。

## Test plan

- [x] `npm run check:all`(textlint / consistency / stale / build)
- [x] `npm run build`(248 ページ完了)
- [x] dist 内の `/policy-evidence/index.html` に 5 件の新しい `/columns/...` リンクがレンダリングされていることを確認