### PR TITLE
chore(security): pin GitHub Actions to SHA

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "22"
           cache: "npm"
@@ -38,7 +38,7 @@ jobs:
 
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: playwright-report
           path: playwright-report/

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -22,10 +22,10 @@ jobs:
       issues: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "22"
           cache: "npm"
@@ -38,7 +38,7 @@ jobs:
 
       - name: Restore lychee cache
         id: lychee-cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: .lycheecache
           key: lychee-${{ github.run_id }}
@@ -46,7 +46,7 @@ jobs:
 
       - name: Run lychee
         id: lychee
-        uses: lycheeverse/lychee-action@v2
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2
         continue-on-error: true
         with:
           # Accept broader status codes (many publishers/journals block
@@ -70,7 +70,7 @@ jobs:
 
       - name: Upload report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: lychee-report-${{ github.run_id }}
           path: lychee-report.md

--- a/.github/workflows/stale-check.yml
+++ b/.github/workflows/stale-check.yml
@@ -19,10 +19,10 @@ jobs:
       issues: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "22"
           cache: "npm"
@@ -37,7 +37,7 @@ jobs:
 
       - name: Upload report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: stale-report-${{ github.run_id }}
           path: stale-report.md


### PR DESCRIPTION
## 背景

直近のサプライチェーン攻撃事案を踏まえ、GitHub Actions のサプライチェーン保護として `uses:` 参照を commit SHA pin に切り替える。

- 2026-05-11 TanStack Mini Shai-Hulud worm: `pull_request_target` + cache poisoning による Pwn Request
- 2026-03 trivy-action 改ざん: 76 タグ中 75 が force-push で書き換え
- 2026-05 MoneyForward の GitHub 不正アクセス事案

## 変更内容

### Actions SHA pin (4 workflows)

- `dependabot-auto-merge.yml`: `dependabot/fetch-metadata@v2` → `@v3` (SHA pin)。v3 の breaking change は Node.js v24 要件のみで本リポは元から Node 24 のため安全。**Dependabot PR #192 を本 PR で吸収**
- `e2e.yml`: `actions/checkout`, `actions/setup-node`, `actions/upload-artifact` を SHA pin
- `link-check.yml`: `actions/checkout`, `actions/setup-node`, `actions/cache`, `lycheeverse/lychee-action`, `actions/upload-artifact` を SHA pin
- `stale-check.yml`: `actions/checkout`, `actions/setup-node`, `actions/upload-artifact` を SHA pin

形式は `uses: <owner>/<repo>@<commit-sha> # <tag>` とし、コメントの `# vN` で Dependabot に major version を認識させて追従可能にする。

## 検証

- `npm audit --omit=dev`: 0 vulnerabilities(本 PR で依存変更なし)
- 12 アクション全てが SHA pin されたことを `grep -nE "uses:\\s+[^@]+@"` で確認

Fixes #192