### PR TITLE
chore(strategies): roll lastVerified for reading-comprehension after EEF Phase 1.5 cross-check

### DIFF
--- a/src/content/strategies/reading-comprehension.md
+++ b/src/content/strategies/reading-comprehension.md
@@ -15,7 +15,7 @@ evidence:
     monthsGained: 7
     strength: 5
     note: "EEF Toolkit で +7ヶ月・エビデンス★5(最高ランク)。言語理解と意味構築を明示的に教える手法。『予測・質問・要約・関連付け』などの戦略を段階的に指導することが効果的。"
-lastVerified: "2026-04-14"
+lastVerified: "2026-05-06"
 methodology:
   studies: 60
   sampleSize: "小中学生を中心とした複数メタ分析"


### PR DESCRIPTION
## 概要

Reading Comprehension 戦略の `lastVerified` を `2026-04-14` → `2026-05-06` に更新。値(monthsGained: 7 / evidenceStrength: 5 / cost: 1)は据え置き。

## 背景

EEF Toolkit は 2025-05-21 に Living Systematic Review 化され、その後ローリング更新が継続している:

- **Phase 1 (2025-05-21、10 strand)**: edu-evidence 側は PR #164 で対応済
- **Phase 1.5 (2025-10-30 二次報道)**: 9 strand + 40 新規研究、Reading Comprehension が +7ヶ月へ更新と Bromley Education Matters / 他二次情報源で確認
- **Phase 2 (2026-01-13)**: Phonics 更新の可能性、ただし WebSearch 再現性検証で +5 / +6 が分裂

Reading Comprehension は edu-evidence 側で既に +7 設定済のため、Phase 1.5 の値変更には実質的に追従済。本 PR では `lastVerified` のみ rolling 更新する。

## スコープに含めなかったもの

- **Phase 1.5 の他 8 strand**: 名前が EEF 公式(Cloudflare 403)でも二次情報源でも未公開のため特定不可
- **Phonics +5→+6**: 同一 strand について 3 回 WebSearch を回したところ、2/3 が +5・1/3 が +6 と再現性なし。Search 2 では「the EEF's Toolkit maintains this +5 months impact figure as of January 2026」と明記されており、+5 据え置きが妥当と判断
- 残 17 件の `source: eef` 戦略: 個別更新の根拠なし、次回 EEF アナウンス待ち

## 検証

- `npm run check`: 0 errors / 0 warnings
- `npm run check:consistency`: 不一致なし
- `npm run check:stale`: 全 73 件 365 日以内
- `npm run check:text`: 0 errors

## 次セッションへの宿題

EEF / Hattie / 日本研究の整合性を定期的に取るため、`docs/source-sync-protocol.md` を新設して以下を仕組み化する予定:

- EEF Toolkit 整合性チェック(月次、`source: eef` 28 件をローテーション)
- Hattie Visible Learning 整合性チェック(年次、`source: hattie` 1 件 + `evidence.hattie` 併記 20 件)
- WebSearch 3 回再現性検証ロジック(本 PR で発見した hallucination パターンの恒久対策)