### PR TITLE
content: add Technical Appendix (methodology) to blocked-vs-interleaved strategy

### DIFF
--- a/src/content/strategies/blocked-vs-interleaved.md
+++ b/src/content/strategies/blocked-vs-interleaved.md
@@ -15,7 +15,17 @@ evidence:
   hattie:
     cohensD: -0.10
     note: "ブロック練習は短期(練習直後)では正答率が高く『できている感覚』を生むが、遅延テストでは交互練習群に劣る(Rohrer & Taylor 2007)。Dunlosky et al.(2013)はブロック練習を『低い有用性』、交互練習を『中〜高い有用性』と評価。"
-lastVerified: "2026-04-14"
+lastVerified: "2026-05-11"
+methodology:
+  studies: 59
+  sampleSize: "k=238 効果量、158 サンプル(就学前〜成人、絵画・数学・単語など素材横断)"
+  effectSize: "全体で交互練習 Hedges' g = 0.42。材料別: 絵画 +0.67 / 数学 +0.34 / 単語 -0.39(単語暗記のみブロック練習が有利)"
+  primaryMetaAnalysis:
+    authors: "Brunmair & Richter"
+    year: 2019
+    title: "Similarity matters: A meta-analysis of interleaved learning and its moderators"
+    url: "https://doi.org/10.1037/bul0000209"
+  limitations: "効果は学習材料の性質に強く依存する。カテゴリ間が類似していてカテゴリ内が多様な複雑材料(算数の問題タイプ判別など)で効果が大きく、単純な単語暗記ではブロック練習が有利になる。習得初期はブロック練習で基本を作り、定着段階で交互練習に切り替えるのが現実的。"
 culturalContext: |
   日本の算数ドリル・漢字練習帳は典型的なブロック練習型で、**見かけの成績(練習時の正答率)は上がるが長期定着は劣る**。保護者や管理職に『練習中の正答率が下がっても問題ない』と説明するには、**望ましい難しさ(desirable difficulty)** の概念共有が必要。
 ---

--- a/src/pages/changelog.astro
+++ b/src/pages/changelog.astro
@@ -3,6 +3,15 @@ import Layout from "../layouts/Layout.astro";
 
 const entries = [
   {
+    date: "2026-05-11",
+    items: [
+      {
+        type: "add",
+        text: "「ブロック学習の落とし穴」に Technical Appendix を追加し、メタ分析 (Brunmair & Richter 2019、59 研究) と材料別の効果差 (絵画 / 数学 / 単語) を確認できるようにしました",
+      },
+    ],
+  },
+  {
     date: "2026-05-07",
     items: [
       {


### PR DESCRIPTION
## 変更内容

「ブロック学習の落とし穴 (blocked-vs-interleaved)」戦略の frontmatter に Technical Appendix (`methodology`) を追加した。残り 47 戦略 (★3 以下) に段階追加する取り組みの第 1 弾。

## 追加した一次出典

**Brunmair, M. & Richter, T. (2019).** "Similarity matters: A meta-analysis of interleaved learning and its moderators." *Psychological Bulletin*, 145(11), 1029–1052. DOI: [10.1037/bul0000209](https://doi.org/10.1037/bul0000209)

- 59 研究 / 158 サンプル / 238 効果量
- 全体: Hedges' g = 0.42(中程度の効果)
- 材料別: 絵画 +0.67 / 数学 +0.34 / 単語 -0.39(単語暗記のみブロック練習が有利)
- モデレータ: カテゴリ間類似性 + カテゴリ内多様性 + 複雑性

## 変更ファイル

- `src/content/strategies/blocked-vs-interleaved.md` — `methodology` ブロック追加、`lastVerified` を 2026-05-11 に更新
- `src/pages/changelog.astro` — 2026-05-11 エントリ 1 行追加(ユーザー価値ベース、rule 8b)

本文 (markdown body) / `evidence` セクション / `culturalContext` は変更なし。研究内容と既存記述は整合しており、Technical Appendix 追記のみで完結する。

## 検証

- \`npm run check\`: 0 errors / 0 warnings / 82 hints(従来維持)
- \`npm run check:consistency\`: 不一致 0
- \`npm run check:text\`: pass
- \`npm run build\`: 252 ページ生成成功、Pagefind 7468 words(+9 words が methodology 追加分)
- \`dist/strategies/blocked-vs-interleaved/index.html\` で \`Brunmair & Richter (2019)\` / \`Hedges' g = 0.42\` 表示確認済

## 注記

95% CI は WebSearch 結果に明示されておらず、原論文 PDF を読まないと確定できないため `effectSize` 文字列には CI を含めていない(推測禁止の方針)。CI を追加したい場合は原論文を別途突合する PR で対応する。