### PR TITLE
ci(link-check): accept HTTP 520 for Cloudflare bot-mitigated origins

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -56,7 +56,7 @@ jobs:
             --cache
             --max-cache-age 1d
             --root-dir ${{ github.workspace }}/dist
-            --accept 200,201,202,203,204,206,301,302,303,307,308,403,429,503
+            --accept 200,201,202,203,204,206,301,302,303,307,308,403,429,503,520
             --exclude 'doi\.org/10\.1037'
             --exclude 'us\.corwin\.com'
             --exclude 'educationendowmentfoundation\.org\.uk'


### PR DESCRIPTION
## 背景

週次の自動 link-check (lychee) が `https://discovery.ucl.ac.uk/id/eprint/10224627/` を「壊れたリンク」として検出 (issue #219)。

実際の URL はブラウザで正常に開く UCL Institute of Education の機関リポジトリページで、Cloudflare の Bot Mitigation による誤検出と判断した。curl の HEAD では `cf-mitigated: challenge` ヘッダ付きで 403 が返り、lychee の HEAD では同等の挙動が 520 として現れている。

## 変更

`.github/workflows/link-check.yml` の `--accept` ステータスリストに `520` を追加。

```diff
- --accept 200,201,202,203,204,206,301,302,303,307,308,403,429,503
+ --accept 200,201,202,203,204,206,301,302,303,307,308,403,429,503,520
```

## 影響

- Cloudflare bot mitigation で 520 を返す他の大学/出版社オリジンのリンクも今後 pass する
- 既存の accept リスト直前のコメント "many publishers/journals block bots but work for humans" の設計思想と整合
- 万一一時的なオリジン障害で 520 が返った場合は pass してしまうが、週次実行で症状が継続する本物のリンク切れは別経路で検知可能

## 確認

- ローカル diff: 1 行追加のみ
- マージ後、workflow_dispatch で手動再実行して 520 ケースが pass することを確認可能

Fixes #219