### PR TITLE
chore(security): align security.txt contact with site contact email

### DIFF
--- a/public/.well-known/security.txt
+++ b/public/.well-known/security.txt
@@ -1,4 +1,4 @@
-Contact: mailto:harnet0119@gmail.com
+Contact: mailto:info@edu-evidence.org
 Expires: 2027-04-17T00:00:00.000Z
 Preferred-Languages: ja, en
 Canonical: https://edu-evidence.org/.well-known/security.txt


### PR DESCRIPTION
## 概要

`public/.well-known/security.txt` の `Contact` を個人 Gmail (`harnet0119@gmail.com`) からサイト内表示の問い合わせ窓口 `info@edu-evidence.org` に変更します。

## 背景

- about / faq / support / voices / changelog ページは `info@edu-evidence.org` を読者向け窓口として案内している
- これまで security.txt だけが個人 Gmail を直接さらしており、脆弱性報告者から見ると窓口が二重で分かりにくい状態だった
- Cloudflare Email Routing で `info@edu-evidence.org` は運営アドレスへ転送されるため、到達性は同等
- Cloudflare Security Insights (2026-05-04 スキャン) で本ファイルが「未構成」と判定されたが、これは Cloudflare 側の再評価未実施。本 PR マージ後にダッシュボードで再評価を実行する

## 変更内容

| 項目 | 変更前 | 変更後 |
|---|---|---|
| `Contact` | `mailto:harnet0119@gmail.com` | `mailto:info@edu-evidence.org` |
| `Expires` / `Preferred-Languages` / `Canonical` | （変更なし） | （変更なし） |

## 検証

- [x] RFC 9116 必須フィールド (Contact / Expires) を維持
- [x] Canonical URL は本番ドメイン `https://edu-evidence.org/.well-known/security.txt` と一致
- [ ] マージ後に本番反映を curl で確認 (`curl -sI https://edu-evidence.org/.well-known/security.txt`)
- [ ] Cloudflare ダッシュボード → Security Center → Insights で当該指摘を再評価