### PR TITLE
Add FSM attainment finding from EEF Student Grouping Study evaluation report

### DIFF
--- a/src/content/strategies/setting-streaming.md
+++ b/src/content/strategies/setting-streaming.md
@@ -15,12 +15,12 @@ evidence:
   eef:
     monthsGained: 1
     strength: 3
-    note: "EEF Toolkit で +1ヶ月・エビデンス★3。**学力進捗** は全体平均で習熟度別編成がやや低く、事前学力上位の児童で約 2 ヶ月遅れる一方、事前学力下位の児童は習熟度別と混合で同等(習熟度別編成は学力面では害なし、利益も乏しい)。**自己肯定感** は混合校が有利で、特に事前学力下位の児童で中程度の負効果が観察される(UCL Student Grouping Study, Taylor & Hodgen 2026)。Francis et al.(2017)の英国縦断研究でも類似の不均衡が確認されている。"
-lastVerified: "2026-05-11"
+    note: "EEF Toolkit で +1ヶ月・エビデンス★3。**学力進捗** は全体平均で習熟度別編成がやや低く、事前学力上位の児童で約 2 ヶ月遅れる一方、事前学力下位の児童は習熟度別と混合で同等(習熟度別編成は学力面では害なし、利益も乏しい)。**FSM(就学援助相当)児童でも学力進捗に両群差はなく**、社会経済的に不利な児童が習熟度別編成でさらに不利になるとは言えない(EEF 2026 報告の強調点)。**自己肯定感** は混合校が有利で、特に事前学力下位の児童で中程度の負効果が観察される(UCL Student Grouping Study, Taylor & Hodgen 2026)。Francis et al.(2017)の英国縦断研究でも類似の不均衡が確認されている。"
+lastVerified: "2026-05-21"
 methodology:
   studies: 1
   sampleSize: "97 校 / Year 7-8 数学(11-13 歳)"
-  effectSize: "学力進捗: 全体 -1 ヶ月(混合 vs 習熟度別編成)、事前学力上位の児童 -2 ヶ月、事前学力下位の児童は両群同等。自己肯定感: 全体 small / FSM 児童 small / 事前学力下位の児童 中程度の負効果(いずれも混合校が高い)"
+  effectSize: "学力進捗: 全体 -1 ヶ月(混合 vs 習熟度別編成)、事前学力上位の児童 -2 ヶ月、事前学力下位の児童・FSM 児童は両群同等。自己肯定感: 全体 small / FSM 児童 small / 事前学力下位の児童 中程度の負効果(いずれも混合校が高い)"
   primaryMetaAnalysis:
     authors: "Taylor & Hodgen"
     year: 2026
@@ -57,7 +57,7 @@ culturalContext: |
 ## 研究からわかっていること
 
 - メタ分析(Steenbergen-Hu et al. 2016)では学力効果量 +1 ヶ月。30 項目中で最も効果が小さい部類です
-- **学力進捗** は事前学力上位の児童にやや正、事前学力下位の児童は習熟度別編成と混合でほぼ同等(格差は『下位が下がる』ではなく『上位だけが乗る』形で広がる)
+- **学力進捗** は事前学力上位の児童にやや正、事前学力下位の児童・FSM(就学援助相当)児童は習熟度別編成と混合でほぼ同等(格差は『下位が下がる』ではなく『上位だけが乗る』形で広がる。EEF はこの「disadvantaged(社会経済的に不利な)児童に害なし」を 2026 報告で強調)
 - **自己肯定感** は混合校が有利で、UCL Student Grouping Study(Taylor & Hodgen 2026)では特に事前学力下位の児童で中程度の負効果が観察された
 - 学級内の一時的なグループ分けは、学級間の固定的な分けよりやや効果が大きい
 - 効果は教師の指導力と、グループの流動性に大きく依存します
@@ -72,7 +72,7 @@ culturalContext: |
 ## 主な参考研究
 
 - Steenbergen-Hu, S., Makel, M. C., & Olszewski-Kubilius, P. (2016). [What one hundred years of research says about the effects of ability grouping and acceleration on K-12 students' academic achievement](https://doi.org/10.3102/0034654316675417). *Review of Educational Research*, 86(4), 849–899. — 100年分の研究を統合したメタ分析。能力別グループ編成の効果は全体的に小さいことを確認。
-- Taylor, B., & Hodgen, J. (2026). [The Student Grouping Study: Evaluation Report](https://discovery.ucl.ac.uk/id/eprint/10224627/). UCL Institute of Education / Education Endowment Foundation. — 英国 97 校・Year 7-8 数学の準実験的評価(2019-2025)。学力進捗は混合がわずかに有利だが事前学力下位の児童は両群同等、自己肯定感は混合校が有利で特に事前学力下位の児童で中程度の負効果。
+- Taylor, B., & Hodgen, J. (2026). [The Student Grouping Study: Evaluation Report](https://discovery.ucl.ac.uk/id/eprint/10224627/). UCL Institute of Education / Education Endowment Foundation([EEF プロジェクトページ](https://educationendowmentfoundation.org.uk/projects-and-evaluation/projects/student-grouping-study))。英国 97 校・Year 7-8 数学の準実験的評価(2019-2025)。学力進捗は混合がわずかに有利だが事前学力下位の児童・FSM(就学援助相当)児童は両群同等、自己肯定感は混合校が有利で特に事前学力下位の児童で中程度の負効果。
 - EEF (2021). Setting and streaming: Evidence review. — 効果量+1ヶ月。上位には正、下位には負の効果で相殺される構造を指摘。
 - Ireson, J., & Hallam, S. (2001). *Ability grouping in education*. Paul Chapman Publishing. — 能力別グループ編成の教育社会学的分析。固定化のリスクを詳述。
 

--- a/src/pages/changelog.astro
+++ b/src/pages/changelog.astro
@@ -3,6 +3,15 @@ import Layout from "../layouts/Layout.astro";
 
 const entries = [
   {
+    date: "2026-05-21",
+    items: [
+      {
+        type: "update",
+        text: "「習熟度別グループ編成」に EEF 2026 報告の追加知見を反映。就学援助対象児童(FSM)でも学力進捗に両群差がなく、社会経済的に不利な児童が習熟度別編成でさらに不利になるとは言えないことを明示",
+      },
+    ],
+  },
+  {
     date: "2026-05-11",
     items: [
       {


### PR DESCRIPTION
## 概要

EEF (Education Endowment Foundation) が 2026-05-19 配信の newsletter "Resources and Reads" で公式公開した Student Grouping Study evaluation report の新発見「FSM 児童でも学力進捗に両群差なし」を `src/content/strategies/setting-streaming.md` に反映する。

newsletter で EEF が新たに明示的に強調しているのは以下の発見:

> "For the sub-group of students in receipt of FSM, there was effectively no difference in attainment, indicating that, contrary to some qualitative evidence, students from disadvantaged backgrounds are not further disadvantaged."

現行記述では「事前学力下位の児童は両群同等」とあったが、prior attainment と FSM(socio-economic disadvantage)は別概念。日本の文脈でも「就学援助対象児童への影響」を懸念する教師が多く、この発見を明示する意味は大きい。

## 変更内容(2 ファイル)

### 1. `src/content/strategies/setting-streaming.md`(commit `176c319`、5 箇所)

1. `evidence.eef.note` 末尾に FSM 児童の学力進捗結果を追記
2. `methodology.effectSize` に「FSM 児童は両群同等」を反映
3. `lastVerified: 2026-05-11` → `2026-05-21`(rolling 更新)
4. 本文「研究からわかっていること」を FSM 児童・EEF 強調を含む記述に修正
5. 本文「主な参考研究」の Taylor & Hodgen 項目に EEF 公式 evaluation report project page リンクを併記 + 「FSM 児童は両群同等」を要約に追加

### 2. `src/pages/changelog.astro`(commit `253a009`、1 エントリ)

`2026-05-21` の update エントリを 1 行追加。直近 5/11 の同戦略 update と整合する粒度で、就学援助対象児童に関する追加知見を読者に通知。

## 触らないもの(意図的)

- `monthsGained: 1` — 効果量の代表値は変更なし(本 newsletter で再評価無し)
- `evidenceStrength: 3` — 同上
- `sourceUrl`(frontmatter)= UCL discovery — rule 14(一次研究ドメインに限定)を維持。EEF project page は publication venue として本文の「主な参考研究」のみに追加

## 出典

- UCL discovery(一次研究): https://discovery.ucl.ac.uk/id/eprint/10224627/
- EEF project page(publication venue): https://educationendowmentfoundation.org.uk/projects-and-evaluation/projects/student-grouping-study
- EEF newsletter "Resources and Reads"(2026-05-19 配信)

## 検証ログ

- `npm run check:consistency` — ok(不一致なし)
- `npm run check:text` — ok(EXIT=0)
- `npm run check:reader-literacy` — ok(errors 0 / warnings 0)。初出注釈括弧として `FSM(就学援助相当)児童` / `disadvantaged(社会経済的に不利な)児童` を本文に追加して P1 を解消
- `npm run check:links` — broken link 11 件あり。ただし内訳は `screen-time` / `school-lunch-free-followup` / `cram-school-effect` / `lesson-study` の 4 ファイルに属する既存問題で、本 PR が編集する `setting-streaming.md` 由来ではない。本 PR で新規追加した EEF project page URL は「既知ボット対策ドメイン(`educationendowmentfoundation.org.uk`)」に分類され green
- `npm run check`(astro 型チェック)— 0 errors / 0 warnings(changelog 追加後に再実行済)

## マージ方針

rule 13 によりマージはユーザー。