### PR TITLE
feat(strategies): add related-strategies cross-links between strategy pages

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -14,6 +14,7 @@ const strategies = defineCollection({
     subjects: z.array(z.string()).default(["全教科"]),
     grades: z.array(z.string()).default(["全学年"]),
     tags: z.array(z.string()).default([]),
+    relatedStrategies: z.array(z.string()).default([]),
     category: z
       .enum(["指導法", "制度・環境", "知っておくべき知見", "認知科学", "家庭・外部"])
       .default("指導法"),

--- a/src/content/strategies/cooperative-learning.md
+++ b/src/content/strategies/cooperative-learning.md
@@ -7,6 +7,7 @@ cost: 1
 subjects: ["全教科"]
 grades: ["全学年"]
 tags: ["グループ学習", "対話"]
+relatedStrategies: ["jigsaw-method"]
 source: eef
 sourceUrl: https://educationendowmentfoundation.org.uk/education-evidence/teaching-learning-toolkit/collaborative-learning-approaches
 sourceTitle: "EEF Teaching and Learning Toolkit — Collaborative learning approaches"

--- a/src/content/strategies/interleaving.md
+++ b/src/content/strategies/interleaving.md
@@ -7,6 +7,7 @@ cost: 1
 subjects: ["算数", "全教科"]
 grades: ["全学年"]
 tags: ["認知科学", "記憶"]
+relatedStrategies: ["blocked-vs-interleaved"]
 category: "認知科学"
 source: mixed
 sourceUrl: https://doi.org/10.1007/s10648-012-9201-3

--- a/src/content/strategies/one-to-one-tuition.md
+++ b/src/content/strategies/one-to-one-tuition.md
@@ -7,6 +7,7 @@ cost: 4
 subjects: ["全教科"]
 grades: ["全学年"]
 tags: ["個別最適化"]
+relatedStrategies: ["small-group-tuition"]
 source: eef
 sourceUrl: https://educationendowmentfoundation.org.uk/education-evidence/teaching-learning-toolkit/one-to-one-tuition
 sourceTitle: "EEF Teaching and Learning Toolkit — One to one tuition"

--- a/src/content/strategies/spaced-practice.md
+++ b/src/content/strategies/spaced-practice.md
@@ -7,6 +7,7 @@ cost: 1
 subjects: ["全教科"]
 grades: ["全学年"]
 tags: ["認知科学", "記憶"]
+relatedStrategies: ["retrieval-practice"]
 category: "認知科学"
 source: mixed
 sourceUrl: https://doi.org/10.1037/0033-2909.132.3.354

--- a/src/content/strategies/summer-learning-loss.md
+++ b/src/content/strategies/summer-learning-loss.md
@@ -7,6 +7,7 @@ cost: 1
 subjects: ["全教科"]
 grades: ["全学年"]
 tags: ["長期休暇", "格差", "負の効果"]
+relatedStrategies: ["summer-schools"]
 category: "知っておくべき知見"
 source: mixed
 sourceUrl: https://doi.org/10.3102/00346543066003227

--- a/src/pages/changelog.astro
+++ b/src/pages/changelog.astro
@@ -3,6 +3,15 @@ import Layout from "../layouts/Layout.astro";
 
 const entries = [
   {
+    date: "2026-06-23",
+    items: [
+      {
+        type: "add",
+        text: "戦略ページに「関連する指導法」を追加。一つの指導法から、あわせて検討したい関連する指導法へたどれるようになりました",
+      },
+    ],
+  },
+  {
     date: "2026-06-21",
     items: [
       {

--- a/src/pages/strategies/[...slug].astro
+++ b/src/pages/strategies/[...slug].astro
@@ -3,6 +3,7 @@ import { getCollection, render } from "astro:content";
 import Layout from "../../layouts/Layout.astro";
 import { annotateGlossaryTerms } from "../../lib/glossary-inline";
 import TableOfContents from "../../components/TableOfContents.astro";
+import RelatedStrategyCard from "../../components/RelatedStrategyCard.astro";
 
 export async function getStaticPaths() {
   const strategies = await getCollection("strategies");
@@ -17,6 +18,16 @@ const allColumns = await getCollection("columns");
 const referringColumns = allColumns
   .filter((c) => (c.data.relatedStrategies ?? []).includes(entry.id))
   .sort((a, b) => (b.data.date || "").localeCompare(a.data.date || ""));
+
+const allStrategies = await getCollection("strategies");
+const forwardIds = d.relatedStrategies ?? [];
+const backwardIds = allStrategies
+  .filter((s) => (s.data.relatedStrategies ?? []).includes(entry.id))
+  .map((s) => s.id);
+const relatedStrategyEntries = [...new Set([...forwardIds, ...backwardIds])]
+  .filter((id) => id !== entry.id)
+  .map((id) => allStrategies.find((s) => s.id === id))
+  .filter((s): s is (typeof allStrategies)[number] => s !== undefined);
 
 const siteUrl = "https://edu-evidence.org";
 const pageUrl = `${siteUrl}/strategies/${entry.id}`;
@@ -360,6 +371,36 @@ const effectNote =
         ) : (
           <p class="text-[var(--color-ink)]">{d.sourceTitle}</p>
         )}
+      </section>
+    )
+  }
+
+  {
+    relatedStrategyEntries.length > 0 && (
+      <section class="pt-10 mt-10 border-t border-[var(--color-line)] max-w-2xl space-y-6">
+        <div class="space-y-1">
+          <div class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]">
+            Related Strategies
+          </div>
+          <h2 class="text-2xl font-black tracking-tight">関連する指導法</h2>
+          <p class="text-sm text-[var(--color-sub)]">
+            この指導法とあわせて検討したい、関連する指導法です。
+          </p>
+        </div>
+        <ul class="space-y-3">
+          {relatedStrategyEntries.map((s) => (
+            <li>
+              <RelatedStrategyCard
+                href={`/strategies/${s.id}`}
+                title={s.data.title}
+                summary={s.data.summary}
+                monthsGained={s.data.monthsGained}
+                evidenceStrength={s.data.evidenceStrength}
+                evidence={s.data.evidence}
+              />
+            </li>
+          ))}
+        </ul>
       </section>
     )
   }


### PR DESCRIPTION
## 概要

戦略詳細ページに「関連する指導法」セクションを追加し、指導法どうしを相互に行き来できるようにしました。これまで戦略ページには「この指導法を扱っているコラム」（コラム → 戦略の逆引き）はありましたが、戦略どうしを繋ぐ導線がなく、ストックした指導法が孤立していました。コラムと対称の仕組みを戦略側にも入れ、回遊性を高めます。

## 変更内容

- **スキーマ**: `strategies` に `relatedStrategies`（slug 配列、`columns` と同形）を追加
- **UI + 双方向ロジック**: `src/pages/strategies/[...slug].astro` で順引き（自分が指定した戦略）と逆引き（自分を指定している戦略）を統合表示。自己参照・重複・不在 slug を除外し、関連が無い戦略ではセクションを非表示
- **カード**: 既存の `RelatedStrategyCard.astro` を流用（効果量・エビデンス強度・出典バッジ付き）
- **パイロット初期データ（5ペア）**: 双方向のため一方の frontmatter に記述すれば両ページに相互表示されます。残りは運用で順次追加
  - 個別指導 ↔ 少人数指導
  - 夏休みの学力低下 ↔ サマースクール
  - 交互練習（インターリービング）↔ ブロック学習の落とし穴
  - 協同学習 ↔ ジグソー法
  - 分散学習（スペーシング）↔ 検索練習（テスト効果）
- **changelog**: 1 行追記

## 検証

- `npm run check` … 0 errors
- `npm run check:consistency` … 不一致なし
- `npm run build` … 成功
- `npm run test:e2e` … 42 passed
- ビルド済み HTML で以下を確認:
  - 双方向表示（順引き側・逆引き側の両ページにセクションが出る）
  - 関連未設定の戦略ではセクション非表示
  - 自己参照の除外
