### PR TITLE
fix: replace sunmark.co.jp legacy URL with new bookstore URL

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -263,7 +263,7 @@ import Layout from "../layouts/Layout.astro";
             <h3 class="font-bold text-lg">海外の研究者・書籍</h3>
             <ul class="space-y-3 text-sm leading-relaxed">
               <li>
-                『<a href="https://www.sunmark.co.jp/detail.php?csid=3843-9" target="_blank" rel="noopener noreferrer" class="link-underline text-[var(--color-accent)]">米国最強経済学者にして 2 児の母が読み解く 子どもの育て方ベスト</a>』 エミリー・オスター 著 / 堀内久美子 訳 (2022), サンマーク出版. — ブラウン大学経済学部教授。中室牧子と同様にデータ・統計を経済学の手法で読み解き、就学前期の子育てをめぐる通説を実証研究に照らして再検討する。
+                『<a href="https://bookstore.sunmark.co.jp/products/9784763138439" target="_blank" rel="noopener noreferrer" class="link-underline text-[var(--color-accent)]">米国最強経済学者にして 2 児の母が読み解く 子どもの育て方ベスト</a>』 エミリー・オスター 著 / 堀内久美子 訳 (2022), サンマーク出版. — ブラウン大学経済学部教授。中室牧子と同様にデータ・統計を経済学の手法で読み解き、就学前期の子育てをめぐる通説を実証研究に照らして再検討する。
               </li>
               <li>
                 『<a href="https://www.hayakawa-online.co.jp/shopdetail/000000013682/" target="_blank" rel="noopener noreferrer" class="link-underline text-[var(--color-accent)]">日本の15歳はなぜ学力が高いのか? — 5つの教育大国に学ぶ成功の秘密</a>』 ルーシー・クレハン 著 / 橋川史 訳 (2017), 早川書房. — 英国の教育研究者が日本・フィンランド・上海・シンガポール・カナダの 5 教育大国を実地調査したフィールドレポート。

--- a/src/pages/guide/evidence.astro
+++ b/src/pages/guide/evidence.astro
@@ -375,7 +375,7 @@ import Layout from "../../layouts/Layout.astro";
             <strong>『<a href="https://www.ohmsha.co.jp/book/9784274065705/" target="_blank" rel="noopener noreferrer" class="link-underline text-[var(--color-accent)]">マンガでわかる 統計学</a>』</strong> — 高橋信 著、トレンド・プロ 漫画制作 (2004)、オーム社. 統計学の基礎(平均・分散・検定・回帰など)をマンガ形式で導入する入門書。エビデンスを読むときに登場する用語を物語の中で掴める。
           </li>
           <li>
-            <strong>『<a href="https://www.sunmark.co.jp/detail.php?csid=3843-9" target="_blank" rel="noopener noreferrer" class="link-underline text-[var(--color-accent)]">米国最強経済学者にして 2 児の母が読み解く 子どもの育て方ベスト</a>』</strong> — エミリー・オスター 著、堀内久美子 訳 (2022)、サンマーク出版. ブラウン大学経済学部教授で 2 児の母である著者が、就学前期の子育てをめぐる通説を経済学・統計の手法でデータに基づき再検討した一般書。エビデンスを家庭の意思決定にどう生かすかの実例として読みやすい。
+            <strong>『<a href="https://bookstore.sunmark.co.jp/products/9784763138439" target="_blank" rel="noopener noreferrer" class="link-underline text-[var(--color-accent)]">米国最強経済学者にして 2 児の母が読み解く 子どもの育て方ベスト</a>』</strong> — エミリー・オスター 著、堀内久美子 訳 (2022)、サンマーク出版. ブラウン大学経済学部教授で 2 児の母である著者が、就学前期の子育てをめぐる通説を経済学・統計の手法でデータに基づき再検討した一般書。エビデンスを家庭の意思決定にどう生かすかの実例として読みやすい。
           </li>
         </ul>
       </div>


### PR DESCRIPTION
## 概要

Issue #156 で報告された自動リンクチェック失敗(`sunmark.co.jp` の SSL 証明書エラー × 2 件)を解消する。

## 背景

サンマーク出版が 2026-04 頃に書籍販売を Shopify ベースの新ストア(`bookstore.sunmark.co.jp`)へ移行し、旧 URL は 301 リダイレクト中。

- 旧: `https://www.sunmark.co.jp/detail.php?csid=3843-9`
- 新: `https://bookstore.sunmark.co.jp/products/9784763138439`

旧ドメインの証明書チェーンに lychee の SSL 検証が反応してエラー扱いになっていた。手元 curl でも旧 URL は `verify ok` で 301 を返すが、CI 環境(lychee)の trust store 差異で再現性のあるエラーになるため、最終遷移先に直接更新する。

## 変更

- `src/pages/about.astro`「海外の研究者・書籍」セクションのオスター本リンク
- `src/pages/guide/evidence.astro`「参考図書」セクションのオスター本リンク

## 検証

- `npm run check`: 0 errors / 0 warnings
- 新 URL の HTTP ステータス: `200 OK`(直接到達、リダイレクトなし)

## 注意

- changelog 更新なし(リンク先書籍は同じため、ユーザー価値の変化なし。memory rule 8b)

Fixes #156