### PR TITLE
fix: correct misattributed citation and reflect controversy in school-uniform strategy

### DIFF
--- a/src/content/strategies/school-uniform.md
+++ b/src/content/strategies/school-uniform.md
@@ -6,7 +6,7 @@ evidenceStrength: 2
 cost: 1
 subjects: ["全教科"]
 grades: ["全学年"]
-tags: ["制度", "負の効果"]
+tags: ["制度"]
 category: "制度・環境"
 source: eef
 sourceUrl: https://educationendowmentfoundation.org.uk/education-evidence/teaching-learning-toolkit/school-uniform
@@ -15,15 +15,15 @@ evidence:
   eef:
     monthsGained: 0
     strength: 2
-    note: "EEF Toolkit で 0 ヶ月・エビデンス★2。制服の着用自体には学力への効果は確認されない。Bodine(2003)・Brunsma & Rockquemore(1998)等の研究でも学力・出席率・行動への効果は見られないか、わずか。『制服で学校文化を作る』という直感的な信念はエビデンスに裏付けられない。"
-lastVerified: "2026-04-14"
+    note: "EEF Toolkit で 0 ヶ月・エビデンス★2。制服の着用自体に学力への効果は確認されていない。なお単一研究の Brunsma & Rockquemore(1998) は学力への負の相関を報告したが、Bodine(2003) が『同じデータはむしろ全体・大半の学校種別で正の相関を示し、負の結論は分析手法の誤用による』と批判し、著者が反論(2003)するなど解釈は定まっていない。『制服で学校文化を作る』という直感的な信念はエビデンスに裏付けられない。"
+lastVerified: "2026-06-15"
 culturalContext: |
   日本の小学校の多くは私服制または指定服(簡易制服)で、**欧米の『制服の有無』論争とはやや文脈が異なる**。ただし、『制服があれば落ち着く』『帰属意識が高まる』といった言説は日本でも聞かれる。経済的負担・選択の自由・ジェンダー表現といった観点と合わせて議論すべき領域で、学力向上の手段として制服を正当化する根拠はない。
 ---
 
 ## 一言でいうと
 
-制服を導入・統一することで学力が向上するかどうかを検証した研究です。結論として、**学力への効果はほぼゼロ**です。帰属意識や規律の改善が期待されることがありますが、それも研究では一貫した結果が出ていません。
+制服を導入・統一することで学力が向上するかどうかを検証した研究です。結論として、**学力への明確な効果は確認されていません**。帰属意識や規律の改善が期待されることがありますが、それも研究では一貫した結果が出ていません。
 
 ## なぜ効果がないのか
 
@@ -42,7 +42,7 @@ culturalContext: |
 
 - EEF Toolkitでは効果量±0ヶ月。学力への効果は確認されていない
 - 帰属意識・出席率への効果を示す研究もあるが、質が高い研究では一貫した結果が出ていない
-- Brunsma & Rockquemore (1998) の大規模分析では、制服と学力・行動の間に有意な関連は見られなかった
+- Brunsma & Rockquemore (1998)（縦断調査データの二次分析・単一研究）は、出席・行動・物質使用には効果がなく、学力にはむしろ負の相関があると報告した。ただしこの解釈は Bodine (2003) に『同じデータはむしろ正の相関を示す／分析手法の誤用』と批判され、著者が反論(2003)するなど論争がある
 
 ## 注意したいこと
 
@@ -52,6 +52,7 @@ culturalContext: |
 
 ## 主な参考研究
 
-- Brunsma, D. L., & Rockquemore, K. A. (1998). [Effects of student uniforms on attendance, behavior problems, substance use, and academic achievement](https://doi.org/10.1080/00220679809597559). *Journal of Educational Research*, 92(1), 53–62. — 大規模データ分析。制服と学力・行動に有意な関連なし。
+- Brunsma, D. L., & Rockquemore, K. A. (1998). [Effects of student uniforms on attendance, behavior problems, substance use, and academic achievement](https://doi.org/10.1080/00220679809597575). *Journal of Educational Research*, 92(1), 53–62. — 縦断調査データの二次分析（単一研究）。出席・行動・物質使用に効果なし、学力には負の相関を報告。ただし解釈には後続の論争がある。
+- Bodine, A. (2003). [School uniforms, academic achievement, and uses of research](https://doi.org/10.1080/00220670309597509). *Journal of Educational Research*, 97(2). — Brunsma & Rockquemore (1998) の負の相関の主張に対し、同じデータは全体・大半の学校種別でむしろ正の相関を示しており、負の結論は学校種別分析の誤用によると批判（著者は2003年に反論）。
 - EEF (2021). School uniform: Evidence review. — 効果量±0ヶ月。帰属意識への効果も限定的。
 - 松岡亮二 (2019). 『教育格差――階層・地域・学歴』筑摩書房. — 日本における教育格差はSESに起因し、外見の統一では解消されないことを実証。

--- a/src/pages/changelog.astro
+++ b/src/pages/changelog.astro
@@ -3,6 +3,15 @@ import Layout from "../layouts/Layout.astro";
 
 const entries = [
   {
+    date: "2026-06-15",
+    items: [
+      {
+        type: "fix",
+        text: "「学校制服」の参考研究を見直し、制服と学力の関係をめぐる研究上の論争(ある単一研究の負の効果の主張と、それへの批判)を正確に反映しました",
+      },
+    ],
+  },
+  {
     date: "2026-06-14",
     items: [
       {


### PR DESCRIPTION
## 概要

学校制服戦略（`school-uniform.md`）の Brunsma & Rockquemore (1998) の扱いにあった不正確を訂正し、制服と学力の関係をめぐる研究上の論争を正確に反映する。

## 背景

- 参考研究の DOI `…597559` が無関係な別論文（Alexander, *Journal of Educational Research* 91(5)）に解決していた。正しくは `…597575`。
- tag「負の効果」と本文「有意な関連なし」が矛盾していた。
- `evidence.eef.note` が Bodine (2003) と B&R (1998) を「どちらも効果なし」と一括りにしていたが、実際は **B&R (1998) が学力への負の相関を主張**、**Bodine (2003) が同じデータはむしろ正の相関を示し B&R は分析手法を誤用と批判**、という正反対の対立。
- 単一研究の所見を確定知見のように本文へ記述していた。

## 変更

**`src/content/strategies/school-uniform.md`**

- tags `["制度", "負の効果"]` → `["制度"]`
- `evidence.eef.note` を論争（B&R の負の相関の主張 → Bodine の批判 → 著者の反論）が分かる記述へ書き換え
- 本文「学力への効果はほぼゼロ」→「学力への明確な効果は確認されていません」
- 「研究からわかっていること」の B&R 記述を、単一研究の所見＋後続の論争として実態化
- 参考研究: B&R 行の DOI を `…597575` に訂正し説明を実所見へ。Bodine (2003) 行を追加（DOI `…597509`、反論を行内で言及）
- lastVerified `2026-04-14` → `2026-06-15`

**`src/pages/changelog.astro`**

- 2026-06-15 エントリを新設（fix 1 件）

格付け（monthsGained 0 / evidenceStrength 2）は EEF Toolkit 由来で不変のため据置。

## 一次確認

- B&R (1998) `10.1080/00220679809597575`: 出席・行動・物質使用に効果なし、学力に負の相関を報告（縦断調査データ二次分析の単一研究）。
- Bodine (2003) `10.1080/00220670309597509`: 同じデータは全体・大半の学校種別で正の相関、負の結論は学校種別分析の誤用と批判。
- B&R (2003) `10.1080/00220670309597510`: 反論論文。
- 上記の著者・誌名・巻号は Crossref で逐語照合済み。

## 検証

`npm run check:all` 決定的チェック通過 / `npm run build` 274 ページ / dist で誤 DOI の消滅・正 DOI の描画・tag「負の効果」非描画を確認 / `npm run test:e2e` 42 passed。

Closes #280
