### PR TITLE
feat(strategies): add UK attendance-intervention evidence to teacher-student-relationships

### DIFF
--- a/src/content/strategies/teacher-student-relationships.md
+++ b/src/content/strategies/teacher-student-relationships.md
@@ -16,7 +16,7 @@ evidence:
   hattie:
     cohensD: 0.72
     note: "Hattie の Visible Learning では d=0.72(上限寄り)。独立メタ分析では Roorda et al.(2011, 99研究)が学業成績との関連 r≒0.16-0.19(d≒0.32-0.39)、Cornelius-White(2007, 119研究)が r=0.31(d≒0.65)と報告。Hattie 値は上端、実態は中程度で **+4 ヶ月程度** が妥当と判断。"
-lastVerified: "2026-04-26"
+lastVerified: "2026-06-01"
 methodology:
   studies: 99
   sampleSize: "就学前〜高校(エンゲージメントとの関連 k=61・N=88,417、学業成績との関連 k=61・N=52,718)"
@@ -58,6 +58,7 @@ culturalContext: |
 - 特に低学年・学習困難を抱える子ども・社会経済的に不利な環境の子どもに対して効果が大きいことが示されています。
 - 温かさと高い期待の「両方」が重要です。温かいだけ(甘やかし)、厳しいだけ(管理的)では効果が弱まります。
 - 関係性の質は、学力だけでなく学校適応・出席率・行動面にも正の影響を与えます。
+- この「関係性が出席にも効く」方向は、海外の大規模評価とも整合します。英国の教育研究財団 EEF が委託した中等学校対象の評価(2026 年)では、出席や家庭連絡を担う職員を配置するだけでは欠席はほぼ改善しませんでした。改善の鍵は役割や仕組みより、学校全体の関係性・文化と個別支援にあると結論づけられています。ただし英国の継続的な欠席は日本の不登校と同義ではなく、上記の効果量もこの評価から導いたものではありません。
 
 ## 注意したいこと
 
@@ -69,6 +70,7 @@ culturalContext: |
 
 - Roorda, D. L., Koomen, H. M. Y., Spilt, J. L., & Oort, F. J. (2011). [The influence of affective teacher–student relationships on students' school engagement and achievement](https://doi.org/10.3102/0034654311421793). *Review of Educational Research*, 81(4), 493–529. — 99研究のメタ分析。教師と子どもの情緒的な関係が、学校への関与と学業成績の両方に影響することを確認。
 - Cornelius-White, J. (2007). [Learner-centered teacher–student relationships are effective: A meta-analysis](https://doi.org/10.3102/003465430298563). *Review of Educational Research*, 77(1), 113–143. — 119研究のメタ分析。学習者中心の関係性(共感、温かさ、真正性)と学業成績の正の関連を実証。
+- Education Endowment Foundation & Youth Endowment Fund (2026). [Four new evaluations of programmes and approaches designed to improve attendance and prevent persistent absence](https://educationendowmentfoundation.org.uk/news/evaluations-improve-attendance-and-prevent-persistent-absence). — 出席・家庭連絡を担う職員の配置(独立評価機関 ICF が実施、中等学校・約 50 万人/621 校)を含む 4 つの評価。専門職の配置だけでは持続的な欠席にほぼ効果がなく(各期間で約 0.1 パーセントポイント、確実性は中〜高)、役割や仕組みより関係性・文化・個別支援の質が鍵と結論。
 
 ## 関連する学習指導要領
 


### PR DESCRIPTION
## 概要

「教師と子どもの関係性」戦略に、英国 EEF・YEF による出席改善介入の大規模評価（2026）を裏付けエビデンスとして追補する。本戦略は既に「関係性の質は出席率にも正の影響を与える」と述べており、その主張を外部の大規模評価で補強する。

## 背景

EEF が委託した中等学校対象の評価（独立評価機関 ICF 実施、約 50 万人・621 校）は、出席や家庭連絡を担う専門職を配置するだけでは持続的な欠席がほぼ改善しないことを示した（各期間 約 0.1 パーセントポイント、確実性 中〜高）。EEF はこれを「万能な解決策は無い」と総括し、改善の鍵は役割や仕組みより学校全体の関係性・文化と一人ひとりへの個別支援にあると結論づけている。この「関係性が出席に効く」という方向は本戦略の中核命題と一致する。

同一の出典・記述は既に `school-refusal-support.md`（不登校支援）に展開済みで、本 PR はそれを関係性戦略の文脈で再利用する。

## 変更点

- 本文「研究からわかっていること」の出席率への言及に続けて、当該評価の知見を 1 項目追加
- 「主な参考研究」に EEF・YEF (2026) の出典を 1 件追加（`school-refusal-support.md` と同一出典・同一記述）
- `lastVerified` を 2026-06-01 に更新

## 射程の限定

- 英国の継続的欠席は日本の不登校と同義ではない旨を本文に明記
- 本戦略の効果量（+4 ヶ月、Roorda 2011 / Cornelius-White 2007 由来）はこの評価から導いたものではない旨を明記
- 出典バッジの誤表示を避けるため frontmatter の `evidence` ブロックは変更せず、`monthsGained` / `evidenceStrength` も据え置き

## 検証

- `npm run check:all`：astro check / textlint / reader-literacy 0 件 / sentence-length critical 0 / consistency 不一致なし / 出典リンク検査 404=0
- 本番ビルド成功（OG 画像再生成・Pagefind インデックス生成を含む）
