### PR TITLE
perf(fonts): self-host Noto Sans JP and JetBrains Mono via @fontsource

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,8 @@
         "@astrojs/react": "^5.0.4",
         "@astrojs/rss": "^4.0.18",
         "@astrojs/sitemap": "^3.7.2",
+        "@fontsource-variable/jetbrains-mono": "5.2.8",
+        "@fontsource-variable/noto-sans-jp": "5.2.10",
         "@tailwindcss/vite": "^4.2.4",
         "@types/react": "^19.0.9",
         "@types/react-dom": "^19.0.3",
@@ -1103,6 +1105,24 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@fontsource-variable/jetbrains-mono": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/jetbrains-mono/-/jetbrains-mono-5.2.8.tgz",
+      "integrity": "sha512-WBA9elru6Jdp5df2mES55wuOO0WIrn3kpXnI4+W2ek5u3ZgLS9XS4gmIlcQhiZOWEKl95meYdvK7xI+ETLCq/Q==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource-variable/noto-sans-jp": {
+      "version": "5.2.10",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/noto-sans-jp/-/noto-sans-jp-5.2.10.tgz",
+      "integrity": "sha512-m0XfZ38rZtCaGAuAQL0cBPQ6fc/RguYEOqw66zvuLOV9vNRUBf9MFqyoazTu2JVCRIcnkrxbwF29UUaHHgTKdg==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@hono/node-server": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     "@astrojs/react": "^5.0.4",
     "@astrojs/rss": "^4.0.18",
     "@astrojs/sitemap": "^3.7.2",
+    "@fontsource-variable/jetbrains-mono": "5.2.8",
+    "@fontsource-variable/noto-sans-jp": "5.2.10",
     "@tailwindcss/vite": "^4.2.4",
     "@types/react": "^19.0.9",
     "@types/react-dom": "^19.0.3",

--- a/public/_headers
+++ b/public/_headers
@@ -4,7 +4,7 @@
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: camera=(), microphone=(), geolocation=()
   X-XSS-Protection: 0
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self' https://static.cloudflareinsights.com; frame-src 'none'; object-src 'none'; base-uri 'self'
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; connect-src 'self' https://static.cloudflareinsights.com; frame-src 'none'; object-src 'none'; base-uri 'self'
   Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
 
 /_astro/*

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -48,14 +48,6 @@ const escapeLd = (obj: object): string => JSON.stringify(obj).replace(/</g, "\\u
     <meta name="twitter:description" content={description} />
     <meta name="twitter:image" content={ogImage} />
 
-    <!-- Fonts (CSS-from-CSS の render-blocking chain を避けるため <link> で直接読み込む) -->
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700;900&family=JetBrains+Mono:wght@400;500&display=swap"
-    />
-
     <!-- Favicon -->
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 

--- a/src/pages/changelog.astro
+++ b/src/pages/changelog.astro
@@ -7,6 +7,10 @@ const entries = [
     items: [
       {
         type: "update",
+        text: "フォントの配信を Google Fonts から自サーバー(Cloudflare 配信)に切り替え、外部接続を排除。表示開始までの時間がさらに短縮",
+      },
+      {
+        type: "update",
         text: "フォントの読み込み経路を見直し、初期表示を高速化。Google Fonts の CSS チェーンを解消し、未使用だった明朝体(Noto Serif JP)を読み込み対象から除外",
       },
     ],

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,3 +1,6 @@
+@import "@fontsource-variable/noto-sans-jp/index.css";
+@import "@fontsource-variable/jetbrains-mono/index.css";
+
 @import "tailwindcss";
 
 @theme {
@@ -17,8 +20,8 @@
   --color-chart-red: #c0392b;
 
   --font-serif: "Hiragino Mincho ProN", "Yu Mincho", serif;
-  --font-sans: "Noto Sans JP", "Hiragino Kaku Gothic ProN", "Yu Gothic", sans-serif;
-  --font-mono: "JetBrains Mono", ui-monospace, monospace;
+  --font-sans: "Noto Sans JP Variable", "Noto Sans JP", "Hiragino Kaku Gothic ProN", "Yu Gothic", sans-serif;
+  --font-mono: "JetBrains Mono Variable", "JetBrains Mono", ui-monospace, monospace;
 }
 
 html {


### PR DESCRIPTION
## Summary

Stage 1(PR #133)で `@import url(googleapis)` を排除した。本 PR(Stage 2)では runtime のフォント配信そのものを Google Fonts から自サイト(Cloudflare Pages 同一オリジン)に移し、外部接続を完全に消す。

## Changes

- `@fontsource-variable/noto-sans-jp@5.2.10` と `@fontsource-variable/jetbrains-mono@5.2.8` を `dependencies` に追加。Variable woff2 で全 weight(100-900)を 1 ファイル分割の unicode-range subset 群でカバー
- `src/styles/global.css` の `@import "tailwindcss";` の前に `@import "@fontsource-variable/noto-sans-jp/index.css";` と `@import "@fontsource-variable/jetbrains-mono/index.css";` を追加。Astro/Vite が woff2(124 + 12 subset)を `/_astro/` 配下に fingerprint 付きで bundle
- `--font-sans` と `--font-mono` を `Noto Sans JP Variable` / `JetBrains Mono Variable`(@fontsource が emit するファミリ名)に切替。既存ファミリ名はフォールバックとして維持
- `Layout.astro` の `<link rel="preconnect">` と `<link rel="stylesheet">`(fonts.googleapis.com / fonts.gstatic.com)を削除
- `public/_headers` の CSP から `https://fonts.googleapis.com`(style-src)と `https://fonts.gstatic.com`(font-src)を削除。両 directive は `'self'` のみに

## Lighthouse mobile (local preview, no CDN)

Stage 1(PR #133 後の本番)→ Stage 2(本 PR、ローカル preview)で比較:

| Page | Perf | FCP | LCP | SI |
|---|---:|---:|---:|---:|
| `/` | 56 → **68** | 10.3s → **3.6s** | 10.3s → 7.1s | 10.3s → **3.6s** |
| `/concerns/` | 56 → **69** | 8.7s → **3.6s** | 8.9s → 6.3s | 8.7s → **3.6s** |
| `/policy-evidence/` | 56 → **68** | 10.4s → **3.8s** | 10.6s → 6.5s | 10.4s → **3.8s** |
| `/columns/giga-school-evidence/` | 56 → **66** | 10.7s → **4.1s** | 10.9s → 7.2s | 10.7s → **4.1s** |

リソース内訳(`/`、ローカル preview):

| 区分 | Stage 1 | Stage 2 | 差分 |
|---|---:|---:|---:|
| Stylesheet | 128 KiB | **43 KiB** | -66% |
| Third-party | 974 KiB | **0 KiB** | -100% |
| Total | 1,001 KiB | **936 KiB** | -65 KiB |

最大の効果は **Third-party 接続が完全消滅した点**。Google Fonts への DNS lookup / TLS handshake / TCP 確立コストが消え、CSP も `'self'` ベースに簡素化された。

## Out of scope

- `src/lib/og-image.ts` は build 時に Satori で Bold weight を Google Fonts から fetch & disk cache する。runtime に出ていく経路ではないため、本 PR では未変更。CSP も build 経路には影響しない。別 PR で migrate する候補

## Test plan

- [x] `npm run build`(248 ページ完了、woff2 129 ファイルが `/_astro/` に bundle)
- [x] `npm run check:text` / `check:consistency` / `check:stale`
- [x] `npm run test:e2e`(37/37 passed)
- [x] HTML head に `fonts.googleapis.com` / `fonts.gstatic.com` への参照が無いこと
- [x] CSP から外部フォントドメインが削除されていること
- [ ] マージ後、本番に対して Lighthouse mobile を再測定して実効値を確認