### PR TITLE
ci: exclude verified-200 false positives from lychee link check

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -58,9 +58,11 @@ jobs:
             --root-dir ${{ github.workspace }}/dist
             --accept 200,201,202,203,204,206,301,302,303,307,308,403,429,503,520
             --exclude 'doi\.org/10\.1037'
+            --exclude 'doi\.org/10\.5951'
             --exclude 'us\.corwin\.com'
             --exclude 'educationendowmentfoundation\.org\.uk'
             --exclude 'nctm\.org'
+            --exclude 'chikumashobo\.co\.jp'
             --timeout 30
             --max-retries 2
             './dist/**/*.html'


### PR DESCRIPTION
## 概要

週次リンクチェック（lychee）が検出した 2 件のリンク切れは、いずれも実在し HTTP 200 を返す誤検知のため、該当 URL を lychee の除外対象に追加する。

## 検出内容（issue #258）

| URL | lychee の結果 | 実際 |
|-----|--------------|------|
| `https://doi.org/10.5951/jresematheduc.42.3.0237` | 405 Method Not Allowed | 200（NCTM `pubs.nctm.org` の JRME 論文へリダイレクト） |
| `https://www.chikumashobo.co.jp/product/9784480072375/` | HTTP/2 protocol error | 200（HTTP/1.1 で取得確認。松岡亮二『教育格差』ちくま新書） |

両 URL はブラウザ相当の User-Agent で取得し 200 を確認済み。404/410（リソース消失）ではなく、リンクチェッカー側のメソッド拒否・HTTP/2 ネゴシエーション失敗による誤検知。

## 変更

`.github/workflows/link-check.yml` の lychee `--exclude` に 2 件追加：

- `doi\.org/10\.5951` — NCTM の DOI。リダイレクト先 `nctm.org` は既に除外済みだが、本文中のリンクは `doi.org` 形式のため除外が効かず毎回 405 になる。既存の `doi\.org/10\.1037`（APA）と同じ対処。
- `chikumashobo\.co\.jp` — サーバの HTTP/2 不備による transport エラーで、ステータスコードではないため `--accept` では対処できない。当該ホストには松岡『教育格差』など複数の書誌リンクが存在する。

## 影響

NCTM DOI とちくま書房の書籍リンクは週次チェックの対象外になる。いずれも安定した出版社ページで、リダイレクト先（nctm.org）は既存の除外と重複する。

Fixes #258
