### PR TITLE
feat(a11y): add skip-to-content link

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -94,6 +94,7 @@ const escapeLd = (obj: object): string => JSON.stringify(obj).replace(/</g, "\\u
     )}
   </head>
   <body class="bg-[var(--color-bg)] text-[var(--color-ink)]" data-menu="closed">
+    <a href="#main-content" class="skip-link">本文へスキップ</a>
     <header class="site-header">
       <div
         class="mx-auto max-w-6xl px-3 xs:px-4 sm:px-6 md:px-10 h-16 flex items-center justify-between gap-4"
@@ -417,7 +418,7 @@ const escapeLd = (obj: object): string => JSON.stringify(obj).replace(/</g, "\\u
       })();
     </script>
 
-    <main class="mx-auto max-w-6xl px-3 xs:px-4 sm:px-6 md:px-10 pb-16 xs:pb-24 sm:pb-32">
+    <main id="main-content" tabindex="-1" class="mx-auto max-w-6xl px-3 xs:px-4 sm:px-6 md:px-10 pb-16 xs:pb-24 sm:pb-32">
       <slot />
     </main>
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -226,6 +226,30 @@ a {
   border: 0;
 }
 
+.skip-link {
+  position: fixed;
+  top: 0;
+  left: 0.5rem;
+  z-index: 100;            /* sticky header z-40・mobile menu z-50 より前面 */
+  transform: translateY(-150%);
+  padding: 0.5rem 1rem;
+  border-radius: 0 0 6px 6px;
+  background: var(--color-accent);
+  color: var(--color-bg);  /* accent×bg は両テーマで約7:1 */
+  font-weight: 600;
+  text-decoration: none;
+  transition: transform 0.15s ease;
+}
+.skip-link:focus {
+  transform: translateY(0);
+  outline: 2px solid var(--color-ink);
+  outline-offset: 2px;
+}
+#main-content:focus { outline: none; }
+@media (prefers-reduced-motion: reduce) {
+  .skip-link { transition: none; }
+}
+
 .mobile-menu {
   position: fixed;
   top: 4rem;


### PR DESCRIPTION
## 概要

全ページ共通レイアウトにスキップリンク（本文へスキップ）を追加し、WCAG 2.4.1 Bypass Blocks に対応する。キーボード／スクリーンリーダー利用者が、各ページでヘッダー・ナビゲーションを Tab で通過せずに本文へ直接移動できるようにする。

## 変更内容

- `src/layouts/Layout.astro`: `<body>` 直後にスキップリンクを追加。`<main>` に `id="main-content"` と `tabindex="-1"` を付与
- `src/styles/global.css`: `.skip-link` を追加。通常は画面外、フォーカス時に左上へスライド表示。配色はアクセント×背景でライト約 7.3:1・ダーク約 7.9:1（AAA 水準）。`prefers-reduced-motion: reduce` で transition を無効化

## 検証

- `npm run check` / `npm run build` 通過
- キーボード操作: 読込 → Tab で「本文へスキップ」出現 → Enter で `<main>` へフォーカス移動を実機確認
- `npm run test:e2e` 42 件全通過（フォーカス順序・a11y 回帰なし）
