### PR TITLE
chore(deps): npm audit fix to patch postcss and hono security advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6387,9 +6387,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.12",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
-      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+      "version": "4.12.16",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.16.tgz",
+      "integrity": "sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9579,9 +9579,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.9",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
-      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+      "version": "8.5.13",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
+      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
       "funding": [
         {
           "type": "opencollective",


### PR DESCRIPTION
## 概要

直近の dependabot 一連(PR #154/#155)マージ後に `npm audit` で検出された moderate 脆弱性のうち、`npm audit fix`(non-force)で解決可能なサブ依存 2 件を解消する。

## 解消対象

| パッケージ | 旧 | 新 | 種別 | 攻撃面 |
|---|---|---|---|---|
| **postcss** | 8.5.9 | 8.5.13 | 本番(`@astrojs/react → vite → postcss`) | XSS via unescaped `</style>` in CSS Stringify Output ([GHSA-qx2v-qp2m-jg93](https://github.com/advisories/GHSA-qx2v-qp2m-jg93)) |
| **hono** | 4.12.12 | 4.12.16 | dev(`textlint → @modelcontextprotocol/sdk → hono` / `@hono/node-server`) | HTML Injection in hono/jsx SSR ([GHSA-458j-xx4x-4375](https://github.com/advisories/GHSA-458j-xx4x-4375)) |

両方 patch リリースで API 変更なし。direct dep ではないため dependabot は拾えない範囲のため手動対応した形。

## 見送り(本 PR スコープ外)

`yaml < 2.8.3` 系 5 件(Stack Overflow via deeply nested YAML collections, GHSA-48c2-rrv3-qjmp)は `--force` 必要で `@astrojs/check` 0.9.9 → 0.9.2 へのダウングレードを伴うため見送り。直近 PR #154 で 0.9.9 に上げたばかりで、上流 `yaml-language-server` のリリース待ち。

経路: `@astrojs/check → @astrojs/language-server → volar-service-yaml → yaml-language-server → yaml`

## 検証

- `npm run check`: 0 errors / 0 warnings
- `npm run build`: 250 ページ正常生成
- `npm run test:e2e`: 37/37 passed

## 注意

- changelog 更新なし: 静的 SSG で実害なし(SSR/動的レンダリングを行わない)、ユーザー体験の変化なし(rule 8b)