### PR TITLE
feat(fv): roll out stacked hero layout to all index/static pages

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -3,22 +3,16 @@ import Layout from "../layouts/Layout.astro";
 ---
 
 <Layout title="About — EduEvidence JP">
-  <section class="py-10 xs:py-14 sm:py-20 md:py-28 grid grid-cols-12 gap-6">
-    <div class="col-span-12 md:col-span-8 space-y-6">
-      <div class="space-y-1">
-        <p
-          class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]"
-        >
-          About
-        </p>
-        <p class="text-xs text-[var(--color-sub)]">サイトについて</p>
-      </div>
-      <h1
-        class="font-black text-5xl md:text-6xl leading-[1.15] tracking-tight"
-      >
-        経験と勘に、<br /><span class="text-[var(--color-accent)]">エビデンス</span>を。
-      </h1>
-    </div>
+  <section class="pt-10 sm:pt-14 md:pt-20 lg:pt-28 pb-10 sm:pb-14 md:pb-20">
+    <p class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]">
+      About
+    </p>
+    <p class="mt-1 text-xs text-[var(--color-sub)]">サイトについて</p>
+    <h1
+      class="mt-5 font-black text-4xl sm:text-5xl md:text-6xl lg:text-7xl leading-[1.15] tracking-tight"
+    >
+      経験と勘に、<br /><span class="text-[var(--color-accent)]">エビデンス</span>を。
+    </h1>
   </section>
 
   <section class="pb-24">

--- a/src/pages/changelog.astro
+++ b/src/pages/changelog.astro
@@ -390,23 +390,18 @@ const typeLabel: Record<string, { label: string; color: string }> = {
 ---
 
 <Layout title="更新履歴 — EduEvidence JP">
-  <section class="py-10 xs:py-14 sm:py-20 md:py-28 grid grid-cols-12 gap-6">
-    <div class="col-span-12 md:col-span-8 space-y-6">
-      <p
-        class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]"
-      >
-        Changelog
-      </p>
-      <h1
-        class="font-black text-5xl md:text-6xl leading-[1.15] tracking-tight"
-      >
-        更新履歴
-      </h1>
-    </div>
-    <div class="col-span-12 md:col-span-4 md:pt-6 text-[var(--color-sub)] leading-loose text-sm">
+  <section class="pt-10 sm:pt-14 md:pt-20 lg:pt-28 pb-10 sm:pb-14 md:pb-20">
+    <p class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]">
+      Changelog
+    </p>
+    <h1
+      class="mt-5 font-black text-4xl sm:text-5xl md:text-6xl lg:text-7xl leading-[1.15] tracking-tight"
+    >
+      更新履歴
+    </h1>
+    <div class="mt-6 max-w-2xl text-[var(--color-sub)] leading-loose text-sm sm:text-base">
       <p>
-        記事の追加・修正・改訂を<br />
-        時系列で記録しています。
+        記事の追加・修正・改訂を時系列で記録しています。
       </p>
     </div>
   </section>

--- a/src/pages/columns/[...slug].astro
+++ b/src/pages/columns/[...slug].astro
@@ -66,43 +66,35 @@ const breadcrumbJsonLd = {
     </a>
   </div>
 
-  <header class="grid grid-cols-12 gap-6 pb-12 border-b border-[var(--color-line)]">
-    <div class="col-span-12 md:col-span-8 space-y-6">
-      <div class="space-y-1">
-        <p
-          class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]"
-        >
-          Column — {d.date}{d.lastVerified && d.lastVerified !== d.date ? ` / 最終更新 ${d.lastVerified}` : ""}
-        </p>
-        <p class="text-xs text-[var(--color-sub)]">コラム</p>
-      </div>
-      <h1
-        class="font-black text-4xl md:text-5xl leading-[1.15] tracking-tight"
-      >
-        {d.title}
-      </h1>
-      <p
-        class="text-[var(--color-sub)] text-base md:text-lg leading-loose max-w-xl"
-      >
-        {d.summary}
-      </p>
-    </div>
-    <div class="col-span-12 md:col-span-4 md:pt-12">
-      {
-        d.tags.length > 0 && (
-          <div class="flex flex-wrap gap-2">
-            {d.tags.map((tag) => (
-              <a
-                href={`/tags/${encodeURIComponent(tag)}`}
-                class="font-mono text-[11px] uppercase tracking-widest text-[var(--color-sub)] border border-[var(--color-line)] rounded-full px-3 py-1 hover:border-[var(--color-accent)] hover:text-[var(--color-accent)] transition"
-              >
-                {tag}
-              </a>
-            ))}
-          </div>
-        )
-      }
-    </div>
+  <header class="pb-12 border-b border-[var(--color-line)]">
+    <p class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]">
+      Column — {d.date}{d.lastVerified && d.lastVerified !== d.date ? ` / 最終更新 ${d.lastVerified}` : ""}
+    </p>
+    <p class="mt-1 text-xs text-[var(--color-sub)]">コラム</p>
+    <h1
+      class="mt-5 font-black text-3xl sm:text-4xl md:text-5xl lg:text-6xl leading-[1.15] tracking-tight"
+    >
+      {d.title}
+    </h1>
+    <p
+      class="mt-6 text-[var(--color-sub)] text-base md:text-lg leading-loose max-w-2xl"
+    >
+      {d.summary}
+    </p>
+    {
+      d.tags.length > 0 && (
+        <div class="mt-6 flex flex-wrap gap-2">
+          {d.tags.map((tag) => (
+            <a
+              href={`/tags/${encodeURIComponent(tag)}`}
+              class="font-mono text-[11px] uppercase tracking-widest text-[var(--color-sub)] border border-[var(--color-line)] rounded-full px-3 py-1 hover:border-[var(--color-accent)] hover:text-[var(--color-accent)] transition"
+            >
+              {tag}
+            </a>
+          ))}
+        </div>
+      )
+    }
   </header>
 
   <div class="lg:grid lg:grid-cols-[minmax(0,1fr)_220px] lg:gap-10">

--- a/src/pages/columns/index.astro
+++ b/src/pages/columns/index.astro
@@ -21,26 +21,18 @@ const initialTag = Astro.url.searchParams.get("tag") ?? "";
 ---
 
 <Layout title="エビデンスで考える — EduEvidence JP">
-  <section class="py-10 xs:py-14 sm:py-20 md:py-28 grid grid-cols-12 gap-6">
-    <div class="col-span-12 md:col-span-8 space-y-6">
-      <p
-        class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]"
-      >
-        Columns — Think with evidence
-      </p>
-      <h1
-        class="font-black text-5xl md:text-6xl leading-[1.15] tracking-tight"
-      >
-        <span class="text-[var(--color-accent)]">エビデンス</span>で考える
-      </h1>
-    </div>
-    <div
-      class="col-span-12 md:col-span-4 md:pt-6 text-[var(--color-sub)] leading-loose text-sm"
+  <section class="pt-10 sm:pt-14 md:pt-20 lg:pt-28 pb-10 sm:pb-14 md:pb-20">
+    <p class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]">
+      Columns — Think with evidence
+    </p>
+    <h1
+      class="mt-5 font-black text-4xl sm:text-5xl md:text-6xl lg:text-7xl leading-[1.15] tracking-tight"
     >
+      <span class="text-[var(--color-accent)]">エビデンス</span>で考える
+    </h1>
+    <div class="mt-6 max-w-2xl text-[var(--color-sub)] leading-loose text-sm sm:text-base">
       <p>
-        教育界で話題のテーマを、<br />
-        研究のエビデンスに照らして考える<br />
-        コラムシリーズです。
+        教育界で話題のテーマを、研究のエビデンスに照らして考えるコラムシリーズです。
       </p>
     </div>
   </section>

--- a/src/pages/concerns/index.astro
+++ b/src/pages/concerns/index.astro
@@ -27,26 +27,18 @@ function formatMonths(m: number): string {
 ---
 
 <Layout title="悩みから探す — EduEvidence JP">
-  <section class="py-10 xs:py-14 sm:py-20 md:py-28 grid grid-cols-12 gap-6">
-    <div class="col-span-12 md:col-span-8 space-y-6">
-      <p
-        class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]"
-      >
-        Find by your concern
-      </p>
-      <h1 class="font-black text-5xl md:text-6xl leading-[1.15] tracking-tight">
-        <span class="text-[var(--color-accent)]">悩み</span>から探す
-      </h1>
-    </div>
-    <div
-      class="col-span-12 md:col-span-4 md:pt-6 text-[var(--color-sub)] leading-loose text-sm"
-    >
+  <section class="pt-10 sm:pt-14 md:pt-20 lg:pt-28 pb-10 sm:pb-14 md:pb-20">
+    <p class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]">
+      Find by your concern
+    </p>
+    <h1 class="mt-5 font-black text-4xl sm:text-5xl md:text-6xl lg:text-7xl leading-[1.15] tracking-tight">
+      <span class="text-[var(--color-accent)]">悩み</span>から探す
+    </h1>
+    <div class="mt-6 max-w-2xl text-[var(--color-sub)] leading-loose text-sm sm:text-base space-y-2">
       <p>
-        現場でよくある悩みから、<br />
-        エビデンスに裏付けられた<br />
-        指導法・コラムに進めます。
+        現場でよくある悩みから、エビデンスに裏付けられた指導法・コラムに進めます。
       </p>
-      <p class="text-xs mt-3">
+      <p class="text-xs">
         {concernCategories.length}カテゴリ / {totalConcerns}の悩み
       </p>
     </div>

--- a/src/pages/cost/index.astro
+++ b/src/pages/cost/index.astro
@@ -40,17 +40,15 @@ const costGroups = [
 ---
 
 <Layout title="コストから探す — EduEvidence JP">
-  <section class="py-10 xs:py-14 sm:py-20 md:py-28 grid grid-cols-12 gap-6">
-    <div class="col-span-12 md:col-span-8 space-y-6">
-      <p class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]">
-        Browse by cost
-      </p>
-      <h1 class="font-black text-5xl md:text-6xl leading-[1.15] tracking-tight">
-        コストから探す
-      </h1>
-    </div>
-    <div class="col-span-12 md:col-span-4 md:pt-6 text-[var(--color-sub)] leading-loose text-sm">
-      <p>「お金をかけずに明日から」<br />始められるものから探せます。</p>
+  <section class="pt-10 sm:pt-14 md:pt-20 lg:pt-28 pb-10 sm:pb-14 md:pb-20">
+    <p class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]">
+      Browse by cost
+    </p>
+    <h1 class="mt-5 font-black text-4xl sm:text-5xl md:text-6xl lg:text-7xl leading-[1.15] tracking-tight">
+      コストから探す
+    </h1>
+    <div class="mt-6 max-w-2xl text-[var(--color-sub)] leading-loose text-sm sm:text-base">
+      <p>「お金をかけずに明日から」始められるものから探せます。</p>
     </div>
   </section>
 

--- a/src/pages/faq.astro
+++ b/src/pages/faq.astro
@@ -102,19 +102,15 @@ const faqSections = [
 ---
 
 <Layout title="よくある質問 — EduEvidence JP">
-  <section class="py-10 xs:py-14 sm:py-20 md:py-28 grid grid-cols-12 gap-6">
-    <div class="col-span-12 md:col-span-8 space-y-6">
-      <p
-        class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]"
-      >
-        Frequently asked questions
-      </p>
-      <h1
-        class="font-black text-5xl md:text-6xl leading-[1.15] tracking-tight"
-      >
-        よくある質問
-      </h1>
-    </div>
+  <section class="pt-10 sm:pt-14 md:pt-20 lg:pt-28 pb-10 sm:pb-14 md:pb-20">
+    <p class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]">
+      Frequently asked questions
+    </p>
+    <h1
+      class="mt-5 font-black text-4xl sm:text-5xl md:text-6xl lg:text-7xl leading-[1.15] tracking-tight"
+    >
+      よくある質問
+    </h1>
   </section>
 
   <section class="pb-24 space-y-16">

--- a/src/pages/grades/[grade].astro
+++ b/src/pages/grades/[grade].astro
@@ -23,20 +23,17 @@ const strategies = allStrategies
 ---
 
 <Layout title={`${grade} — EduEvidence JP`}>
-  <section class="py-10 xs:py-14 sm:py-20 md:py-28 grid grid-cols-12 gap-6">
-    <div class="col-span-12 md:col-span-8 space-y-6">
-      <div class="space-y-1">
-        <p class="font-mono text-xs uppercase tracking-widest text-[var(--color-sub)]">
-          <a href="/grades" class="hover:text-[var(--color-ink)]">Grades</a> /
-        </p>
-        <p class="text-xs text-[var(--color-sub)]">学年で絞り込み</p>
-      </div>
-      <h1 class="font-black text-5xl md:text-6xl leading-[1.15] tracking-tight">
-        <span class="text-[var(--color-accent)]">{grade}</span>
-      </h1>
-    </div>
-    <div class="col-span-12 md:col-span-4 md:pt-6 text-[var(--color-sub)] leading-loose text-sm">
-      <p>「{grade}」で活用できる指導法<br /><span class="text-xs">{strategies.length}件</span></p>
+  <section class="pt-10 sm:pt-14 md:pt-20 lg:pt-28 pb-10 sm:pb-14 md:pb-20">
+    <p class="font-mono text-xs uppercase tracking-widest text-[var(--color-sub)]">
+      <a href="/grades" class="hover:text-[var(--color-ink)]">Grades</a> /
+    </p>
+    <p class="mt-1 text-xs text-[var(--color-sub)]">学年で絞り込み</p>
+    <h1 class="mt-5 font-black text-4xl sm:text-5xl md:text-6xl lg:text-7xl leading-[1.15] tracking-tight">
+      <span class="text-[var(--color-accent)]">{grade}</span>
+    </h1>
+    <div class="mt-6 max-w-2xl text-[var(--color-sub)] leading-loose text-sm sm:text-base space-y-1">
+      <p>「{grade}」で活用できる指導法</p>
+      <p class="text-xs">{strategies.length}件</p>
     </div>
   </section>
 

--- a/src/pages/grades/index.astro
+++ b/src/pages/grades/index.astro
@@ -18,17 +18,15 @@ const grades = [...gradeMap.entries()].sort(
 ---
 
 <Layout title="学年から探す — EduEvidence JP">
-  <section class="py-10 xs:py-14 sm:py-20 md:py-28 grid grid-cols-12 gap-6">
-    <div class="col-span-12 md:col-span-8 space-y-6">
-      <p class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]">
-        Browse by grade
-      </p>
-      <h1 class="font-black text-5xl md:text-6xl leading-[1.15] tracking-tight">
-        学年から探す
-      </h1>
-    </div>
-    <div class="col-span-12 md:col-span-4 md:pt-6 text-[var(--color-sub)] leading-loose text-sm">
-      <p>担当する学年で<br />使える指導法を見つけられます。</p>
+  <section class="pt-10 sm:pt-14 md:pt-20 lg:pt-28 pb-10 sm:pb-14 md:pb-20">
+    <p class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]">
+      Browse by grade
+    </p>
+    <h1 class="mt-5 font-black text-4xl sm:text-5xl md:text-6xl lg:text-7xl leading-[1.15] tracking-tight">
+      学年から探す
+    </h1>
+    <div class="mt-6 max-w-2xl text-[var(--color-sub)] leading-loose text-sm sm:text-base">
+      <p>担当する学年で使える指導法を見つけられます。</p>
     </div>
   </section>
 

--- a/src/pages/guide/cultural-context.astro
+++ b/src/pages/guide/cultural-context.astro
@@ -3,23 +3,18 @@ import Layout from "../../layouts/Layout.astro";
 ---
 
 <Layout title="エビデンスと文化的文脈 — EduEvidence JP">
-  <section class="py-10 xs:py-14 sm:py-20 md:py-28 grid grid-cols-12 gap-6">
-    <div class="col-span-12 md:col-span-8 space-y-6">
-      <p
-        class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]"
-      >
-        Guide — Evidence in cultural context
-      </p>
-      <h1
-        class="font-black text-5xl md:text-6xl leading-[1.15] tracking-tight"
-      >
-        エビデンスと<br /><span class="text-[var(--color-accent)]">文化的文脈</span>
-      </h1>
-    </div>
-    <div class="col-span-12 md:col-span-4 md:pt-6 text-[var(--color-sub)] leading-loose text-sm">
+  <section class="pt-10 sm:pt-14 md:pt-20 lg:pt-28 pb-10 sm:pb-14 md:pb-20">
+    <p class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]">
+      Guide — Evidence in cultural context
+    </p>
+    <h1
+      class="mt-5 font-black text-4xl sm:text-5xl md:text-6xl lg:text-7xl leading-[1.15] tracking-tight"
+    >
+      エビデンスと<br /><span class="text-[var(--color-accent)]">文化的文脈</span>
+    </h1>
+    <div class="mt-6 max-w-2xl text-[var(--color-sub)] leading-loose text-sm sm:text-base">
       <p>
-        海外の教育研究は、そのまま日本に当てはまりません。<br />
-        本サイトがどう「出典と文化」を扱うかを説明します。
+        海外の教育研究は、そのまま日本に当てはまりません。本サイトがどう「出典と文化」を扱うかを説明します。
       </p>
     </div>
   </section>

--- a/src/pages/guide/evidence.astro
+++ b/src/pages/guide/evidence.astro
@@ -3,24 +3,18 @@ import Layout from "../../layouts/Layout.astro";
 ---
 
 <Layout title="エビデンス入門 — EduEvidence JP">
-  <section class="py-10 xs:py-14 sm:py-20 md:py-28 grid grid-cols-12 gap-6">
-    <div class="col-span-12 md:col-span-8 space-y-6">
-      <p
-        class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]"
-      >
-        Guide — What is evidence?
-      </p>
-      <h1
-        class="font-black text-5xl md:text-6xl leading-[1.15] tracking-tight"
-      >
-        <span class="text-[var(--color-accent)]">エビデンス</span>入門
-      </h1>
-    </div>
-    <div class="col-span-12 md:col-span-4 md:pt-6 text-[var(--color-sub)] leading-loose text-sm">
+  <section class="pt-10 sm:pt-14 md:pt-20 lg:pt-28 pb-10 sm:pb-14 md:pb-20">
+    <p class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]">
+      Guide — What is evidence?
+    </p>
+    <h1
+      class="mt-5 font-black text-4xl sm:text-5xl md:text-6xl lg:text-7xl leading-[1.15] tracking-tight"
+    >
+      <span class="text-[var(--color-accent)]">エビデンス</span>入門
+    </h1>
+    <div class="mt-6 max-w-2xl text-[var(--color-sub)] leading-loose text-sm sm:text-base">
       <p>
-        「エビデンスに基づく教育」の基本を、<br />
-        研究の読み方が分からなくても<br />
-        理解できるように解説します。
+        「エビデンスに基づく教育」の基本を、研究の読み方が分からなくても理解できるように解説します。
       </p>
     </div>
   </section>

--- a/src/pages/guide/glossary.astro
+++ b/src/pages/guide/glossary.astro
@@ -87,25 +87,20 @@ const terms = [
 ---
 
 <Layout title="用語集 — EduEvidence JP">
-  <section class="py-10 xs:py-14 sm:py-20 md:py-28 grid grid-cols-12 gap-6">
-    <div class="col-span-12 md:col-span-8 space-y-6">
-      <p
-        class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]"
-      >
-        Guide — Glossary
-      </p>
-      <h1
-        class="font-black text-5xl md:text-6xl leading-[1.15] tracking-tight"
-      >
-        用語集
-      </h1>
-    </div>
-    <div class="col-span-12 md:col-span-4 md:pt-6 text-[var(--color-sub)] leading-loose text-sm">
+  <section class="pt-10 sm:pt-14 md:pt-20 lg:pt-28 pb-10 sm:pb-14 md:pb-20">
+    <p class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]">
+      Guide — Glossary
+    </p>
+    <h1
+      class="mt-5 font-black text-4xl sm:text-5xl md:text-6xl lg:text-7xl leading-[1.15] tracking-tight"
+    >
+      用語集
+    </h1>
+    <div class="mt-6 max-w-2xl text-[var(--color-sub)] leading-loose text-sm sm:text-base space-y-2">
       <p>
-        本サイトで使われている<br />
-        専門用語を一行で解説します。<br />
-        <span class="text-xs">{terms.length}語収録</span>
+        本サイトで使われている専門用語を一行で解説します。
       </p>
+      <p class="text-xs">{terms.length}語収録</p>
     </div>
   </section>
 

--- a/src/pages/guide/index.astro
+++ b/src/pages/guide/index.astro
@@ -30,23 +30,18 @@ const guides = [
 ---
 
 <Layout title="Guide — EduEvidence JP">
-  <section class="py-10 xs:py-14 sm:py-20 md:py-28 grid grid-cols-12 gap-6">
-    <div class="col-span-12 md:col-span-8 space-y-6">
-      <p
-        class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]"
-      >
-        Guide
-      </p>
-      <h1
-        class="font-black text-5xl md:text-6xl leading-[1.15] tracking-tight"
-      >
-        読み方ガイド
-      </h1>
-    </div>
-    <div class="col-span-12 md:col-span-4 md:pt-6 text-[var(--color-sub)] leading-loose text-sm">
+  <section class="pt-10 sm:pt-14 md:pt-20 lg:pt-28 pb-10 sm:pb-14 md:pb-20">
+    <p class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]">
+      Guide
+    </p>
+    <h1
+      class="mt-5 font-black text-4xl sm:text-5xl md:text-6xl lg:text-7xl leading-[1.15] tracking-tight"
+    >
+      読み方ガイド
+    </h1>
+    <div class="mt-6 max-w-2xl text-[var(--color-sub)] leading-loose text-sm sm:text-base">
       <p>
-        指導法の記事をより深く理解するための<br />
-        補助資料を揃えています。
+        指導法の記事をより深く理解するための補助資料を揃えています。
       </p>
     </div>
   </section>

--- a/src/pages/guide/indicators.astro
+++ b/src/pages/guide/indicators.astro
@@ -3,23 +3,18 @@ import Layout from "../../layouts/Layout.astro";
 ---
 
 <Layout title="指標の読み方 — EduEvidence JP">
-  <section class="py-10 xs:py-14 sm:py-20 md:py-28 grid grid-cols-12 gap-6">
-    <div class="col-span-12 md:col-span-8 space-y-6">
-      <p
-        class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]"
-      >
-        Guide — How to read
-      </p>
-      <h1
-        class="font-black text-5xl md:text-6xl leading-[1.15] tracking-tight"
-      >
-        4つの指標の<br /><span class="text-[var(--color-accent)]">読み方</span>
-      </h1>
-    </div>
-    <div class="col-span-12 md:col-span-4 md:pt-6 text-[var(--color-sub)] leading-loose text-sm">
+  <section class="pt-10 sm:pt-14 md:pt-20 lg:pt-28 pb-10 sm:pb-14 md:pb-20">
+    <p class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]">
+      Guide — How to read
+    </p>
+    <h1
+      class="mt-5 font-black text-4xl sm:text-5xl md:text-6xl lg:text-7xl leading-[1.15] tracking-tight"
+    >
+      4つの指標の<br /><span class="text-[var(--color-accent)]">読み方</span>
+    </h1>
+    <div class="mt-6 max-w-2xl text-[var(--color-sub)] leading-loose text-sm sm:text-base">
       <p>
-        本サイトの各指導法には4つの指標が付いています。<br />
-        ここでは、それぞれの意味と読み取り方を解説します。
+        本サイトの各指導法には4つの指標が付いています。ここでは、それぞれの意味と読み取り方を解説します。
       </p>
     </div>
   </section>

--- a/src/pages/policy-evidence.astro
+++ b/src/pages/policy-evidence.astro
@@ -175,26 +175,18 @@ const alignmentLabel: Record<string, { text: string; color: string }> = {
 ---
 
 <Layout title="政策とエビデンス — EduEvidence JP">
-  <section class="py-10 xs:py-14 sm:py-20 md:py-28 grid grid-cols-12 gap-6">
-    <div class="col-span-12 md:col-span-8 space-y-6">
-      <p
-        class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]"
-      >
-        Policy × Evidence
-      </p>
-      <h1
-        class="font-black text-5xl md:text-6xl leading-[1.15] tracking-tight"
-      >
-        政策と<span class="text-[var(--color-accent)]">エビデンス</span>
-      </h1>
-    </div>
-    <div
-      class="col-span-12 md:col-span-4 md:pt-6 text-[var(--color-sub)] leading-loose text-sm"
+  <section class="pt-10 sm:pt-14 md:pt-20 lg:pt-28 pb-10 sm:pb-14 md:pb-20">
+    <p class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]">
+      Policy × Evidence
+    </p>
+    <h1
+      class="mt-5 font-black text-4xl sm:text-5xl md:text-6xl lg:text-7xl leading-[1.15] tracking-tight"
     >
+      政策と<span class="text-[var(--color-accent)]">エビデンス</span>
+    </h1>
+    <div class="mt-6 max-w-2xl text-[var(--color-sub)] leading-loose text-sm sm:text-base">
       <p>
-        教育委員会や文部科学省から<br />
-        推進される主な政策を、<br />
-        研究のエビデンスと照らし合わせます。
+        教育委員会や文部科学省から推進される主な政策を、研究のエビデンスと照らし合わせます。
       </p>
     </div>
   </section>

--- a/src/pages/subjects/[subject].astro
+++ b/src/pages/subjects/[subject].astro
@@ -23,20 +23,17 @@ const strategies = allStrategies
 ---
 
 <Layout title={`${subject} — EduEvidence JP`}>
-  <section class="py-10 xs:py-14 sm:py-20 md:py-28 grid grid-cols-12 gap-6">
-    <div class="col-span-12 md:col-span-8 space-y-6">
-      <div class="space-y-1">
-        <p class="font-mono text-xs uppercase tracking-widest text-[var(--color-sub)]">
-          <a href="/subjects" class="hover:text-[var(--color-ink)]">Subjects</a> /
-        </p>
-        <p class="text-xs text-[var(--color-sub)]">教科で絞り込み</p>
-      </div>
-      <h1 class="font-black text-5xl md:text-6xl leading-[1.15] tracking-tight">
-        <span class="text-[var(--color-accent)]">{subject}</span>
-      </h1>
-    </div>
-    <div class="col-span-12 md:col-span-4 md:pt-6 text-[var(--color-sub)] leading-loose text-sm">
-      <p>「{subject}」に関連する指導法<br /><span class="text-xs">{strategies.length}件</span></p>
+  <section class="pt-10 sm:pt-14 md:pt-20 lg:pt-28 pb-10 sm:pb-14 md:pb-20">
+    <p class="font-mono text-xs uppercase tracking-widest text-[var(--color-sub)]">
+      <a href="/subjects" class="hover:text-[var(--color-ink)]">Subjects</a> /
+    </p>
+    <p class="mt-1 text-xs text-[var(--color-sub)]">教科で絞り込み</p>
+    <h1 class="mt-5 font-black text-4xl sm:text-5xl md:text-6xl lg:text-7xl leading-[1.15] tracking-tight">
+      <span class="text-[var(--color-accent)]">{subject}</span>
+    </h1>
+    <div class="mt-6 max-w-2xl text-[var(--color-sub)] leading-loose text-sm sm:text-base space-y-1">
+      <p>「{subject}」に関連する指導法</p>
+      <p class="text-xs">{strategies.length}件</p>
     </div>
   </section>
 

--- a/src/pages/subjects/index.astro
+++ b/src/pages/subjects/index.astro
@@ -15,17 +15,15 @@ const subjects = [...subjectMap.entries()].sort((a, b) => b[1] - a[1]);
 ---
 
 <Layout title="教科から探す — EduEvidence JP">
-  <section class="py-10 xs:py-14 sm:py-20 md:py-28 grid grid-cols-12 gap-6">
-    <div class="col-span-12 md:col-span-8 space-y-6">
-      <p class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]">
-        Browse by subject
-      </p>
-      <h1 class="font-black text-5xl md:text-6xl leading-[1.15] tracking-tight">
-        教科から探す
-      </h1>
-    </div>
-    <div class="col-span-12 md:col-span-4 md:pt-6 text-[var(--color-sub)] leading-loose text-sm">
-      <p>担当する教科に関連する<br />指導法を見つけられます。</p>
+  <section class="pt-10 sm:pt-14 md:pt-20 lg:pt-28 pb-10 sm:pb-14 md:pb-20">
+    <p class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]">
+      Browse by subject
+    </p>
+    <h1 class="mt-5 font-black text-4xl sm:text-5xl md:text-6xl lg:text-7xl leading-[1.15] tracking-tight">
+      教科から探す
+    </h1>
+    <div class="mt-6 max-w-2xl text-[var(--color-sub)] leading-loose text-sm sm:text-base">
+      <p>担当する教科に関連する指導法を見つけられます。</p>
     </div>
   </section>
 

--- a/src/pages/support.astro
+++ b/src/pages/support.astro
@@ -3,24 +3,18 @@ import Layout from "../layouts/Layout.astro";
 ---
 
 <Layout title="運営を支援する — EduEvidence JP">
-  <section class="py-10 xs:py-14 sm:py-20 md:py-28 grid grid-cols-12 gap-6">
-    <div class="col-span-12 md:col-span-8 space-y-6">
-      <p
-        class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]"
-      >
-        Support
-      </p>
-      <h1
-        class="font-black text-5xl md:text-6xl leading-[1.15] tracking-tight"
-      >
-        運営を<br /><span class="text-[var(--color-accent)]">支援</span>する
-      </h1>
-    </div>
-    <div class="col-span-12 md:col-span-4 md:pt-6 text-[var(--color-sub)] leading-loose text-sm">
+  <section class="pt-10 sm:pt-14 md:pt-20 lg:pt-28 pb-10 sm:pb-14 md:pb-20">
+    <p class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]">
+      Support
+    </p>
+    <h1
+      class="mt-5 font-black text-4xl sm:text-5xl md:text-6xl lg:text-7xl leading-[1.15] tracking-tight"
+    >
+      運営を<br /><span class="text-[var(--color-accent)]">支援</span>する
+    </h1>
+    <div class="mt-6 max-w-2xl text-[var(--color-sub)] leading-loose text-sm sm:text-base">
       <p>
-        EduEvidence JP は非営利で運営しています。<br />
-        広告を入れず、教員にとって<br />
-        信頼できる情報源であり続けるために。
+        EduEvidence JP は非営利で運営しています。広告を入れず、教員にとって信頼できる情報源であり続けるために。
       </p>
     </div>
   </section>

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -35,29 +35,19 @@ const totalCount = strategies.length + columns.length;
 ---
 
 <Layout title={`${tag} — EduEvidence JP`}>
-  <section class="py-10 xs:py-14 sm:py-20 md:py-28 grid grid-cols-12 gap-6">
-    <div class="col-span-12 md:col-span-8 space-y-6">
-      <div class="space-y-1">
-        <p
-          class="font-mono text-xs uppercase tracking-widest text-[var(--color-sub)]"
-        >
-          <a href="/tags" class="hover:text-[var(--color-ink)]">Tags</a> /
-        </p>
-        <p class="text-xs text-[var(--color-sub)]">タグから絞り込み</p>
-      </div>
-      <h1
-        class="font-black text-5xl md:text-6xl leading-[1.15] tracking-tight"
-      >
-        <span class="text-[var(--color-accent)]">{tag}</span>
-      </h1>
-    </div>
-    <div class="col-span-12 md:col-span-4 md:pt-6 text-[var(--color-sub)] leading-loose text-sm">
-      <p>
-        「{tag}」に関連するコンテンツ<br />
-        <span class="text-xs">
-          指導法 {strategies.length}件 / コラム {columns.length}件
-        </span>
-      </p>
+  <section class="pt-10 sm:pt-14 md:pt-20 lg:pt-28 pb-10 sm:pb-14 md:pb-20">
+    <p class="font-mono text-xs uppercase tracking-widest text-[var(--color-sub)]">
+      <a href="/tags" class="hover:text-[var(--color-ink)]">Tags</a> /
+    </p>
+    <p class="mt-1 text-xs text-[var(--color-sub)]">タグから絞り込み</p>
+    <h1
+      class="mt-5 font-black text-4xl sm:text-5xl md:text-6xl lg:text-7xl leading-[1.15] tracking-tight"
+    >
+      <span class="text-[var(--color-accent)]">{tag}</span>
+    </h1>
+    <div class="mt-6 max-w-2xl text-[var(--color-sub)] leading-loose text-sm sm:text-base space-y-1">
+      <p>「{tag}」に関連するコンテンツ</p>
+      <p class="text-xs">指導法 {strategies.length}件 / コラム {columns.length}件</p>
     </div>
   </section>
 

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -21,25 +21,20 @@ const tags = [...tagMap.entries()].sort((a, b) => b[1] - a[1]);
 ---
 
 <Layout title="タグ一覧 — EduEvidence JP">
-  <section class="py-10 xs:py-14 sm:py-20 md:py-28 grid grid-cols-12 gap-6">
-    <div class="col-span-12 md:col-span-8 space-y-6">
-      <p
-        class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]"
-      >
-        Tags
-      </p>
-      <h1
-        class="font-black text-5xl md:text-6xl leading-[1.15] tracking-tight"
-      >
-        タグ一覧
-      </h1>
-    </div>
-    <div class="col-span-12 md:col-span-4 md:pt-6 text-[var(--color-sub)] leading-loose text-sm">
+  <section class="pt-10 sm:pt-14 md:pt-20 lg:pt-28 pb-10 sm:pb-14 md:pb-20">
+    <p class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]">
+      Tags
+    </p>
+    <h1
+      class="mt-5 font-black text-4xl sm:text-5xl md:text-6xl lg:text-7xl leading-[1.15] tracking-tight"
+    >
+      タグ一覧
+    </h1>
+    <div class="mt-6 max-w-2xl text-[var(--color-sub)] leading-loose text-sm sm:text-base space-y-2">
       <p>
-        指導法とコラムを関心のあるテーマから<br />
-        探すことができます。<br />
-        <span class="text-xs">{tags.length}タグ / 指導法 {strategies.length}件 / コラム {columns.length}件</span>
+        指導法とコラムを関心のあるテーマから探すことができます。
       </p>
+      <p class="text-xs">{tags.length}タグ / 指導法 {strategies.length}件 / コラム {columns.length}件</p>
     </div>
   </section>
 

--- a/src/pages/voices.astro
+++ b/src/pages/voices.astro
@@ -3,23 +3,18 @@ import Layout from "../layouts/Layout.astro";
 ---
 
 <Layout title="現場の声 — EduEvidence JP">
-  <section class="py-10 xs:py-14 sm:py-20 md:py-28 grid grid-cols-12 gap-6">
-    <div class="col-span-12 md:col-span-8 space-y-6">
-      <p
-        class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]"
-      >
-        Voices from the field
-      </p>
-      <h1
-        class="font-black text-5xl md:text-6xl leading-[1.15] tracking-tight"
-      >
-        現場の声
-      </h1>
-    </div>
-    <div class="col-span-12 md:col-span-4 md:pt-6 text-[var(--color-sub)] leading-loose text-sm">
+  <section class="pt-10 sm:pt-14 md:pt-20 lg:pt-28 pb-10 sm:pb-14 md:pb-20">
+    <p class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]">
+      Voices from the field
+    </p>
+    <h1
+      class="mt-5 font-black text-4xl sm:text-5xl md:text-6xl lg:text-7xl leading-[1.15] tracking-tight"
+    >
+      現場の声
+    </h1>
+    <div class="mt-6 max-w-2xl text-[var(--color-sub)] leading-loose text-sm sm:text-base">
       <p>
-        本サイトの情報を実際の教室で<br />
-        活用された先生方の声を掲載します。
+        本サイトの情報を実際の教室で活用された先生方の声を掲載します。
       </p>
     </div>
   </section>


### PR DESCRIPTION
## Summary

ADR 0009(PR #145)で確定した縦積み Hero 共通仕様を、edu-evidence の残り 21 FV ページへ機械的に適用する。

## 対象ページ

| カテゴリ | ファイル |
|---|---|
| 一覧系 | `columns/index` / `concerns/index` / `policy-evidence` |
| 静的ページ | `about` / `faq` / `changelog` / `voices` / `support` |
| ガイド | `guide/index` / `guide/cultural-context` / `guide/glossary` / `guide/indicators` / `guide/evidence` |
| 学年・教科・タグ・コスト | `grades/index` / `grades/[grade]` / `subjects/index` / `subjects/[subject]` / `tags/index` / `tags/[tag]` / `cost/index` |
| 個別記事 | `columns/[...slug]`(ADR 例外: H1 を 1 段下げ) |

## 変更内容

各ページの FV を ADR 0009 の共通仕様に揃えた:

```html
<section class="pt-10 sm:pt-14 md:pt-20 lg:pt-28 pb-10 sm:pb-14 md:pb-20">
  <p class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]">
    {Kicker}
  </p>
  <h1 class="mt-5 font-black text-4xl sm:text-5xl md:text-6xl lg:text-7xl leading-[1.15] tracking-tight">
    {Title}
  </h1>
  <div class="mt-6 max-w-2xl text-[var(--color-sub)] leading-loose text-sm sm:text-base">
    {Description}
  </div>
  <!-- ページ固有の追加要素(タグチップ等)が必要なら mt-6 で続ける -->
</section>
```

説明文の hard `<br/>` 改行を削除し、`max-w-2xl` の自然折り返しに任せる(様々なビューポートで読みやすさが向上)。

### 個別記事(`columns/[...slug]`)の例外適用

ADR 0009 の例外節に従い、H1 サイズを 1 段下げ:

```
text-3xl sm:text-4xl md:text-5xl lg:text-6xl
```

タグチップは右 col-span-4 から H1 直下のフローへ移動。

## Out of scope

**`strategies/[...slug]`**: 戦略個別ページの右 col-span-4 は **効果量・エビデンス・コスト・出典バッジの中核メタブロック** を持ち、H1 直下に流すと中核情報の優先度が下がる。12-col grid 構造を維持するのが合理的なため、本 PR では触らない。後続 PR で ADR 0009 の例外節をもう一段拡張(「メタデータブロック付きの個別ページは 12-col grid を許容」)し、H1 サイズだけ整える。

## changelog

`changelog.astro` は更新しない(レイアウト rearrangement で読み手は同じ内容を別配置で見るだけ、rule 8b 準拠)。edu-watch を同仕様に揃える次 PR で「サイト横断のヘッダー統一」として 1 行追加する想定。

## アクセシビリティ

ADR 0009 の評価通り:
- WCAG SC 1.3.2 / 1.4.4 / 1.4.10 / 2.4.6 すべて達成
- 既存コントラストトークン維持(AA)

## 数値

- 21 ページ更新、241 insertions / 352 deletions(差分が多いのは hard `<br/>` 削除と grid 構造削除によるもの)
- ファイル単位平均 -5 行(クリーンアップ効果)

## Test plan

- [x] `npm run check:text` / `check:consistency`
- [x] `npm run build`(248 ページ完了)
- [x] `npm run test:e2e`(37/37 passed)
- [ ] マージ後、本番で全 FV ページの表示をモバイル / デスクトップで確認
- [ ] 戦略個別ページは現状維持(`strategies/[...slug]`)

## 後続 PR

| Step | 内容 |
|---|---|
| 3 | edu-watch の全 FV ページに同仕様適用(ADR ミラー含む)+ 共通 changelog エントリ |
| 4 | 戦略個別ページの ADR 0009 例外節拡張 + H1 サイズ調整 |