### PR TITLE
perf(fonts): remove @import chain and drop unused Noto Serif JP

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -48,6 +48,14 @@ const escapeLd = (obj: object): string => JSON.stringify(obj).replace(/</g, "\\u
     <meta name="twitter:description" content={description} />
     <meta name="twitter:image" content={ogImage} />
 
+    <!-- Fonts (CSS-from-CSS の render-blocking chain を避けるため <link> で直接読み込む) -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700;900&family=JetBrains+Mono:wght@400;500&display=swap"
+    />
+
     <!-- Favicon -->
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 

--- a/src/pages/changelog.astro
+++ b/src/pages/changelog.astro
@@ -3,6 +3,15 @@ import Layout from "../layouts/Layout.astro";
 
 const entries = [
   {
+    date: "2026-05-01",
+    items: [
+      {
+        type: "update",
+        text: "フォントの読み込み経路を見直し、初期表示を高速化。Google Fonts の CSS チェーンを解消し、未使用だった明朝体(Noto Serif JP)を読み込み対象から除外",
+      },
+    ],
+  },
+  {
     date: "2026-04-30",
     items: [
       {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,5 +1,3 @@
-@import url("https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700;900&family=Noto+Serif+JP:wght@500;700;900&family=JetBrains+Mono:wght@400;500&display=swap");
-
 @import "tailwindcss";
 
 @theme {
@@ -18,7 +16,7 @@
   /* チャート系列の対比色(アクセント深緑と視認性を確保するため) */
   --color-chart-red: #c0392b;
 
-  --font-serif: "Noto Serif JP", "Hiragino Mincho ProN", "Yu Mincho", serif;
+  --font-serif: "Hiragino Mincho ProN", "Yu Mincho", serif;
   --font-sans: "Noto Sans JP", "Hiragino Kaku Gothic ProN", "Yu Gothic", sans-serif;
   --font-mono: "JetBrains Mono", ui-monospace, monospace;
 }


### PR DESCRIPTION
## Summary

Lighthouse(本番、Mobile・simulate)で Performance スコアが 44-62、FCP/LCP が 4-11 秒の範囲だった。原因は `src/styles/global.css` 先頭の `@import url("https://fonts.googleapis.com/...")` による CSS-from-CSS の render-blocking chain と、未使用フォント Noto Serif JP の同時読み込み。

| Page | Perf | FCP | LCP | TBT | CLS | SI |
|---|---:|---:|---:|---:|---:|---:|
| `/` | 62 | 5.9s | 6.7s | 0ms | 0.007 | 5.9s |
| `/concerns/` | 56 | 10.6s | 11.0s | 0ms | 0 | 10.6s |
| `/policy-evidence/` | 56 | 10.7s | 10.9s | 0ms | 0 | 10.7s |
| `/columns/giga-school-evidence/` | 44 | 4.1s | 4.1s | 1,420ms | 0.008 | 13.3s |

リソース内訳: 全 1,127 KiB のうちフォント関連が 855 KiB(42 リクエスト)+ Google Fonts CSS 208 KiB(Lighthouse 報告で 100% unused)。

## Changes

- `global.css` 先頭の `@import url(googleapis)` を削除
- `Layout.astro` の `<head>` に下記を追加
  - `<link rel="preconnect" href="https://fonts.googleapis.com">`
  - `<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>`
  - `<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700;900&family=JetBrains+Mono:wght@400;500&display=swap">`
- Noto Serif JP を読み込み対象から除外。`.font-serif` ユーティリティの呼び出し箇所が `src/` 内に 0 件で、3 weight(500/700/900)を空転送していた
- `--font-serif` をシステム明朝(Hiragino Mincho ProN / Yu Mincho)にフォールバック

CSP は既に `style-src https://fonts.googleapis.com` と `font-src https://fonts.gstatic.com` を許可しているため、ヘッダー変更は不要。

## Verification

ローカル preview(本番より遅い基準)での before/after:

- Stylesheet 転送量: 217 KiB → 128 KiB(-41%)
- unused CSS: 208 KiB → 119 KiB
- bundle 後の CSS から `@import url(googleapis)` が消滅
- Total: 1,127 KiB → 1,001 KiB(-126 KiB)

絶対値の改善幅は本番デプロイ後の再測定で評価する(別 issue で追跡)。

## Follow-up

- Stage 2: `@fontsource-variable/noto-sans-jp` で self-host 化(別 PR)
- `/strategies/` index ページ未存在(404)を別 PR で対応(本 PR の範囲外、Lighthouse 計測中に発見)

## Test plan

- [x] `npm run check:text` / `npm run check:consistency` / `npm run check:stale`
- [x] `npm run build`(248 ページ完了)
- [x] `npm run test:e2e`(37/37 passed)
- [x] dist 内 HTML / CSS の出力確認(`@import` 消滅、preconnect / stylesheet 出力済み)
- [ ] マージ後、本番に対して Lighthouse mobile を再測定し、Stage 2 着手判断