### PR TITLE
fix(redirects): send /strategies to /#strategy-list

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,2 +1,7 @@
 # www付きからwwwなしへリダイレクト(カスタムドメイン取得後に有効)
 # https://www.edu-evidence.jp/* https://edu-evidence.jp/:splat 301
+
+# /strategies は独立ページではなくトップの #strategy-list セクションに集約しているため、
+# /strategies と /strategies/ への直接アクセスをトップへリダイレクトする
+/strategies     /#strategy-list   301
+/strategies/    /#strategy-list   301


### PR DESCRIPTION
## Summary

`/strategies` および `/strategies/` への直接アクセスが 404 になる問題を修正。**トップページの `#strategy-list` セクション** へ 301 リダイレクトする。

## 背景

PR #133 のフォントローディング監査(Lighthouse 計測)中に発見した 404。

戦略一覧は独立ページではなく **トップページ内の `#strategy-list` セクション** に集約されている設計で、ヘッダー / フッター / モバイルメニューの「指導法から探す」「指導法一覧」リンクはすべて `/#strategy-list` を指している。しかし `/strategies/` への直接アクセス(検索流入・URL 直接入力・古いブックマーク・誤入力)は 404 になっていた。

## 変更内容

`public/_redirects` に 301 リダイレクトを追加(Cloudflare Pages 標準形式):

```
/strategies     /#strategy-list   301
/strategies/    /#strategy-list   301
```

末尾スラッシュの有無両方をカバー。`/strategies/{slug}/` の個別戦略ページは Astro が生成する具体的なルートが優先されるため影響なし。

## 設計判断: 独立ページ作成ではなくリダイレクトを選んだ理由

| 案 | 評価 |
|---|---|
| **A. 独立ページ作成**(`src/pages/strategies/index.astro`) | トップ内 `#strategy-list` セクションと内容が重複する。設計の一本化のため除外 |
| **B. リダイレクト**(本 PR) | 軽量、既存のトップ動線を維持、SEO・誤入力救済になる |
| C. トップから戦略リストを切り出して独立ページに | 大規模変更でリスクが高い |

## changelog

`changelog.astro` は更新しない(URL 直接アクセスの 404 救済はユーザー(教員・保護者)の通常動線にはほぼ影響しない裏方修正、rule 8b に基づく判断)。

## Test plan

- [x] `npm run build`(248 ページ完了、`dist/_redirects` に追加内容が出力される)
- [x] `npm run test:e2e`(37/37 passed)
- [x] マージ後、本番で `https://edu-evidence.org/strategies` および `https://edu-evidence.org/strategies/` にアクセスしてトップの `#strategy-list` セクションへリダイレクトされることを確認