### PR TITLE
chore: add LLM corruption / multi-turn drift defense hooks

### DIFF
--- a/.claude/hooks/__tests__/post-edit-roundtrip-spot-check.test.cjs
+++ b/.claude/hooks/__tests__/post-edit-roundtrip-spot-check.test.cjs
@@ -1,0 +1,135 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { run, extractTokens, diffTokens, TARGET_PATH_RE } =
+  require('../post-edit-roundtrip-spot-check.cjs');
+
+test('TARGET_PATH_RE: src/content paths fire', () => {
+  assert.match('src/content/strategies/x.md', TARGET_PATH_RE);
+  assert.match('src/content/columns/y.md', TARGET_PATH_RE);
+});
+
+test('TARGET_PATH_RE: code paths skip', () => {
+  assert.doesNotMatch('src/lib/util.ts', TARGET_PATH_RE);
+});
+
+test('extractTokens: ignores single-digit numbers', () => {
+  const t = extractTokens('a 1 b 12 c 100');
+  assert.deepEqual([...t.number].sort(), ['100', '12']);
+});
+
+test('extractTokens: strips DP-ids before number extraction', () => {
+  const t = extractTokens('DP24-1 effect d=0.42 N=200');
+  assert.deepEqual([...t.dp_id], ['DP24-1']);
+  assert.ok(![...t.number].includes('1'));
+  assert.deepEqual([...t.number].sort(), ['0.42', '200']);
+});
+
+test('PostToolUse: numeric body change emits additionalContext', () => {
+  const oldS = '効果量は d=0.42 でした。N=200 のサンプル。';
+  const newS = '効果量は d=0.81 でした。N=800 のサンプル。';
+  const input = JSON.stringify({
+    tool_name: 'Edit',
+    tool_input: { file_path: 'src/content/strategies/x.md', old_string: oldS, new_string: newS },
+  });
+  const out = run(input);
+  assert.equal(out.exitCode, 0);
+  assert.ok(out.stdout);
+  const parsed = JSON.parse(out.stdout);
+  assert.equal(parsed.hookSpecificOutput.hookEventName, 'PostToolUse');
+  assert.match(parsed.hookSpecificOutput.additionalContext, /effect_size/);
+  assert.match(parsed.hookSpecificOutput.additionalContext, /number/);
+});
+
+test('PostToolUse: stderr remains empty (user not spammed)', () => {
+  const oldS = 'd=0.42';
+  const newS = 'd=0.81';
+  const input = JSON.stringify({
+    tool_name: 'Edit',
+    tool_input: { file_path: 'src/content/strategies/x.md', old_string: oldS, new_string: newS },
+  });
+  const out = run(input);
+  assert.ok(!out.stderr);
+});
+
+test('PostToolUse: prose-only change emits nothing', () => {
+  const oldS = '本文の typo';
+  const newS = '本文の typo 直し';
+  const input = JSON.stringify({
+    tool_name: 'Edit',
+    tool_input: { file_path: 'src/content/strategies/x.md', old_string: oldS, new_string: newS },
+  });
+  const out = run(input);
+  assert.equal(out.exitCode, 0);
+  assert.ok(!out.stdout);
+});
+
+test('PostToolUse: code path skips even with numeric change', () => {
+  const oldS = 'const N = 200';
+  const newS = 'const N = 800';
+  const input = JSON.stringify({
+    tool_name: 'Edit',
+    tool_input: { file_path: 'src/lib/util.ts', old_string: oldS, new_string: newS },
+  });
+  const out = run(input);
+  assert.equal(out.exitCode, 0);
+  assert.ok(!out.stdout);
+});
+
+test('PostToolUse: URL change in body fires', () => {
+  const oldS = 'see https://nier.go.jp/source';
+  const newS = 'see https://wikipedia.org/article';
+  const input = JSON.stringify({
+    tool_name: 'Edit',
+    tool_input: { file_path: 'src/content/columns/y.md', old_string: oldS, new_string: newS },
+  });
+  const out = run(input);
+  assert.equal(out.exitCode, 0);
+  const parsed = JSON.parse(out.stdout);
+  assert.match(parsed.hookSpecificOutput.additionalContext, /url/);
+});
+
+test('PostToolUse: DP-id renumber fires', () => {
+  const oldS = 'DP25-029 study';
+  const newS = 'DP25-099 study';
+  const input = JSON.stringify({
+    tool_name: 'Edit',
+    tool_input: { file_path: 'src/content/strategies/x.md', old_string: oldS, new_string: newS },
+  });
+  const out = run(input);
+  const parsed = JSON.parse(out.stdout);
+  assert.match(parsed.hookSpecificOutput.additionalContext, /dp_id/);
+});
+
+test('MultiEdit: aggregates token diffs across edits', () => {
+  const input = JSON.stringify({
+    tool_name: 'MultiEdit',
+    tool_input: {
+      file_path: 'src/content/strategies/x.md',
+      edits: [
+        { old_string: 'foo', new_string: 'bar' },
+        { old_string: 'N=200', new_string: 'N=800' },
+      ],
+    },
+  });
+  const out = run(input);
+  assert.ok(out.stdout);
+  const parsed = JSON.parse(out.stdout);
+  assert.match(parsed.hookSpecificOutput.additionalContext, /number/);
+});
+
+test('Other tool names ignored', () => {
+  const out = run(JSON.stringify({ tool_name: 'Write', tool_input: {} }));
+  assert.equal(out.exitCode, 0);
+  assert.ok(!out.stdout);
+});
+
+test('Malformed JSON does not crash', () => {
+  const out = run('not json');
+  assert.equal(out.exitCode, 0);
+});
+
+test('diffTokens: no-op returns empty', () => {
+  assert.deepEqual(diffTokens('hello', 'hello'), []);
+});

--- a/.claude/hooks/__tests__/pre-edit-frontmatter-immutable.test.cjs
+++ b/.claude/hooks/__tests__/pre-edit-frontmatter-immutable.test.cjs
@@ -1,0 +1,203 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  run,
+  extractFrontmatter,
+  captureProtectedFields,
+  diffMaps,
+  TARGET_PATH_RE,
+} = require('../pre-edit-frontmatter-immutable.cjs');
+
+test('TARGET_PATH_RE: matches strategies/columns paths', () => {
+  assert.match('src/content/strategies/x.md', TARGET_PATH_RE);
+  assert.match('src/content/columns/y.md', TARGET_PATH_RE);
+  assert.match('/Users/H/edu-evidence/src/content/strategies/z.md', TARGET_PATH_RE);
+});
+
+test('TARGET_PATH_RE: rejects unrelated paths', () => {
+  assert.doesNotMatch('src/components/X.astro', TARGET_PATH_RE);
+  assert.doesNotMatch('docs/decisions/0001.md', TARGET_PATH_RE);
+  assert.doesNotMatch('README.md', TARGET_PATH_RE);
+});
+
+test('extractFrontmatter: extracts YAML block', () => {
+  const md = '---\ntitle: x\nmonthsGained: 5\n---\n\n# body';
+  assert.equal(extractFrontmatter(md), 'title: x\nmonthsGained: 5');
+});
+
+test('extractFrontmatter: returns null when missing', () => {
+  assert.equal(extractFrontmatter('# just body'), null);
+});
+
+test('captureProtectedFields: top-level scalars', () => {
+  const fm = 'title: x\nmonthsGained: 5\nevidenceStrength: 4\ncost: 2\nsourceUrl: https://example.com/a';
+  const m = captureProtectedFields(fm);
+  assert.deepEqual(m.get('monthsGained'), ['5']);
+  assert.deepEqual(m.get('evidenceStrength'), ['4']);
+  assert.deepEqual(m.get('cost'), ['2']);
+  assert.deepEqual(m.get('sourceUrl'), ['https://example.com/a']);
+});
+
+test('captureProtectedFields: nested fields under evidence/methodology', () => {
+  const fm = [
+    'evidence:',
+    '  eef:',
+    '    monthsGained: 3',
+    '    strength: 4',
+    '  japan:',
+    '    monthsGained: 5',
+    '    strength: 3',
+    '  hattie:',
+    '    cohensD: 0.42',
+    'methodology:',
+    '  studies: 12',
+    '  effectSize: "d=0.37"',
+    '  primaryMetaAnalysis:',
+    '    authors: "Nickow et al."',
+    '    year: 2020',
+    '    url: https://doi.org/10.1234/abc',
+  ].join('\n');
+  const m = captureProtectedFields(fm);
+  assert.deepEqual(m.get('monthsGained'), ['3', '5']);
+  assert.deepEqual(m.get('strength'), ['4', '3']);
+  assert.deepEqual(m.get('cohensD'), ['0.42']);
+  assert.deepEqual(m.get('studies'), ['12']);
+  assert.deepEqual(m.get('effectSize'), ['d=0.37']);
+  assert.deepEqual(m.get('authors'), ['Nickow et al.']);
+  assert.deepEqual(m.get('year'), ['2020']);
+  assert.deepEqual(m.get('url'), ['https://doi.org/10.1234/abc']);
+});
+
+test('diffMaps: detects changed monthsGained', () => {
+  const before = new Map([['monthsGained', ['5']]]);
+  const after = new Map([['monthsGained', ['7']]]);
+  const d = diffMaps(before, after);
+  assert.equal(d.length, 1);
+  assert.equal(d[0].key, 'monthsGained');
+  assert.deepEqual(d[0].before, ['5']);
+  assert.deepEqual(d[0].after, ['7']);
+});
+
+test('diffMaps: detects added field', () => {
+  const before = new Map();
+  const after = new Map([['cost', ['3']]]);
+  const d = diffMaps(before, after);
+  assert.equal(d.length, 1);
+  assert.equal(d[0].key, 'cost');
+});
+
+test('Edit on strategy: monthsGained change fires ask', () => {
+  const oldS = '---\ntitle: x\nmonthsGained: 5\n---\n\nbody';
+  const newS = '---\ntitle: x\nmonthsGained: 9\n---\n\nbody';
+  const input = JSON.stringify({
+    tool_name: 'Edit',
+    tool_input: { file_path: 'src/content/strategies/x.md', old_string: oldS, new_string: newS },
+  });
+  const out = run(input);
+  assert.equal(out.exitCode, 0);
+  assert.ok(out.stdout);
+  const parsed = JSON.parse(out.stdout);
+  assert.equal(parsed.hookSpecificOutput.permissionDecision, 'ask');
+  assert.match(parsed.hookSpecificOutput.permissionDecisionReason, /monthsGained/);
+});
+
+test('Edit on strategy: sourceUrl swap fires ask', () => {
+  const oldS = '---\nsourceUrl: https://nier.go.jp/a\ntitle: x\n---\n';
+  const newS = '---\nsourceUrl: https://wikipedia.org/b\ntitle: x\n---\n';
+  const input = JSON.stringify({
+    tool_name: 'Edit',
+    tool_input: { file_path: 'src/content/strategies/x.md', old_string: oldS, new_string: newS },
+  });
+  const out = run(input);
+  assert.equal(out.exitCode, 0);
+  assert.ok(out.stdout);
+  const parsed = JSON.parse(out.stdout);
+  assert.match(parsed.hookSpecificOutput.permissionDecisionReason, /sourceUrl/);
+});
+
+test('Edit on strategy: prose-only change does not fire', () => {
+  const oldS = '---\nmonthsGained: 5\n---\n\n本文の typo。';
+  const newS = '---\nmonthsGained: 5\n---\n\n本文の typo を直した。';
+  const input = JSON.stringify({
+    tool_name: 'Edit',
+    tool_input: { file_path: 'src/content/strategies/x.md', old_string: oldS, new_string: newS },
+  });
+  const out = run(input);
+  assert.equal(out.exitCode, 0);
+  assert.ok(!out.stdout);
+});
+
+test('Edit on strategy: title change does not fire (not protected)', () => {
+  const oldS = '---\ntitle: 古い\nmonthsGained: 5\n---\n';
+  const newS = '---\ntitle: 新しい\nmonthsGained: 5\n---\n';
+  const input = JSON.stringify({
+    tool_name: 'Edit',
+    tool_input: { file_path: 'src/content/strategies/x.md', old_string: oldS, new_string: newS },
+  });
+  const out = run(input);
+  assert.equal(out.exitCode, 0);
+  assert.ok(!out.stdout);
+});
+
+test('Edit on non-content path: skips entirely', () => {
+  const oldS = '---\nmonthsGained: 5\n---\n';
+  const newS = '---\nmonthsGained: 9\n---\n';
+  const input = JSON.stringify({
+    tool_name: 'Edit',
+    tool_input: { file_path: 'docs/decisions/0001.md', old_string: oldS, new_string: newS },
+  });
+  const out = run(input);
+  assert.equal(out.exitCode, 0);
+  assert.ok(!out.stdout);
+});
+
+test('Edit on column: lastVerified is not protected (allowed)', () => {
+  const oldS = '---\ntitle: x\ndate: "2026-04-01"\nlastVerified: "2026-04-01"\n---\n';
+  const newS = '---\ntitle: x\ndate: "2026-04-01"\nlastVerified: "2026-05-04"\n---\n';
+  const input = JSON.stringify({
+    tool_name: 'Edit',
+    tool_input: { file_path: 'src/content/columns/y.md', old_string: oldS, new_string: newS },
+  });
+  const out = run(input);
+  assert.equal(out.exitCode, 0);
+  assert.ok(!out.stdout);
+});
+
+test('MultiEdit: any edit changing protected field fires', () => {
+  const input = JSON.stringify({
+    tool_name: 'MultiEdit',
+    tool_input: {
+      file_path: 'src/content/strategies/x.md',
+      edits: [
+        { old_string: '本文 typo', new_string: '本文 typo 直し' },
+        {
+          old_string: '---\nmonthsGained: 5\n---\n',
+          new_string: '---\nmonthsGained: 7\n---\n',
+        },
+      ],
+    },
+  });
+  const out = run(input);
+  assert.equal(out.exitCode, 0);
+  assert.ok(out.stdout);
+  const parsed = JSON.parse(out.stdout);
+  assert.match(parsed.hookSpecificOutput.permissionDecisionReason, /monthsGained/);
+});
+
+test('Quoted string values: quotes stripped from comparison', () => {
+  const fm1 = captureProtectedFields('authors: "Nickow et al."');
+  const fm2 = captureProtectedFields("authors: 'Nickow et al.'");
+  assert.deepEqual(fm1.get('authors'), fm2.get('authors'));
+});
+
+test('Malformed JSON does not crash', () => {
+  const out = run('not json');
+  assert.equal(out.exitCode, 0);
+});
+
+test('Other tool names ignored', () => {
+  const out = run(JSON.stringify({ tool_name: 'Bash', tool_input: {} }));
+  assert.equal(out.exitCode, 0);
+});

--- a/.claude/hooks/post-edit-roundtrip-spot-check.cjs
+++ b/.claude/hooks/post-edit-roundtrip-spot-check.cjs
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+/**
+ * PostToolUse hook (Edit | MultiEdit) — roundtrip spot check.
+ *
+ * After a Markdown edit in src/content/, surfaces a Claude-only
+ * additionalContext message listing the numeric / URL / DOI / DP-id
+ * tokens that changed. The user does not see this message — it nudges
+ * Claude to confirm sourcing in its next turn.
+ *
+ * Backed by DELEGATE-52 (arxiv 2604.15597): sparse silent corruption
+ * compounds over interactions. A post-edit nudge breaks the silence
+ * before it accumulates.
+ *
+ * Cannot block (PostToolUse exit 2 is ignored), so always exits 0 with
+ * additionalContext payload via stdout JSON.
+ */
+
+'use strict';
+
+const URL_RE = /\bhttps?:\/\/[^\s)>"']+/gi;
+const DOI_RE = /\b10\.\d{4,9}\/[^\s)>"']+/gi;
+const DP_ID_RE = /\bDP\d{2}-\d+\b/gi;
+const EFFECT_SIZE_RE = /\b(?:cohen'?s\s*)?[dgr]\s*=\s*-?\d+\.\d+\b/gi;
+const NUMBER_RE = /\b\d[\d.,]*\d\b/g;
+
+const TARGET_PATH_RE = /(?:^|\/)src\/content\/(strategies|columns)\/[^/]+\.(md|mdx)$/i;
+
+const KINDS = ['number', 'url', 'doi', 'dp_id', 'effect_size'];
+
+function extractTokens(s) {
+  const src = String(s ?? '');
+  const dpIds = src.match(DP_ID_RE) || [];
+  const stripped = src.replace(DP_ID_RE, ' ');
+  return {
+    number: new Set((stripped.match(NUMBER_RE) || []).map(x => x.trim())),
+    url: new Set((src.match(URL_RE) || []).map(x => x.trim())),
+    doi: new Set((src.match(DOI_RE) || []).map(x => x.trim())),
+    dp_id: new Set(dpIds.map(x => x.trim())),
+    effect_size: new Set((src.match(EFFECT_SIZE_RE) || []).map(x => x.trim().toLowerCase())),
+  };
+}
+
+function diffTokens(beforeS, afterS) {
+  const before = extractTokens(beforeS);
+  const after = extractTokens(afterS);
+  const result = [];
+  for (const k of KINDS) {
+    const added = [...after[k]].filter(x => !before[k].has(x));
+    const removed = [...before[k]].filter(x => !after[k].has(x));
+    if (added.length || removed.length) {
+      result.push({ kind: k, added, removed });
+    }
+  }
+  return result;
+}
+
+function evaluatePayload(toolName, toolInput) {
+  if (toolName === 'Edit') {
+    return diffTokens(toolInput?.old_string ?? '', toolInput?.new_string ?? '');
+  }
+  if (toolName === 'MultiEdit') {
+    const edits = Array.isArray(toolInput?.edits) ? toolInput.edits : [];
+    const merged = [];
+    for (const e of edits) {
+      merged.push(...diffTokens(e?.old_string ?? '', e?.new_string ?? ''));
+    }
+    return merged;
+  }
+  return [];
+}
+
+function fmtList(items) {
+  if (!items.length) return '∅';
+  const head = items.slice(0, 4).join(', ');
+  const tail = items.length > 4 ? ` (+${items.length - 4} more)` : '';
+  return head + tail;
+}
+
+function buildContext(diffs, filePath) {
+  const lines = [
+    `[roundtrip] Tracked tokens changed in ${filePath}:`,
+  ];
+  for (const d of diffs) {
+    if (d.added.length) lines.push(`  + ${d.kind}: ${fmtList(d.added)}`);
+    if (d.removed.length) lines.push(`  - ${d.kind}: ${fmtList(d.removed)}`);
+  }
+  lines.push('');
+  lines.push('Before continuing, briefly state which primary research source supports');
+  lines.push('each numeric or URL change. If unsure, ask the user before further edits.');
+  return lines.join('\n');
+}
+
+function run(inputOrRaw, _options = {}) {
+  let input;
+  try {
+    input = typeof inputOrRaw === 'string'
+      ? (inputOrRaw.trim() ? JSON.parse(inputOrRaw) : {})
+      : (inputOrRaw || {});
+  } catch {
+    return { exitCode: 0 };
+  }
+
+  const toolName = String(input?.tool_name || '');
+  if (!['Edit', 'MultiEdit'].includes(toolName)) return { exitCode: 0 };
+
+  const toolInput = input?.tool_input || {};
+  const filePath = String(toolInput?.file_path || '');
+  if (!TARGET_PATH_RE.test(filePath)) return { exitCode: 0 };
+
+  const diffs = evaluatePayload(toolName, toolInput);
+  if (!diffs.length) return { exitCode: 0 };
+
+  const additionalContext = buildContext(diffs, filePath);
+  const stdout = JSON.stringify({
+    hookSpecificOutput: {
+      hookEventName: 'PostToolUse',
+      additionalContext,
+    },
+  });
+
+  // Intentional: stderr empty so the user is not spammed.
+  return { exitCode: 0, stdout };
+}
+
+module.exports = { run, extractTokens, diffTokens, TARGET_PATH_RE };
+
+if (require.main === module) {
+  let data = '';
+  process.stdin.setEncoding('utf8');
+  process.stdin.on('data', c => { data += c; });
+  process.stdin.on('end', () => {
+    const out = run(data);
+    if (out.stdout) process.stdout.write(out.stdout);
+    process.exit(Number.isInteger(out.exitCode) ? out.exitCode : 0);
+  });
+}

--- a/.claude/hooks/pre-edit-frontmatter-immutable.cjs
+++ b/.claude/hooks/pre-edit-frontmatter-immutable.cjs
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+/**
+ * PreToolUse hook (Edit | MultiEdit) — frontmatter immutable guard.
+ *
+ * Blocks silent edits to high-stakes frontmatter fields in
+ * src/content/strategies/*.md and src/content/columns/*.md.
+ *
+ * Protected fields (any value change → permissionDecision="ask"):
+ *   - sourceUrl              (Rule 14: primary research only)
+ *   - monthsGained           (effect-size months)
+ *   - evidenceStrength
+ *   - cost
+ *   - cohensD                (Hattie's d, under evidence.hattie)
+ *   - strength               (under evidence.{eef,japan})
+ *   - studies                (methodology.studies)
+ *   - sampleSize             (methodology.sampleSize)
+ *   - effectSize             (methodology.effectSize)
+ *   - year                   (methodology.primaryMetaAnalysis.year)
+ *   - authors                (methodology.primaryMetaAnalysis.authors)
+ *   - url                    (methodology.primaryMetaAnalysis.url)
+ *
+ * Backed by DELEGATE-52 (arxiv 2604.15597) — sparse silent corruption
+ * (Claude 4.6 Opus 26.9% rate) most often targets numeric/URL frontmatter.
+ */
+
+'use strict';
+
+const PROTECTED_KEYS = [
+  'sourceUrl',
+  'monthsGained',
+  'evidenceStrength',
+  'cost',
+  'cohensD',
+  'strength',
+  'studies',
+  'sampleSize',
+  'effectSize',
+  'year',
+  'authors',
+  'url',
+];
+
+const FRONTMATTER_RE = /^---\s*\n([\s\S]*?)\n---\s*(?:\n|$)/;
+const TARGET_PATH_RE = /(?:^|\/)src\/content\/(strategies|columns)\/[^/]+\.(md|mdx)$/i;
+
+function extractFrontmatter(s) {
+  if (!s) return null;
+  const m = s.match(FRONTMATTER_RE);
+  return m ? m[1] : null;
+}
+
+function captureProtectedFields(fm) {
+  if (!fm) return new Map();
+  const map = new Map();
+  for (const key of PROTECTED_KEYS) {
+    const re = new RegExp(`^\\s*-?\\s*${key}:\\s*(.+?)\\s*$`, 'gm');
+    const values = [...fm.matchAll(re)].map(m => m[1].replace(/^["']|["']$/g, ''));
+    if (values.length) map.set(key, values);
+  }
+  return map;
+}
+
+function diffMaps(beforeM, afterM) {
+  const allKeys = new Set([...beforeM.keys(), ...afterM.keys()]);
+  const diffs = [];
+  for (const key of allKeys) {
+    const before = beforeM.get(key) ?? [];
+    const after = afterM.get(key) ?? [];
+    const beforeStr = JSON.stringify(before);
+    const afterStr = JSON.stringify(after);
+    if (beforeStr !== afterStr) {
+      diffs.push({ key, before, after });
+    }
+  }
+  return diffs;
+}
+
+function evaluatePair(oldStr, newStr) {
+  const beforeFm = extractFrontmatter(oldStr);
+  const afterFm = extractFrontmatter(newStr);
+  if (!beforeFm && !afterFm) return [];
+  return diffMaps(captureProtectedFields(beforeFm), captureProtectedFields(afterFm));
+}
+
+function evaluatePayload(toolName, toolInput) {
+  if (toolName === 'Edit') {
+    return evaluatePair(toolInput?.old_string ?? '', toolInput?.new_string ?? '');
+  }
+  if (toolName === 'MultiEdit') {
+    const edits = Array.isArray(toolInput?.edits) ? toolInput.edits : [];
+    const merged = [];
+    for (const e of edits) {
+      merged.push(...evaluatePair(e?.old_string ?? '', e?.new_string ?? ''));
+    }
+    return merged;
+  }
+  return [];
+}
+
+function fmtVal(arr) {
+  if (!arr.length) return '∅';
+  return arr.map(v => (v.length > 60 ? v.slice(0, 57) + '...' : v)).join(' | ');
+}
+
+function buildReason(diffs, filePath) {
+  const lines = [`[frontmatter-immutable] Protected fields changed in ${filePath}:`];
+  for (const d of diffs) {
+    lines.push(`  ${d.key}:`);
+    lines.push(`    before: ${fmtVal(d.before)}`);
+    lines.push(`    after:  ${fmtVal(d.after)}`);
+  }
+  lines.push('');
+  lines.push('Frontmatter values back claims that readers act on (effect sizes,');
+  lines.push('strengths, primary research URLs). Confirm a primary research source');
+  lines.push('(Rule 14: sourceUrl is primary research only) before applying.');
+  return lines.join('\n');
+}
+
+function run(inputOrRaw, _options = {}) {
+  let input;
+  try {
+    input = typeof inputOrRaw === 'string'
+      ? (inputOrRaw.trim() ? JSON.parse(inputOrRaw) : {})
+      : (inputOrRaw || {});
+  } catch {
+    return { exitCode: 0 };
+  }
+
+  const toolName = String(input?.tool_name || '');
+  if (!['Edit', 'MultiEdit'].includes(toolName)) return { exitCode: 0 };
+
+  const toolInput = input?.tool_input || {};
+  const filePath = String(toolInput?.file_path || '');
+  if (!TARGET_PATH_RE.test(filePath)) return { exitCode: 0 };
+
+  const diffs = evaluatePayload(toolName, toolInput);
+  if (!diffs.length) return { exitCode: 0 };
+
+  const reason = buildReason(diffs, filePath);
+  const stdout = JSON.stringify({
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
+      permissionDecision: 'ask',
+      permissionDecisionReason: reason,
+    },
+  });
+
+  return { exitCode: 0, stdout, stderr: reason };
+}
+
+module.exports = {
+  run,
+  extractFrontmatter,
+  captureProtectedFields,
+  diffMaps,
+  PROTECTED_KEYS,
+  TARGET_PATH_RE,
+};
+
+if (require.main === module) {
+  let data = '';
+  process.stdin.setEncoding('utf8');
+  process.stdin.on('data', c => { data += c; });
+  process.stdin.on('end', () => {
+    const out = run(data);
+    if (out.stdout) process.stdout.write(out.stdout);
+    if (out.stderr) process.stderr.write(out.stderr.endsWith('\n') ? out.stderr : out.stderr + '\n');
+    process.exit(Number.isInteger(out.exitCode) ? out.exitCode : 0);
+  });
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,6 +10,28 @@
             "command": ".claude/hooks/branch-guard.sh"
           }
         ]
+      },
+      {
+        "matcher": "Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .claude/hooks/pre-edit-frontmatter-immutable.cjs",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .claude/hooks/post-edit-roundtrip-spot-check.cjs",
+            "timeout": 5
+          }
+        ]
       }
     ],
     "PreCompact": [


### PR DESCRIPTION
## Summary

DELEGATE-52 (arxiv 2604.15597 / 2026, Microsoft) と Lost in Multi-Turn (arxiv 2505.06120 / ICLR 2026 Best Paper) を踏まえ、Claude Code 経由の編集における sparse but severe な破損を防ぐ project-local hook を追加する。

- フロンティアモデル (Claude 4.6 Opus) でも文書破損率は **26.9%**、その大半が「数値の桁ずれ・URL 改変・1 文字構文崩し」のような少数だが致命的なパターン
- マルチターン会話では **39% の相対性能低下** (aptitude -16% / unreliability +112%) が起き、LLM は「迷子」から自力 recover しない

## Hooks added

- **`pre-edit-frontmatter-immutable.cjs`** (PreToolUse / Edit | MultiEdit)
  - 戦略・コラムの保護 frontmatter フィールド (`sourceUrl` / `monthsGained` / `evidenceStrength` / `cost` / `evidence.{eef,japan}.{monthsGained,strength}` / `evidence.hattie.cohensD` / `methodology.{studies,sampleSize,effectSize,primaryMetaAnalysis.{authors,year,url}}`) の変更を検出すると `permissionDecision="ask"` で user 承認を要求
  - Edit chunk が `---` を含まない単一行編集でも検出可能 (whole-chunk fallback + `^\s*-?\s*key:` でリスト要素対応)
- **`post-edit-roundtrip-spot-check.cjs`** (PostToolUse / Edit | MultiEdit)
  - `src/content/{strategies,columns}/*.md` の編集後に数値・URL・DOI・DP-id・効果量の集合差分を計算し、`additionalContext` 経由で **Claude にだけ** 「出典は?」と問い直す
  - user の画面には出力しない (PostToolUse は block 不可なので nudge 専用)

## Behavior

- 既存の `branch-guard.sh` と並列で動作 (相互独立)
- 本文プローズの修正・`title` / `summary` / `tags` 変更には反応しない (false positive 抑制)
- code path (`src/lib/*.ts` 等) は対象外
- 出典情報を伴わない数値・URL 変更を機械的に拾える

## Tests

- `node --test .claude/hooks/__tests__/pre-edit-frontmatter-immutable.test.cjs` → 18/18 pass
- `node --test .claude/hooks/__tests__/post-edit-roundtrip-spot-check.test.cjs` → 14/14 pass
- 合計 32 ケース全 green

## Test plan

- [ ] `node --test .claude/hooks/__tests__/*.test.cjs` を実行して 32/32 pass を確認
- [ ] `src/content/strategies/*.md` の `monthsGained` を 1 つ書き換えて、ask 通知が出ることを実体験で確認
- [ ] `src/content/columns/*.md` の本文プローズだけ書き換えて、誤通知が出ないことを確認
- [ ] 既存 `branch-guard.sh` が引き続き main 編集をブロックすることを確認