### PR TITLE
content(strategies): reflect UCL Student Grouping Study 2026 in setting-streaming

### DIFF
--- a/src/content/strategies/setting-streaming.md
+++ b/src/content/strategies/setting-streaming.md
@@ -15,8 +15,18 @@ evidence:
   eef:
     monthsGained: 1
     strength: 3
-    note: "EEF Toolkit で +1ヶ月・エビデンス★3。全体平均では小さな正の効果だが、**下位グループの子どもに対しては負の効果**(自己肯定感低下・ラベリング・期待の低下)が報告される。上位層には若干の正、下位層には明確な負で、相殺されて全体では+1。Francis et al.(2017)の英国の縦断研究でも同様の不均衡が確認されている。"
-lastVerified: "2026-04-14"
+    note: "EEF Toolkit で +1ヶ月・エビデンス★3。**学力進捗** は全体平均で setting がやや低く、事前学力上位の児童で約 2 ヶ月遅れる一方、事前学力下位の児童は setting/mixed で同等(setting は学力面では害なし、利益も乏しい)。**自己肯定感** は混合校が有利で、特に事前学力下位の児童で moderate negative effect が観察される(UCL Student Grouping Study, Taylor & Hodgen 2026)。Francis et al.(2017)の英国縦断研究でも類似の不均衡が確認されている。"
+lastVerified: "2026-05-11"
+methodology:
+  studies: 1
+  sampleSize: "97 校 / Year 7-8 数学(11-13 歳)"
+  effectSize: "学力進捗: 全体 -1 ヶ月(混合 vs setting)、事前学力上位の児童 -2 ヶ月、事前学力下位の児童は両群同等。自己肯定感: 全体 small / FSM 児童 small / 事前学力下位の児童 moderate negative(いずれも混合校が高い)"
+  primaryMetaAnalysis:
+    authors: "Taylor & Hodgen"
+    year: 2026
+    title: "The Student Grouping Study: Evaluation Report"
+    url: "https://discovery.ucl.ac.uk/id/eprint/10224627/"
+  limitations: "英国 Year 7-8(中学校相当)数学の準実験的(quasi-experimental)マッチング比較で、無作為割付ではない。日本の小学校算数とは校種・教科の文脈が異なるため、自己肯定感への効果方向は参考に留め、学力進捗の小ささは Steenbergen-Hu et al. (2016) のメタ分析と整合的に受け取れる。"
 culturalContext: |
   **日本の算数で広く実施される『習熟度別少人数指導』は EEF の setting-streaming に近い** 側面を持ち、効果が限定的であることを認識する必要がある。下位グループに固定される子どもの自己肯定感低下という負の効果は日本でも報告されている(松尾 2013 等)。EEF は **small-group-tuition(+4)** の方を推奨しており、**固定的な習熟度別編成ではなく、一時的・targeted・流動的な少人数指導**が効果的。日本の現場でグループ編成を検討する際の重要な論点。
 ---
@@ -29,8 +39,8 @@ culturalContext: |
 
 「レベルに合わせれば効率的に学べる」という直感に反して、効果が小さい理由は:
 
-- 上位グループはやや伸びるが、下位グループは伸びにくい。**全体として見ると効果が相殺される**
-- 下位グループに配置された子の自己肯定感が低下し、学習意欲が下がる
+- **学力進捗** では上位群はやや伸びるが、下位群は setting と混合でほぼ差がない。全体としても +1 ヶ月と小さい
+- **自己肯定感** が混合校に比べて下がりやすく、特に下位グループに配置された子で中程度の負の影響が報告される(UCL Student Grouping Study, Taylor & Hodgen 2026)
 - グループが固定化されると、下位から上位への移動がほとんど起きない(ラベリング効果)
 - 教師の期待が無意識にグループによって変わってしまう
 
@@ -46,20 +56,23 @@ culturalContext: |
 
 ## 研究からわかっていること
 
-- メタ分析では効果量+1ヶ月。30項目中で最も効果が小さい部類です
-- 上位の子には正の効果、下位の子には負の効果が出る傾向(格差が拡大する方向)
+- メタ分析(Steenbergen-Hu et al. 2016)では学力効果量 +1 ヶ月。30 項目中で最も効果が小さい部類です
+- **学力進捗** は上位児童にやや正、下位児童は setting と混合でほぼ同等(格差は『下位が下がる』ではなく『上位だけが乗る』形で広がる)
+- **自己肯定感** は混合校が有利で、UCL Student Grouping Study(Taylor & Hodgen 2026)では特に事前学力下位の児童で moderate negative の差が観察された
 - 学級内の一時的なグループ分けは、学級間の固定的な分けよりやや効果が大きい
 - 効果は教師の指導力と、グループの流動性に大きく依存します
 
 ## 注意したいこと
 
 - 「習熟度別にすれば学力が上がる」という前提は研究と整合しません
-- 特に下位グループの子への影響(自己肯定感・学習意欲)に細心の注意が必要です
+- **学力進捗** の格差は「下位が下がる」のではなく「上位だけが乗りやすい」形。下位の子に学力面の害はありませんが、メリットも乏しいことに注意が必要です
+- **自己肯定感** への負の影響(混合校に比べた事前学力下位の児童の中程度の負効果)が、固定的な習熟度別を選ぶ最大のコストです
 - 日本の算数で広く実施されている実態を踏まえ、「やめるべき」ではなく「やり方を改善すべき」と捉えるのが現実的です
 
 ## 主な参考研究
 
 - Steenbergen-Hu, S., Makel, M. C., & Olszewski-Kubilius, P. (2016). [What one hundred years of research says about the effects of ability grouping and acceleration on K-12 students' academic achievement](https://doi.org/10.3102/0034654316675417). *Review of Educational Research*, 86(4), 849–899. — 100年分の研究を統合したメタ分析。能力別グループ編成の効果は全体的に小さいことを確認。
+- Taylor, B., & Hodgen, J. (2026). [The Student Grouping Study: Evaluation Report](https://discovery.ucl.ac.uk/id/eprint/10224627/). UCL Institute of Education / Education Endowment Foundation. — 英国 97 校・Year 7-8 数学の準実験的評価(2019-2025)。学力進捗は混合がわずかに有利だが下位児童は両群同等、自己肯定感は混合校が有利で特に事前学力下位の児童で moderate negative。
 - EEF (2021). Setting and streaming: Evidence review. — 効果量+1ヶ月。上位には正、下位には負の効果で相殺される構造を指摘。
 - Ireson, J., & Hallam, S. (2001). *Ability grouping in education*. Paul Chapman Publishing. — 能力別グループ編成の教育社会学的分析。固定化のリスクを詳述。
 

--- a/src/content/strategies/setting-streaming.md
+++ b/src/content/strategies/setting-streaming.md
@@ -15,12 +15,12 @@ evidence:
   eef:
     monthsGained: 1
     strength: 3
-    note: "EEF Toolkit で +1ヶ月・エビデンス★3。**学力進捗** は全体平均で setting がやや低く、事前学力上位の児童で約 2 ヶ月遅れる一方、事前学力下位の児童は setting/mixed で同等(setting は学力面では害なし、利益も乏しい)。**自己肯定感** は混合校が有利で、特に事前学力下位の児童で moderate negative effect が観察される(UCL Student Grouping Study, Taylor & Hodgen 2026)。Francis et al.(2017)の英国縦断研究でも類似の不均衡が確認されている。"
+    note: "EEF Toolkit で +1ヶ月・エビデンス★3。**学力進捗** は全体平均で習熟度別編成がやや低く、事前学力上位の児童で約 2 ヶ月遅れる一方、事前学力下位の児童は習熟度別と混合で同等(習熟度別編成は学力面では害なし、利益も乏しい)。**自己肯定感** は混合校が有利で、特に事前学力下位の児童で中程度の負効果が観察される(UCL Student Grouping Study, Taylor & Hodgen 2026)。Francis et al.(2017)の英国縦断研究でも類似の不均衡が確認されている。"
 lastVerified: "2026-05-11"
 methodology:
   studies: 1
   sampleSize: "97 校 / Year 7-8 数学(11-13 歳)"
-  effectSize: "学力進捗: 全体 -1 ヶ月(混合 vs setting)、事前学力上位の児童 -2 ヶ月、事前学力下位の児童は両群同等。自己肯定感: 全体 small / FSM 児童 small / 事前学力下位の児童 moderate negative(いずれも混合校が高い)"
+  effectSize: "学力進捗: 全体 -1 ヶ月(混合 vs 習熟度別編成)、事前学力上位の児童 -2 ヶ月、事前学力下位の児童は両群同等。自己肯定感: 全体 small / FSM 児童 small / 事前学力下位の児童 中程度の負効果(いずれも混合校が高い)"
   primaryMetaAnalysis:
     authors: "Taylor & Hodgen"
     year: 2026
@@ -28,7 +28,7 @@ methodology:
     url: "https://discovery.ucl.ac.uk/id/eprint/10224627/"
   limitations: "英国 Year 7-8(中学校相当)数学の準実験的(quasi-experimental)マッチング比較で、無作為割付ではない。日本の小学校算数とは校種・教科の文脈が異なるため、自己肯定感への効果方向は参考に留め、学力進捗の小ささは Steenbergen-Hu et al. (2016) のメタ分析と整合的に受け取れる。"
 culturalContext: |
-  **日本の算数で広く実施される『習熟度別少人数指導』は EEF の setting-streaming に近い** 側面を持ち、効果が限定的であることを認識する必要がある。下位グループに固定される子どもの自己肯定感低下という負の効果は日本でも報告されている(松尾 2013 等)。EEF は **small-group-tuition(+4)** の方を推奨しており、**固定的な習熟度別編成ではなく、一時的・targeted・流動的な少人数指導**が効果的。日本の現場でグループ編成を検討する際の重要な論点。
+  **日本の算数で広く実施される『習熟度別少人数指導』は EEF の習熟度別編成カテゴリ(setting-streaming)に近い** 側面を持ち、効果が限定的であることを認識する必要がある。下位グループに固定される子どもの自己肯定感低下という負の効果は日本でも報告されている(松尾 2013 等)。EEF は **small-group-tuition(+4)** の方を推奨しており、**固定的な習熟度別編成ではなく、一時的・対象を絞った・流動的な少人数指導**が効果的。日本の現場でグループ編成を検討する際の重要な論点。
 ---
 
 ## 一言でいうと
@@ -39,7 +39,7 @@ culturalContext: |
 
 「レベルに合わせれば効率的に学べる」という直感に反して、効果が小さい理由は:
 
-- **学力進捗** では上位群はやや伸びるが、下位群は setting と混合でほぼ差がない。全体としても +1 ヶ月と小さい
+- **学力進捗** では上位群はやや伸びるが、下位群は習熟度別編成と混合でほぼ差がない。全体としても +1 ヶ月と小さい
 - **自己肯定感** が混合校に比べて下がりやすく、特に下位グループに配置された子で中程度の負の影響が報告される(UCL Student Grouping Study, Taylor & Hodgen 2026)
 - グループが固定化されると、下位から上位への移動がほとんど起きない(ラベリング効果)
 - 教師の期待が無意識にグループによって変わってしまう
@@ -57,8 +57,8 @@ culturalContext: |
 ## 研究からわかっていること
 
 - メタ分析(Steenbergen-Hu et al. 2016)では学力効果量 +1 ヶ月。30 項目中で最も効果が小さい部類です
-- **学力進捗** は上位児童にやや正、下位児童は setting と混合でほぼ同等(格差は『下位が下がる』ではなく『上位だけが乗る』形で広がる)
-- **自己肯定感** は混合校が有利で、UCL Student Grouping Study(Taylor & Hodgen 2026)では特に事前学力下位の児童で moderate negative の差が観察された
+- **学力進捗** は上位児童にやや正、下位児童は習熟度別編成と混合でほぼ同等(格差は『下位が下がる』ではなく『上位だけが乗る』形で広がる)
+- **自己肯定感** は混合校が有利で、UCL Student Grouping Study(Taylor & Hodgen 2026)では特に事前学力下位の児童で中程度の負効果が観察された
 - 学級内の一時的なグループ分けは、学級間の固定的な分けよりやや効果が大きい
 - 効果は教師の指導力と、グループの流動性に大きく依存します
 
@@ -72,7 +72,7 @@ culturalContext: |
 ## 主な参考研究
 
 - Steenbergen-Hu, S., Makel, M. C., & Olszewski-Kubilius, P. (2016). [What one hundred years of research says about the effects of ability grouping and acceleration on K-12 students' academic achievement](https://doi.org/10.3102/0034654316675417). *Review of Educational Research*, 86(4), 849–899. — 100年分の研究を統合したメタ分析。能力別グループ編成の効果は全体的に小さいことを確認。
-- Taylor, B., & Hodgen, J. (2026). [The Student Grouping Study: Evaluation Report](https://discovery.ucl.ac.uk/id/eprint/10224627/). UCL Institute of Education / Education Endowment Foundation. — 英国 97 校・Year 7-8 数学の準実験的評価(2019-2025)。学力進捗は混合がわずかに有利だが下位児童は両群同等、自己肯定感は混合校が有利で特に事前学力下位の児童で moderate negative。
+- Taylor, B., & Hodgen, J. (2026). [The Student Grouping Study: Evaluation Report](https://discovery.ucl.ac.uk/id/eprint/10224627/). UCL Institute of Education / Education Endowment Foundation. — 英国 97 校・Year 7-8 数学の準実験的評価(2019-2025)。学力進捗は混合がわずかに有利だが下位児童は両群同等、自己肯定感は混合校が有利で特に事前学力下位の児童で中程度の負効果。
 - EEF (2021). Setting and streaming: Evidence review. — 効果量+1ヶ月。上位には正、下位には負の効果で相殺される構造を指摘。
 - Ireson, J., & Hallam, S. (2001). *Ability grouping in education*. Paul Chapman Publishing. — 能力別グループ編成の教育社会学的分析。固定化のリスクを詳述。
 

--- a/src/pages/changelog.astro
+++ b/src/pages/changelog.astro
@@ -9,6 +9,10 @@ const entries = [
         type: "add",
         text: "「ブロック学習の落とし穴」に Technical Appendix を追加し、メタ分析 (Brunmair & Richter 2019、59 研究) と材料別の効果差 (絵画 / 数学 / 単語) を確認できるようにしました",
       },
+      {
+        type: "update",
+        text: "「習熟度別グループ編成」を更新。学力進捗(下位児童は混合と同等)と自己肯定感(混合校が有利、特に事前学力下位の児童で中程度の負効果)を分けて整理し、UCL Student Grouping Study (Taylor & Hodgen 2026) を一次研究として追加",
+      },
     ],
   },
   {


### PR DESCRIPTION
## 概要

`src/content/strategies/setting-streaming.md` を UCL Student Grouping Study (Taylor & Hodgen 2026-04-29) の結果に対応させ、「学力進捗」と「自己肯定感」を分離した記述に整理する。

## 主な変更

- `frontmatter.lastVerified`: 2026-04-14 → 2026-05-11
- `frontmatter.evidence.eef.note`: 学力進捗と自己肯定感を分離した版へ書き換え
- `frontmatter.methodology` を新規追加
  - `primaryMetaAnalysis`: Taylor & Hodgen (2026), UCL Discovery PDF
  - `limitations`: 英国 Year 7-8・準実験的(quasi-experimental)・日本小学校算数とは校種が異なる旨を明記
- 本文「なぜ効果が小さいのか」「研究からわかっていること」「注意したいこと」を学力進捗と自己肯定感で分離
- 「主な参考研究」に Taylor & Hodgen (2026) を追加
- `src/pages/changelog.astro` 2026-05-11 entry に update 行を追加

## 一次研究

- Taylor, B. & Hodgen, J. (2026). *Student Grouping Study*. UCL Institute of Education.
- 報告書 PDF: <https://discovery.ucl.ac.uk/id/eprint/10224627/>
- 対象: 英国 97 校 / Year 7-8 数学 / 2019-2025 / 準実験的・マッチド比較
- 主要結果:
  - 全体: setting で約 1 ヶ月の学力進捗
  - 事前学力上位の児童: setting で +2 ヶ月
  - 事前学力下位の児童: setting と mixed で学力進捗は同等(setting に害なし)
  - 自己肯定感: 混合校で負方向(全体 small / 事前学力下位 moderate negative)

二次まとめ(EEF newsletter / EEF Toolkit)ではなく、UCL Discovery PDF を一次出典として `methodology.primaryMetaAnalysis.url` に格納している(rule 14 系統)。`sourceUrl` の EEF Toolkit リンクは据え置き。

## 用語

英語の "prior attainment" の訳語として **「事前学力下位 / 上位の児童」** を採用し、10 箇所で統一した。英単語と漢字を混在させた表現(例: 「低 prior 児童」)を避け、frontmatter / 本文 / Technical Appendix block を通して一貫させている。

## 検証

- `npm run check:consistency` ✓
- `npm run check:text` ✓
- `npm run check:stale` ✓(lastVerified 2026-05-11、stale 検出 0)
- `npm run check` ✓(0 errors / 0 warnings)
- `npm run build` ✓(252 pages)
- `dist/strategies/setting-streaming/index.html` grep ✓(事前学力下位 4 行 / 上位 1 行 / Taylor & Hodgen / UCL Discovery PDF リンク / Technical Appendix block)
- `dist/changelog/index.html` grep ✓(2026-05-11 update 行 + 「事前学力下位の児童」表現)

## Out of scope

- `metacognition.md` への EEF Seven-step model (2026-05) 追記は別 PR
- 読者リテラシー検査(英単語 + 漢字混在パターン検出 / 英略語の用語集未登録検出)は別 issue で起票予定

## 追補(2026-05-11、commit `f50fcda`)

フィードバック「setting がわかりにくい」を受け、`setting-streaming.md` の本文・frontmatter に残っていた英単語を日本語化。

### 訳語

- `setting` → **習熟度別編成**(本記事タイトル「習熟度別グループ編成」と一貫)
- `mixed` → **混合**(本文の既存表記に合流)
- `moderate negative` → **中程度の負効果**(既存表記に合流)
- `targeted` → **対象を絞った**

### 変更箇所(7 トークン / 6 箇所)

- `frontmatter.evidence.eef.note`(setting ×3 + `setting/mixed` + `moderate negative effect` を日本語化)
- `frontmatter.methodology.effectSize`(`混合 vs setting` → `混合 vs 習熟度別編成` / `moderate negative` → `中程度の負効果`)
- `frontmatter.culturalContext`(`EEF の setting-streaming` → `EEF の習熟度別編成カテゴリ(setting-streaming)` / `targeted` → `対象を絞った`)
- 本文 L42 / L60(`setting と混合` → `習熟度別編成と混合`)
- 参考研究 Taylor & Hodgen 説明(`moderate negative` → `中程度の負効果`)

### 温存

- `sourceUrl` / `sourceTitle` / 論文タイトル "The Student Grouping Study" / URL slug `/setting-streaming` / EEF カテゴリ識別子 `setting-streaming`(culturalContext 内で初出のみ括弧併記)
- 他 30+ 戦略の `frontmatter.source: mixed`(Zod スキーマの「複数ソース」識別子で別概念)

### 検証(追補分)

- `npm run check:consistency` ✓
- `npm run check:text` ✓
- `npm run check:stale` ✓
- `npm run check` ✓(0 errors / 0 warnings / 82 hints は既存)
- `npm run build` ✓(252 pages)
- `dist/strategies/setting-streaming/index.html` grep ✓(「習熟度別編成」4 / 「中程度の負効果」4 / 「対象を絞った」1 / `(setting-streaming)` 1 / `moderate negative` 0 / `targeted` 0)

### 追補スコープ外

- 本文に残る「下位群/上位群/下位児童/上位児童」の「事前学力下位/上位の児童」への統一(文体整合性の独立タスクとして次セッションで別 PR)
- changelog.astro は更新不要(ユーザー価値は元 PR の「習熟度別グループ編成の更新」に内包、rule 8b の 1 PR = 最大 1 行を維持)
