### PR TITLE
docs: link learning-styles column from policy-evidence

### DIFF
--- a/src/pages/policy-evidence.astro
+++ b/src/pages/policy-evidence.astro
@@ -94,6 +94,7 @@ const comparisons = [
       { name: "ICT活用", href: "/strategies/digital-technology" },
       { name: "協同学習", href: "/strategies/cooperative-learning" },
     ],
+    column: { name: "「学習スタイル」は本当に効果があるのか? — VARK と meshing 仮説の現在地", href: "/columns/learning-styles-reconsidered" },
     alignment: "partial",
   },
   {


### PR DESCRIPTION
## 概要

/policy-evidence(政策とエビデンスの対照表)の「個別最適な学び」の推進 項目に、関連コラムへのリンクを追加する。

Refs #247(リンク未設定 6 項目のうち 1 項目に対応。残り 5 項目は対応するコラムが存在しないため、コラム新規執筆のタイトル案を issue 側にコメントで追記)

## 変更内容

- `src/pages/policy-evidence.astro`: 「個別最適な学び」項目に `column:` キーを追加(リンク先: 「学習スタイル」は本当に効果があるのか? — VARK と meshing 仮説の現在地)

## 選定理由

コラム 28 本へのキーワード調査で「個別最適」に言及するのは 5 本。うち learning-styles-reconsidered は「個別最適な学び」を中央教育審議会 2021 年答申の柱として定義し、学習スタイル分類との混同という誤解を正面から扱っており、政策項目の文脈に最も適合する。他 4 本は流行語としての列挙・周辺的言及・既リンク項目(AIドリル)との重複のため見送り。

## 検証

`npm run check`: 0 errors / 0 warnings