### PR TITLE
ci: add Dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,25 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for patch and minor updates
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr merge --auto --squash --delete-branch "$PR_URL"


### PR DESCRIPTION
## 概要
Dependabot が出す patch / minor 更新の PR を、required な CI が green の状態に到達した時点で自動マージする。major 更新は引き続き手動レビュー。

## 変更
- `.github/workflows/dependabot-auto-merge.yml` を追加
  - `dependabot/fetch-metadata@v2` で `update-type` を取得
  - `version-update:semver-major` 以外で `gh pr merge --auto --squash --delete-branch`

## 後続作業(別 PR / 設定変更)
- `allow_auto_merge` を有効化(`gh api PATCH /repos/{owner}/{repo}`)
- main ブランチ保護を有効化し、required status check に `Playwright E2E` を設定

## 確認方法
- マージ後、次回の Dependabot patch / minor PR が opened されたタイミングで auto-merge が enable され、`Playwright E2E` が green になった時点でマージされること
- major 更新の PR では auto-merge step がスキップされ、手動マージ待ちになること