### PR TITLE
content(strategies): unify prior-attainment subgroup terminology in setting-streaming

### DIFF
--- a/src/content/strategies/setting-streaming.md
+++ b/src/content/strategies/setting-streaming.md
@@ -39,7 +39,7 @@ culturalContext: |
 
 「レベルに合わせれば効率的に学べる」という直感に反して、効果が小さい理由は:
 
-- **学力進捗** では上位群はやや伸びるが、下位群は習熟度別編成と混合でほぼ差がない。全体としても +1 ヶ月と小さい
+- **学力進捗** では事前学力上位の児童はやや伸びるが、事前学力下位の児童は習熟度別編成と混合でほぼ差がない。全体としても +1 ヶ月と小さい
 - **自己肯定感** が混合校に比べて下がりやすく、特に下位グループに配置された子で中程度の負の影響が報告される(UCL Student Grouping Study, Taylor & Hodgen 2026)
 - グループが固定化されると、下位から上位への移動がほとんど起きない(ラベリング効果)
 - 教師の期待が無意識にグループによって変わってしまう
@@ -57,7 +57,7 @@ culturalContext: |
 ## 研究からわかっていること
 
 - メタ分析(Steenbergen-Hu et al. 2016)では学力効果量 +1 ヶ月。30 項目中で最も効果が小さい部類です
-- **学力進捗** は上位児童にやや正、下位児童は習熟度別編成と混合でほぼ同等(格差は『下位が下がる』ではなく『上位だけが乗る』形で広がる)
+- **学力進捗** は事前学力上位の児童にやや正、事前学力下位の児童は習熟度別編成と混合でほぼ同等(格差は『下位が下がる』ではなく『上位だけが乗る』形で広がる)
 - **自己肯定感** は混合校が有利で、UCL Student Grouping Study(Taylor & Hodgen 2026)では特に事前学力下位の児童で中程度の負効果が観察された
 - 学級内の一時的なグループ分けは、学級間の固定的な分けよりやや効果が大きい
 - 効果は教師の指導力と、グループの流動性に大きく依存します
@@ -72,7 +72,7 @@ culturalContext: |
 ## 主な参考研究
 
 - Steenbergen-Hu, S., Makel, M. C., & Olszewski-Kubilius, P. (2016). [What one hundred years of research says about the effects of ability grouping and acceleration on K-12 students' academic achievement](https://doi.org/10.3102/0034654316675417). *Review of Educational Research*, 86(4), 849–899. — 100年分の研究を統合したメタ分析。能力別グループ編成の効果は全体的に小さいことを確認。
-- Taylor, B., & Hodgen, J. (2026). [The Student Grouping Study: Evaluation Report](https://discovery.ucl.ac.uk/id/eprint/10224627/). UCL Institute of Education / Education Endowment Foundation. — 英国 97 校・Year 7-8 数学の準実験的評価(2019-2025)。学力進捗は混合がわずかに有利だが下位児童は両群同等、自己肯定感は混合校が有利で特に事前学力下位の児童で中程度の負効果。
+- Taylor, B., & Hodgen, J. (2026). [The Student Grouping Study: Evaluation Report](https://discovery.ucl.ac.uk/id/eprint/10224627/). UCL Institute of Education / Education Endowment Foundation. — 英国 97 校・Year 7-8 数学の準実験的評価(2019-2025)。学力進捗は混合がわずかに有利だが事前学力下位の児童は両群同等、自己肯定感は混合校が有利で特に事前学力下位の児童で中程度の負効果。
 - EEF (2021). Setting and streaming: Evidence review. — 効果量+1ヶ月。上位には正、下位には負の効果で相殺される構造を指摘。
 - Ireson, J., & Hallam, S. (2001). *Ability grouping in education*. Paul Chapman Publishing. — 能力別グループ編成の教育社会学的分析。固定化のリスクを詳述。
 


### PR DESCRIPTION
## 背景

直前の PR #180(UCL Student Grouping Study 2026 反映)で `setting-streaming.md` の frontmatter(`evidence.eef.note` / `methodology.effectSize`)を「事前学力上位の児童」「事前学力下位の児童」に揃えたが、本文側に短縮表記「上位群 / 下位群」「上位児童 / 下位児童」が 5 か所残置し、frontmatter / methodology / 本文の 3 層で同じ概念が 3 種類の語で書かれる状態だった。

可読性を上げるため、本文中の同概念を「事前学力上位 / 下位の児童」1 表現に一本化する。

## 変更内容

`src/content/strategies/setting-streaming.md` 本文 3 ブロック(+3 / -3 行):

- 「なぜ効果が小さいのか」セクション: `上位群` / `下位群` → `事前学力上位の児童` / `事前学力下位の児童`
- 「研究からわかっていること」セクション: `上位児童` / `下位児童` → 同上
- 「主な参考研究」内の Taylor & Hodgen (2026) 注釈: `下位児童` → `事前学力下位の児童`

## 意図的に温存した表現

「下位グループに配置された子」「下位から上位への移動」「できない子のグループ」「下位グループの指導」「下位の子」は **「グループ分け / 移動 / ラベリング呼称 / 教師配置 / 学力進捗の対比」** を主題にした文脈で、「事前学力下位の児童」と置換すると主題(配置のロジック / ラベルの呼ばれ方)が壊れるため温存する。本 PR は同概念を別語で書いていた 5 か所のみを対象とする。

## 検証

| Check | Result |
|---|---|
| `npm run check:consistency` | pass |
| `npm run check:text` | pass |
| `npm run check:stale` | stale 0 件 |
| `npm run check` | 0 errors / 0 warnings(82 hints は既存) |
| `npm run build` | 251 pages 生成 |
| `src/content/strategies/setting-streaming.md` 上で `上位群\|下位群\|上位児童\|下位児童` の grep | 0 件 |
| `dist/strategies/setting-streaming/index.html` 上で旧 4 表現の grep | 0 件 |
| `dist/strategies/setting-streaming/index.html` 上で `事前学力上位の児童` / `事前学力下位の児童` の grep | 各 3 / 6 出現 |

## changelog 更新の有無

なし。ユーザー価値の変化を伴わない用語統一のため(同概念の別称合流のみ、戦略の内容・判断根拠とも不変)。