### PR TITLE
feat: add sister site links to footer and mobile menu

### DIFF
--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -21,16 +21,17 @@ test.describe("ナビゲーション", () => {
     await expect(page.locator("body")).toHaveAttribute("data-menu", "closed");
   });
 
-  test("モバイルメニューに 4 つのセクション(Explore / Learn / About / Display)が表示される", async ({ page }) => {
+  test("モバイルメニューに 5 つのセクション(Explore / Learn / About / Sister Sites / Display)が表示される", async ({ page }) => {
     await page.setViewportSize({ width: 375, height: 812 });
     await page.goto("/");
     await page.locator("#menu-toggle").click();
     const titles = page.locator(".mobile-menu-section-title");
-    await expect(titles).toHaveCount(4);
+    await expect(titles).toHaveCount(5);
     await expect(titles.nth(0)).toContainText("Explore");
     await expect(titles.nth(1)).toContainText("Learn");
     await expect(titles.nth(2)).toContainText("About");
-    await expect(titles.nth(3)).toContainText("Display");
+    await expect(titles.nth(3)).toContainText("Sister Sites");
+    await expect(titles.nth(4)).toContainText("Display");
   });
 
   test("モバイルメニューを開くと検索 input にフォーカスが移る", async ({ page }) => {

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -224,6 +224,14 @@ const escapeLd = (obj: object): string => JSON.stringify(obj).replace(/</g, "\\u
             </section>
 
             <section class="mobile-menu-section">
+              <h2 class="mobile-menu-section-title">Sister Sites — 姉妹サイト</h2>
+              <ul>
+                <li><a href="https://news.edu-evidence.org">EduWatch JP — 教育ニュース</a></li>
+                <li><a href="https://law.edu-evidence.org">EduLaw JP — 教育法令</a></li>
+              </ul>
+            </section>
+
+            <section class="mobile-menu-section">
               <h2 class="mobile-menu-section-title">Display — 表示</h2>
               <button
                 id="theme-toggle-mobile"
@@ -533,20 +541,41 @@ const escapeLd = (obj: object): string => JSON.stringify(obj).replace(/</g, "\\u
           </ul>
         </section>
 
-        <!-- Column 4: About — サイトについて -->
-        <section aria-labelledby="footer-about" class="space-y-3">
-          <h2
-            id="footer-about"
-            class="font-mono uppercase tracking-widest text-[var(--color-ink)] text-xs"
-          >
-            About — サイトについて
-          </h2>
-          <ul class="space-y-1.5">
-            <li><a href="/about" class="link-underline">このサイトについて</a></li>
-            <li><a href="/support" class="link-underline">運営を支援する</a></li>
-            <li><a href="/changelog" class="link-underline">更新履歴</a></li>
-          </ul>
-        </section>
+        <!-- Column 4: About — サイトについて / Sister Sites — 姉妹サイト -->
+        <div class="space-y-8">
+          <section aria-labelledby="footer-about" class="space-y-3">
+            <h2
+              id="footer-about"
+              class="font-mono uppercase tracking-widest text-[var(--color-ink)] text-xs"
+            >
+              About — サイトについて
+            </h2>
+            <ul class="space-y-1.5">
+              <li><a href="/about" class="link-underline">このサイトについて</a></li>
+              <li><a href="/support" class="link-underline">運営を支援する</a></li>
+              <li><a href="/changelog" class="link-underline">更新履歴</a></li>
+            </ul>
+          </section>
+          <section aria-labelledby="footer-sister" class="space-y-3">
+            <h2
+              id="footer-sister"
+              class="font-mono uppercase tracking-widest text-[var(--color-ink)] text-xs"
+            >
+              Sister Sites — 姉妹サイト
+            </h2>
+            <ul class="space-y-1.5">
+              <li>
+                <span aria-current="page" class="text-[var(--color-ink)]">EduEvidence JP(このサイト)</span>
+              </li>
+              <li>
+                <a href="https://news.edu-evidence.org" class="link-underline">EduWatch JP — 教育ニュース</a>
+              </li>
+              <li>
+                <a href="https://law.edu-evidence.org" class="link-underline">EduLaw JP — 教育法令</a>
+              </li>
+            </ul>
+          </section>
+        </div>
       </div>
       <div class="mx-auto max-w-6xl px-3 xs:px-4 sm:px-6 md:px-10 pb-4 xs:pb-6 sm:pb-8 text-[10px] text-[var(--color-sub)] leading-relaxed">
         © 2026 EduEvidence JP. CC BY-SA 4.0. 英国 EEF

--- a/src/pages/changelog.astro
+++ b/src/pages/changelog.astro
@@ -3,6 +3,15 @@ import Layout from "../layouts/Layout.astro";
 
 const entries = [
   {
+    date: "2026-06-11",
+    items: [
+      {
+        type: "add",
+        text: "フッターとモバイルメニューに姉妹サイトへの導線を追加。教育ニュースの EduWatch JP、教育関連法令の EduLaw JP へサイト内から直接移動できるように",
+      },
+    ],
+  },
+  {
     date: "2026-06-07",
     items: [
       {


### PR DESCRIPTION
## 概要

フッターとモバイルメニューに姉妹サイト(EduWatch JP / EduLaw JP)への導線を追加する。

姉妹サイト側(EduWatch JP のナビゲーション、EduLaw JP のフッター)には edu-evidence.org へのリンクがある一方、本サイトから姉妹サイトへの導線は存在しなかった。サイト間の回遊を双方向にする。

## 変更内容

- `src/layouts/Layout.astro`
  - フッター第 4 カラムを About / Sister Sites の 2 セクション縦積みに変更(グリッドは 4 カラムのまま)。マークアップは EduLaw JP フッターの Sister Sites セクションと同型で、自サイトは `aria-current="page"` の span 表記
  - モバイルメニューの About と Display の間に Sister Sites セクションを追加(EduWatch JP のメニュー構成と同順)
  - リンク先は公開済みの 2 サイト(news.edu-evidence.org / law.edu-evidence.org)のみ。各リンクに役割の短い注記(教育ニュース / 教育法令)を付す
- `e2e/navigation.spec.ts` — モバイルメニューのセクション数検証を 4 → 5 に更新
- `src/pages/changelog.astro` — 2026-06-11 のエントリを追加

## 検証

- `npm run check` — 0 errors / 0 warnings
- `npm run build` — 273 ページ生成。全 273 ページのフッターに両サイトへのリンクを確認
- `npm run test:e2e` — 42 passed