### PR TITLE
feat(og-image): add cache-busting query to OG image URLs (ADR 0019)

### DIFF
--- a/docs/decisions/0019-og-cache-refresh-policy.md
+++ b/docs/decisions/0019-og-cache-refresh-policy.md
@@ -136,6 +136,15 @@ portfolio ADR 0003 と揃えて、**本 ADR を採択する PR では `Layout.as
 | `scripts/generate-default-og.ts` のレイアウト変更 | 必要 | 同上 |
 | ハブページ(トップ / コラム一覧)の本文・カードレイアウト変更 | 不要 | OG 画像自体は変わらない |
 
+### 同梱フォントの変更(2026-06-07 追記、実装 PR にて)
+
+ADR 0017 で同梱したフォント(`scripts/fonts/noto-sans-jp-bold.bin`)は、戦略個別 OG(`src/lib/og-image.ts`)と静的 default OG(`scripts/generate-default-og.ts`)の **両方が参照している**。フォントを差し替えた場合は両系統の見た目が変わるため、次の両方を行う:
+
+| 対象 | 操作 |
+|---|---|
+| 静的 default OG | `npm run og:default` で再生成し、`OG_DEFAULT_VERSION` を生成日(YYYYMMDD)に更新 |
+| 戦略個別 OG | 全戦略の `lastVerified` 一括更新(または、その時点で別 ADR を起こして個別ハンドリングを設計) |
+
 ## edu-evidence 固有の運用ワークフロー
 
 ### 戦略を更新するとき(コンテンツ編集者向け)

--- a/docs/decisions/0019-og-cache-refresh-policy.md
+++ b/docs/decisions/0019-og-cache-refresh-policy.md
@@ -2,7 +2,7 @@
 
 - 状態: 採用
 - 日付: 2026-05-05
-- 関連 PR: 本 ADR と同一 PR で確定
+- 関連 PR: 本 ADR と同一 PR で確定(採択 PR #162)/ 実装 PR #250
 - 起点 ADR: ISAGAWA HAYATO Portfolio ADR 0003(共通フレーム + SNS runbook の元、PR #44 マージ済)
 - 関連 ADR: 0017(動的 OG 画像生成用フォント同梱)/ 0018(静的 default OG 画像)
 - 姉妹サイト ADR: edu-watch ADR 0034(同方針のミラー、別 PR で確定予定)
@@ -136,7 +136,7 @@ portfolio ADR 0003 と揃えて、**本 ADR を採択する PR では `Layout.as
 | `scripts/generate-default-og.ts` のレイアウト変更 | 必要 | 同上 |
 | ハブページ(トップ / コラム一覧)の本文・カードレイアウト変更 | 不要 | OG 画像自体は変わらない |
 
-### 同梱フォントの変更(2026-06-07 追記、実装 PR にて)
+### 同梱フォントの変更(2026-06-07 追記、PR #250)
 
 ADR 0017 で同梱したフォント(`scripts/fonts/noto-sans-jp-bold.bin`)は、戦略個別 OG(`src/lib/og-image.ts`)と静的 default OG(`scripts/generate-default-og.ts`)の **両方が参照している**。フォントを差し替えた場合は両系統の見た目が変わるため、次の両方を行う:
 

--- a/src/data/og-version.ts
+++ b/src/data/og-version.ts
@@ -1,0 +1,3 @@
+// 静的 default OG 画像(/og-image.png)のキャッシュバスティング用バージョン(ADR 0019)
+// public/og-image.png の見た目が変わる変更をしたら、生成日(YYYYMMDD)に更新する
+export const OG_DEFAULT_VERSION = "20260504"; // ADR 0018 で /og-image.png を整備した日

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,10 +1,12 @@
 ---
 import "../styles/global.css";
 import Logo from "../components/Logo.astro";
+import { OG_DEFAULT_VERSION } from "../data/og-version";
 interface Props {
   title?: string;
   description?: string;
   ogImagePath?: string;
+  ogVersion?: string;
   articleJsonLd?: object;
   breadcrumbJsonLd?: object;
   longForm?: boolean;
@@ -13,13 +15,17 @@ const {
   title = "EduEvidence JP — 小学校エビデンスポータル",
   description = "日本の小学校教員のための教育エビデンスまとめサイト。国内外の研究から得られた知見を「効果」「信頼性」「コスト」「出典」の4指標で整理し、現場で使える形に翻案して公開。",
   ogImagePath,
+  ogVersion,
   articleJsonLd,
   breadcrumbJsonLd,
   longForm = false,
 } = Astro.props;
 const siteUrl = "https://edu-evidence.org";
 const canonicalUrl = new URL(Astro.url.pathname, siteUrl).href;
-const ogImage = ogImagePath ? `${siteUrl}${ogImagePath}` : `${siteUrl}/og-image.png`;
+const versionQuery = ogVersion ? `?v=${ogVersion}` : "";
+const ogImage = ogImagePath
+  ? `${siteUrl}${ogImagePath}${versionQuery}`
+  : `${siteUrl}/og-image.png?v=${OG_DEFAULT_VERSION}`;
 
 const escapeLd = (obj: object): string => JSON.stringify(obj).replace(/</g, "\\u003c");
 ---

--- a/src/pages/changelog.astro
+++ b/src/pages/changelog.astro
@@ -3,15 +3,6 @@ import Layout from "../layouts/Layout.astro";
 
 const entries = [
   {
-    date: "2026-06-07",
-    items: [
-      {
-        type: "update",
-        text: "戦略ページの内容を更新したとき、SNS でシェアした際のサムネイル画像が古いまま残らず、最新の状態で表示されるように",
-      },
-    ],
-  },
-  {
     date: "2026-06-06",
     items: [
       {

--- a/src/pages/changelog.astro
+++ b/src/pages/changelog.astro
@@ -3,6 +3,15 @@ import Layout from "../layouts/Layout.astro";
 
 const entries = [
   {
+    date: "2026-06-07",
+    items: [
+      {
+        type: "update",
+        text: "戦略ページの内容を更新したとき、SNS でシェアした際のサムネイル画像が古いまま残らず、最新の状態で表示されるように",
+      },
+    ],
+  },
+  {
     date: "2026-06-06",
     items: [
       {

--- a/src/pages/strategies/[...slug].astro
+++ b/src/pages/strategies/[...slug].astro
@@ -83,6 +83,7 @@ const effectNote =
   title={`${d.title} — EduEvidence JP`}
   description={d.summary}
   ogImagePath={`/og/${entry.id}.png`}
+  ogVersion={entry.data.lastVerified?.replaceAll("-", "")}
   articleJsonLd={articleJsonLd}
   breadcrumbJsonLd={breadcrumbJsonLd}
   longForm


### PR DESCRIPTION
## 概要

ADR 0019(OG 画像キャッシュ更新ポリシー)で採択済みの `?v=` クエリ方式を実装する。OG 画像の更新時に SNS 側キャッシュが旧画像を保持し続ける問題への対策として、OG 画像 URL にバージョンクエリを付与する。

Fixes #244

## 変更内容

- `src/data/og-version.ts` を新設し、静的 default OG(`/og-image.png`)用の `OG_DEFAULT_VERSION = "20260504"`(ADR 0018 で整備した日)を一元管理
- `Layout.astro` の `Props` に `ogVersion` を追加し、og:image / twitter:image の URL を `?v=` 付きで構築
  - `ogImagePath` がある場合(戦略個別 OG): `ogVersion` 指定時に `?v=<YYYYMMDD>` を付与
  - fallback(静的 default OG): 常に `?v=${OG_DEFAULT_VERSION}` を付与
- `src/pages/strategies/[...slug].astro` から `lastVerified` 由来の `ogVersion` を渡す。ADR の実装例は `lastVerified` を required 前提としているが、zod スキーマ上は optional のため `?.` でアクセスする(実データは全 74 戦略で設定済み)
- ADR 0019 に同梱フォント変更時の運用を追記: `scripts/fonts/noto-sans-jp-bold.bin` は戦略個別 OG と静的 default OG の両方が参照するため、差し替え時は `OG_DEFAULT_VERSION` の更新と全戦略 `lastVerified` の一括更新の両方が必要。あわせて ADR の関連 PR 欄に採択 PR #162 / 実装 PR #250 を記録

## 検証

- `npm run check`: 0 エラー
- `npm run build` 後の dist:
  - トップ / コラムページの og:image は `og-image.png?v=20260504`
  - 戦略ページ 74/74 件で `/og/<slug>.png?v=<YYYYMMDD>` を確認(例: `feedback` は `lastVerified: "2026-04-22"` → `?v=20260422`)
  - twitter:image も og:image と同一 URL
- `npm run test:e2e`: 42/42 合格