### PR TITLE
feat: add known-broken link baseline to check:links

### DIFF
--- a/docs/CONTENT_GUIDELINES.md
+++ b/docs/CONTENT_GUIDELINES.md
@@ -528,7 +528,7 @@ Hattie の有名な言葉:
   - **用語集・ツールチップ**: `glossary.astro` / `glossary.ts` の戦略名(+N ヶ月)
 
 - `check:links:source`: md ソース中の外部 URL 到達性(dist ビルド不要、404 / 410 / network error のみ失敗)
-- `check:links`: ビルド後の dist に対する linkinator 走査
+- `check:links`: ビルド後の dist に対する linkinator 走査(既知 broken はベースラインで管理、新規破損のみ失敗)
 
 `check:links:source` の挙動:
 
@@ -539,6 +539,18 @@ Hattie の有名な言葉:
 - **404 / 410 / network error**: error(exit code 1)
 - `HEAD` で 401 / 403 / 404 / 405 / 429 / 501 が返った場合はブラウザ風ヘッダ + `Range: bytes=0-0` で GET フォールバックし、ボット対策を一部回避
 - markdown リンク `[text](url)` は balanced-paren 抽出のため `doi.org/10.1016/S2352-4642(19)30186-5` のような括弧入り URL にも対応
+
+`check:links` の挙動:
+
+- broken URL を `scripts/links-known-issues.json`(baseline)と照合して 3 分類する
+  - **NEW**: baseline に無い URL、または baseline 登録済みでも今回 404 / 410 / network error に変化した URL → 列挙して error(exit code 1。ボット対策 403 → 本物の消滅への変化も検知)
+  - **known**: baseline 登録済みで 404 / 410 / network error 以外 → ホスト別サマリ表示のみ(失敗にしない)
+  - **stale**: baseline 登録済みだが今回 broken でない(直った)→ 情報表示のみ(baseline の縮小余地)
+- NEW が出たときの対応: リンク自体を修正する。ブラウザでは開ける新たなボット対策ドメインであれば `npm run links:baseline` で baseline を再生成
+- `npm run links:baseline`: 現在の broken 集合で baseline を書き直す(404 / 410 / network error は本物の死リンクの可能性が高いため登録せず警告のみ)
+- 照合キーは URL のみ。status 値は「403 = ボット対策」等の文脈メモで、403 ↔ 503 のネットワーク揺れで NEW 化しない
+- dist が無い場合は exit code 2(先に `npm run build`)
+- a11y 検査(`e2e/a11y-known-issues.json` + `npm run a11y:baseline`)と同じベースライン方式で、操作も対称
 
 GitHub Actions で稼働中の自動化:
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "preview": "astro preview",
     "astro": "astro",
     "check": "astro check",
-    "check:links": "linkinator dist --recurse --skip 'mailto:|^#|doi\\.org/10\\.1037|us\\.corwin\\.com'",
+    "check:links": "npx tsx scripts/check-links.ts",
     "check:links:live": "linkinator https://edu-evidence.org --recurse --skip 'mailto:|^#|doi\\.org/10\\.1037|us\\.corwin\\.com'",
     "check:links:source": "npx tsx scripts/check-source-links.ts",
     "check:text": "textlint 'src/content/**/*.md'",
@@ -26,6 +26,7 @@
     "test:e2e": "npx playwright test",
     "test:e2e:ui": "npx playwright test --ui",
     "a11y:baseline": "node scripts/a11y-baseline.mjs",
+    "links:baseline": "npx tsx scripts/check-links.ts --update-baseline",
     "og:default": "npx tsx scripts/generate-default-og.ts"
   },
   "dependencies": {

--- a/scripts/check-links.ts
+++ b/scripts/check-links.ts
@@ -1,0 +1,204 @@
+/**
+ * dist の linkinator 走査 + 既知 broken リンクのベースライン照合
+ *
+ * a11y 検査(e2e/a11y-known-issues.json + scripts/a11y-baseline.mjs)と同じ
+ * ベースライン方式。ボット対策で 403/503 等を返す既知ドメインの URL を
+ * scripts/links-known-issues.json で管理し、ベースラインにない新規破損のみ
+ * 失敗として報告する。
+ *
+ * 分類:
+ *   - NEW   … baseline に無い URL、または baseline にあっても今回 404 / 410 /
+ *             network error(ボット対策 403 → 本物の消滅 404 への変化も検知)
+ *   - known … baseline にあり、404 / 410 / 0 以外 → ホスト別サマリ表示のみ
+ *   - stale … baseline にあるが今回 broken でない(直った)→ 情報表示のみ
+ *
+ * exit code:
+ *   - 0 … NEW broken なし(known / stale は失敗にしない)
+ *   - 1 … NEW broken あり
+ *   - 2 … dist 不在 / 予期せぬ例外
+ *
+ * 使い方:
+ *   npm run check:links      … 照合モード
+ *   npm run links:baseline   … baseline 再生成(常に exit 0)
+ *   既知 broken は別 PR で順次解消し、再生成して baseline を縮める
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { check, LinkState } from "linkinator";
+
+const BASELINE_PATH = path.resolve("scripts/links-known-issues.json");
+const DIST_DIR = path.resolve("dist");
+
+// 旧 CLI `linkinator dist --recurse --skip '...'` と同一挙動を維持する設定。
+// - linksToSkip は 1 要素のまま渡す(CLI と同じ正規表現 OR 評価)
+// - timeout / userAgent / retry は渡さない(UA を変えると 403 を返す母集合が
+//   変わり baseline が実態とずれるため、旧 CLI のデフォルトを踏襲)
+const CHECK_OPTIONS = {
+  path: "dist",
+  recurse: true,
+  linksToSkip: ["mailto:|^#|doi\\.org/10\\.1037|us\\.corwin\\.com"],
+  concurrency: 100,
+};
+
+// 「確定した消滅 / 到達不能」とみなす status。baseline 登録済みでも NEW 扱い。
+// (check-source-links.ts の categorize と同じ思想。0 = network error / timeout)
+const HARD_BROKEN_STATUSES = new Set([404, 410, 0]);
+
+function hostOf(url: string): string {
+  try {
+    return new URL(url).hostname.toLowerCase();
+  } catch {
+    return "";
+  }
+}
+
+function statusLabel(status: number): string {
+  return status === 0 ? "network error" : `HTTP ${status}`;
+}
+
+function loadBaseline(): Record<string, number> {
+  if (!fs.existsSync(BASELINE_PATH)) return {};
+  return JSON.parse(fs.readFileSync(BASELINE_PATH, "utf-8")) as Record<string, number>;
+}
+
+interface ScanResult {
+  broken: Map<string, number>;
+  totalChecked: number;
+  skippedCount: number;
+}
+
+async function scan(): Promise<ScanResult> {
+  const result = await check(CHECK_OPTIONS);
+  // BROKEN は同一 URL が parent ごとに複数件返るため、URL でユニーク化する
+  const broken = new Map<string, number>();
+  let skippedCount = 0;
+  for (const link of result.links) {
+    if (link.state === LinkState.SKIPPED) skippedCount++;
+    if (link.state !== LinkState.BROKEN) continue;
+    if (!broken.has(link.url)) {
+      broken.set(link.url, link.status ?? 0);
+    }
+  }
+  return { broken, totalChecked: result.links.length, skippedCount };
+}
+
+function writeBaseline(broken: Map<string, number>) {
+  const entries = [...broken.entries()].sort(([a], [b]) => a.localeCompare(b));
+  const hardBroken = entries.filter(([, status]) => HARD_BROKEN_STATUSES.has(status));
+  const baseline = Object.fromEntries(
+    entries.filter(([, status]) => !HARD_BROKEN_STATUSES.has(status)),
+  );
+
+  fs.writeFileSync(BASELINE_PATH, JSON.stringify(baseline, null, 2) + "\n");
+  console.log(
+    `Baseline written to ${path.relative(process.cwd(), BASELINE_PATH)} (${Object.keys(baseline).length} entries)`,
+  );
+
+  if (hardBroken.length > 0) {
+    console.error("");
+    console.error("⚠️ 以下は 404 / 410 / network error のため baseline に登録しませんでした。");
+    console.error("   本当に壊れている可能性が高いので、リンク自体を修正してください:");
+    for (const [url, status] of hardBroken) {
+      console.error(`   - ${url} → ${statusLabel(status)}`);
+    }
+  }
+}
+
+function reportAndJudge(broken: Map<string, number>, baseline: Record<string, number>): number {
+  const newBroken: Array<[string, number]> = [];
+  const knownBroken: Array<[string, number]> = [];
+
+  for (const [url, status] of broken) {
+    if (url in baseline && !HARD_BROKEN_STATUSES.has(status)) {
+      knownBroken.push([url, status]);
+    } else {
+      newBroken.push([url, status]);
+    }
+  }
+
+  const stale = Object.keys(baseline).filter((url) => !broken.has(url));
+
+  if (newBroken.length > 0) {
+    console.log(`## ❌ 新規 broken リンク(要対応)`);
+    console.log("");
+    for (const [url, status] of newBroken.sort(([a], [b]) => a.localeCompare(b))) {
+      const note =
+        url in baseline ? "(baseline 登録済みだが 404 / 410 / network error に変化)" : "";
+      console.log(`- ${url} → ${statusLabel(status)}${note}`);
+    }
+    console.log("");
+  }
+
+  if (knownBroken.length > 0) {
+    const byHost = new Map<string, number>();
+    for (const [url] of knownBroken) {
+      const h = hostOf(url);
+      byHost.set(h, (byHost.get(h) ?? 0) + 1);
+    }
+    console.log(`## ℹ️ [known] 既知ボット対策ドメイン(baseline 登録済み、ブラウザでは通常 200)`);
+    console.log("");
+    for (const [h, n] of [...byHost.entries()].sort((a, b) => b[1] - a[1])) {
+      console.log(`- ${h}: ${n} 件`);
+    }
+    console.log("");
+  }
+
+  if (stale.length > 0) {
+    console.log(`## 🧹 stale エントリ(baseline 登録済みだが今回 broken でない)`);
+    console.log("");
+    for (const url of stale) {
+      console.log(`- ${url}`);
+    }
+    console.log("");
+    console.log("`npm run links:baseline` で再生成すると baseline を縮められます。");
+    console.log("");
+  }
+
+  console.log(`## 集計`);
+  console.log(`- ❌ 新規 broken: ${newBroken.length}`);
+  console.log(`- ℹ️ 既知 (baseline): ${knownBroken.length}`);
+  console.log(`- 🧹 stale: ${stale.length}`);
+
+  if (newBroken.length > 0) {
+    console.error(
+      `\n新規 broken リンクが ${newBroken.length} 件あります。リンクを修正するか、` +
+        "ボット対策ドメインであれば `npm run links:baseline` で baseline を更新してください。",
+    );
+    return 1;
+  }
+  return 0;
+}
+
+async function main(): Promise<number> {
+  if (!fs.existsSync(DIST_DIR)) {
+    console.error("dist/ がありません。先に `npm run build` を実行してください。");
+    return 2;
+  }
+
+  const updateMode = process.argv.includes("--update-baseline");
+
+  console.log(`=== check:links(linkinator + baseline 照合)===`);
+  console.log(`対象: dist / モード: ${updateMode ? "baseline 再生成" : "照合"}`);
+  console.log("");
+
+  const { broken, totalChecked, skippedCount } = await scan();
+  console.log(
+    `検査リンク: ${totalChecked}(SKIPPED ${skippedCount} / BROKEN ユニーク ${broken.size})`,
+  );
+  console.log("");
+
+  if (updateMode) {
+    writeBaseline(broken);
+    return 0;
+  }
+
+  return reportAndJudge(broken, loadBaseline());
+}
+
+main()
+  .then((code) => process.exit(code))
+  .catch((err) => {
+    console.error(err);
+    process.exit(2);
+  });

--- a/scripts/links-known-issues.json
+++ b/scripts/links-known-issues.json
@@ -1,0 +1,10 @@
+{
+  "https://doi.org/10.1001/jamapediatrics.2018.5056": 403,
+  "https://doi.org/10.2307/2673258": 403,
+  "https://doi.org/10.5951/jresematheduc.42.3.0237": 403,
+  "https://pubs.nctm.org/view/journals/jrme/48/3/article-p261.xml": 403,
+  "https://schoolmealscoalition.org/sites/default/files/2024-05/Brennan_etal_2022_School_Meals_Case_Study_Scotland.pdf": 403,
+  "https://schoolmealscoalition.org/sites/default/files/2024-05/Kuusipalo_Manninen_2023_Food_Meals_Case_Study_Finland.pdf": 403,
+  "https://www.jstor.org/stable/4609267": 403,
+  "https://www.sbcr.jp/product/4815633417/": 403
+}


### PR DESCRIPTION
## 概要

`npm run check:links`(linkinator CLI)は、ボット対策で 403 等を返す既知ドメインを毎回 broken と計上するため、実行のたびに出力を既知一覧と目視照合する運用だった。a11y 検査で実績のあるベースライン方式(`e2e/a11y-known-issues.json` + `a11y:baseline`)を check:links にも導入し、ベースラインにない新規破損のみを失敗として報告する。

Fixes #245

## 変更内容

- `scripts/check-links.ts` を新設。linkinator Node API `check()` で dist を走査し(オプションは旧 CLI と同一: `--skip` 相当の正規表現 / concurrency 100 / UA・timeout はデフォルト)、broken URL を `scripts/links-known-issues.json` と照合して 3 分類する
  - **NEW**: baseline に無い URL、または baseline 登録済みでも 404 / 410 / network error に変化した URL → 列挙して exit 1(ボット対策 403 → 本物の消滅への変化も検知)
  - **known**: baseline 登録済み → ホスト別サマリ表示のみ(失敗にしない)
  - **stale**: baseline 登録済みだが今回 broken でない → 情報表示し、再生成を案内
- `scripts/links-known-issues.json` を新設(`{url: status}` のソート済みマップ、8 件・全て 403)。照合キーは URL のみで、status 値は文脈メモ(403 ↔ 503 のネットワーク揺れで NEW 化しない)
- `package.json`: `check:links` を新スクリプトに差し替え、baseline 再生成用の `links:baseline` を追加。`--update-baseline` は 404 / 410 / network error を baseline に書かず警告するため、本物の死リンクは焼き込めない
- `docs/CONTENT_GUIDELINES.md` §7: check:links の挙動詳細(分類・NEW 時の対応・再生成・a11y 方式との対称性)を追記

## baseline が 8 件である理由(issue 記載は約 19 件)

linkinator は Cloudflare 等の bot-mitigation 応答を自動で SKIPPED に分類するため(今回のスキャンで 150 件)、BROKEN として計上されるのは 8 件(doi.org ×3 / schoolmealscoalition.org ×2 / pubs.nctm.org / jstor.org / sbcr.jp)のみ。baseline には「実際に BROKEN 計上される URL」だけを置く。

## 検証

- `npm run check:links`: 検査リンク 1254 / NEW 0 / known 8 / stale 0 / exit 0
- baseline から 1 件削除した状態の実スキャン: NEW 1 / exit 1。有効 URL を一時追加した状態: stale 1 / exit 0
- dist 不在時: exit 2(`npm run build` を案内)
- `npm run check`(astro check): 0 errors

changelog は更新していない(読者体験に変化のない内部チェック機構のため)。