### PR TITLE
docs: add reference book to About reference list

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -253,6 +253,9 @@ import Layout from "../layouts/Layout.astro";
                 『<a href="https://www.chikumashobo.co.jp/product/9784480072375/" target="_blank" rel="noopener noreferrer" class="link-underline text-[var(--color-accent)]">教育格差</a>』 松岡亮二 (2019), ちくま新書. — 家庭の SES・地域・性別が学力・進学率・学歴に与える影響を体系的に実証。教育格差の論点では本書を基盤に置いている。
               </li>
               <li>
+                『<a href="https://www.minervashobo.co.jp/book/b589599.html" target="_blank" rel="noopener noreferrer" class="link-underline text-[var(--color-accent)]">現場で使える教育社会学 — 教職のための「教育格差」入門</a>』 中村高康・松岡亮二 編著 (2021), ミネルヴァ書房. — 教育格差を教職課程向けに解説した教育社会学の入門テキスト。教員養成で十分に扱われてこなかった教育格差を全 15 章で扱い、各章に現場のための Q&A と演習を備える。松岡『教育格差』と問題意識を共有する一冊。
+              </li>
+              <li>
                 『<a href="https://www.chuko.co.jp/laclef/2021/09/150740.html" target="_blank" rel="noopener noreferrer" class="link-underline text-[var(--color-accent)]">教育論の新常識 — 格差・学力・政策・未来</a>』 松岡亮二 編著 (2021), 中公新書ラクレ. — GIGA スクール・子どもの貧困・ジェンダー・九月入学など 20 のキーワードを、中室牧子ら計 22 名の専門家が解説する共著。
               </li>
               <li>


### PR DESCRIPTION
## 概要

「サイトについて」の「参考にしているもの > 日本の研究・書籍」に、執筆者が読了した参考図書を 1 冊追加する。

- 『現場で使える教育社会学 — 教職のための「教育格差」入門』 中村高康・松岡亮二 編著 (2021), ミネルヴァ書房

直前の PR #253 で明文化した「書籍は執筆者が読了したもののみ参考資料に載せる」方針に沿った追加。

## 変更内容

- `src/pages/about.astro` — 松岡『教育格差』(2019) の直後に li を 1 つ挿入。教育格差クラスター(『教育格差』→ 本書 →『教育論の新常識』)に並べ、教職課程向けの入門書として位置づけた

## 書誌の確認

編著者・出版社・刊行年・URL は一次情報で照合済み(編著は中村高康・松岡亮二の 2 名):

- [現場で使える教育社会学 — ミネルヴァ書房(公式)](https://www.minervashobo.co.jp/book/b589599.html)
- [CiNii 図書 - 現場で使える教育社会学](https://ci.nii.ac.jp/ncid/BC10284718)
- ISBN: 9784623092604

## 検証

- `npm run check`: 0 errors / 0 warnings