### PR TITLE
test: add gated visual regression testing for visual-surface PRs

### DIFF
--- a/.github/workflows/vrt.yml
+++ b/.github/workflows/vrt.yml
@@ -1,0 +1,76 @@
+name: VRT
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "src/layouts/**"
+      - "src/components/**"
+      - "src/styles/**"
+      - "astro.config.*"
+      - "vrt/**"
+      - "playwright.vrt.config.ts"
+      - ".github/workflows/vrt.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: vrt-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  vrt:
+    name: Visual Regression
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "24"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browser
+        run: npx playwright install chromium --with-deps
+
+      - name: Build PR branch
+        run: npm run build
+
+      - name: Stash PR build
+        run: mv dist dist-pr
+
+      - name: Build main (baseline)
+        run: |
+          git worktree add /tmp/evi-main origin/main
+          npm --prefix /tmp/evi-main ci
+          npm --prefix /tmp/evi-main run build
+          mv /tmp/evi-main/dist dist-main
+
+      - name: Capture baseline from main
+        env:
+          VRT_DIST: dist-main
+        run: npx playwright test --config playwright.vrt.config.ts --update-snapshots
+
+      - name: Compare PR against baseline
+        env:
+          VRT_DIST: dist-pr
+        run: npx playwright test --config playwright.vrt.config.ts
+
+      - name: Upload VRT report
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: vrt-report
+          path: |
+            playwright-report/
+            test-results/
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,11 @@ test-results
 playwright-report
 blob-report
 
+# VRT(ADR 0024): ベースラインはコミットせず CI の 2 ビルド差分で都度生成する
+vrt/__screenshots__/
+dist-pr
+dist-main
+
 # OG 画像生成のフォントは scripts/fonts/noto-sans-jp-bold.bin をリポジトリに同梱
 # (ADR 0017、Google Fonts / jsDelivr への build-time 依存を排除)。
 # その他の binary / 派生フォントは引き続き除外する。

--- a/docs/decisions/0024-visual-regression-testing.md
+++ b/docs/decisions/0024-visual-regression-testing.md
@@ -1,0 +1,67 @@
+# ADR 0024: ビジュアルリグレッションテスト(VRT)を視覚変更 PR に限定して導入
+
+## Status
+
+採択 (2026-06-25)
+
+## Context
+
+EduEvidence JP は共有レイアウト(`src/layouts/Layout.astro`)・共有コンポーネント(`src/components/`)・単一のグローバル CSS(`src/styles/global.css`、Tailwind v4)で全ページの見た目を統一している。これらに手を入れると 70 以上の戦略ページ・コラム・各ハブへ視覚的影響が波及するが、現状その回帰は手動の目視監査(UI/UX 横断調査)でしか検出できていない。
+
+既存の `e2e.yml`(Playwright)は DOM 構造・テキスト・属性の機能テストであり、レイアウト崩れ・余白・配色といったピクセルレベルの回帰は対象外である。一方でコンテンツ(`src/content/**` の markdown)編集は毎回テキスト差分を生むため、全 PR に VRT をかけると差分がノイズだらけになる。
+
+VRT のベースラインの持ち方には 2 案がある。(A) CI 内で main と PR を両方ビルドし同一 Linux 環境で撮影して比較する案、(B) ベースライン PNG をリポジトリにコミットする案。本サイトは Web フォントを使わずシステムフォントスタック(ADR 0010)で描画するため、ローカル(macOS)と CI(Linux)でフォント描画が異なる。案 B では Linux で生成したベースラインをコミットする手間と PNG の重量が生じる。
+
+## Decision
+
+Playwright をベースに、**視覚面に触れる PR だけに走るゲート付き VRT** を案 A(2 ビルド差分)で導入する。
+
+### 既存 E2E との分離
+
+機能テストと混ざらないよう VRT を独立させる:
+
+- スペック: `vrt/`(既存機能テストの `e2e/` とは別ディレクトリ)
+- 設定: `playwright.vrt.config.ts`(`testDir: ./vrt`、desktop 1280 / mobile 390 の 2 projects、`toHaveScreenshot` の差分閾値とアニメーション無効化)
+- ベースラインはコミットしない。`vrt/__screenshots__/` は `.gitignore` で除外
+
+### 対象 URL
+
+テンプレートごとに代表 1 ページ(計 16): トップ / コラム一覧・詳細 / 戦略詳細 / 季節ハブ / 一覧(subjects・concerns)/ ガイド・用語集 / 主要静的ページ / changelog / 検索 / 404。同一テンプレートの複数ページは 1 枚で代表する。テンプレートを追加したら `vrt/pages.spec.ts` に代表 URL を 1 行追記する。
+
+### ゲート
+
+`.github/workflows/vrt.yml` を `pull_request` の `paths` フィルタで `src/layouts/**`・`src/components/**`・`src/styles/**`・`astro.config.*`・`vrt/**`・`playwright.vrt.config.ts` に限定する。`src/content/**` だけの PR では起動しない。`workflow_dispatch` で手動実行も可能。
+
+### 2 ビルド差分(案 A)
+
+CI ジョブ内で PR ブランチをビルド(`dist-pr`)、`git worktree` で main をビルド(`dist-main`)し、main を `--update-snapshots` で撮影してベースライン化、続けて PR を同一環境で撮影・比較する。両者を同じ Linux ジョブで撮るため、システムフォント差はキャンセルされ、検出される差分は実変更のみとなる。
+
+### required check に含めない
+
+VRT は視覚変更 PR でしか起動しないため、main ブランチ保護(ADR 0022)の required status checks には追加しない。結果は情報提供であり、マージ可否は編集者が判断する(rule 13)。
+
+## Consequences
+
+### 利点
+
+- 共有レイアウト・コンポーネント・`global.css` 改修時の視覚回帰を、目視に頼らず差分画像で確認できる
+- ベースラインをコミットしないため、リポジトリが PNG で肥大化せず、macOS↔Linux のフォント描画差問題も回避できる
+- コンテンツ編集 PR は対象外のため、日常のテキスト更新を妨げない
+
+### コスト
+
+- 視覚変更 PR では main と PR を 2 回ビルドするため、1 回の VRT 実行に追加のビルド時間(各ビルド約 2 分)がかかる
+- 対象 URL・差分閾値は手動メンテナンスが必要
+
+### 影響範囲
+
+- 既存 `e2e.yml`(機能テスト)は変更しない。VRT は別ワークフロー・別ディレクトリで併走する
+- ローカルでは `npm run vrt`(現在の `dist` に対する撮影・比較)で確認できる。権威ある 2 ビルド差分は CI で行う
+- パイロットは edu-evidence。確立後に edu-watch(UI を本サイトに揃えている)・edu-law・portfolio へミラーする(ADR 0023 と同じファミリー横展開方針)
+
+## References
+
+- `playwright.vrt.config.ts` / `vrt/pages.spec.ts` / `.github/workflows/vrt.yml`
+- 既存機能テスト: `playwright.config.ts` / `e2e/` / `.github/workflows/e2e.yml`
+- ADR 0010(システムフォントスタック・Web フォント不使用)/ ADR 0022(main ブランチ保護と required checks)
+- 関連 rule: 7(edu-watch の UI を本サイトに揃える)/ 9(アクセントバー scope)/ 13(マージは編集者判断)

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "check:all": "npm run check && npm run check:text && npm run check:reader-literacy && npm run check:sentence-length && npm run check:consistency && npm run check:links:source && npm run check:links",
     "test:e2e": "npx playwright test",
     "test:e2e:ui": "npx playwright test --ui",
+    "vrt": "npx playwright test --config playwright.vrt.config.ts",
     "a11y:baseline": "node scripts/a11y-baseline.mjs",
     "links:baseline": "npx tsx scripts/check-links.ts --update-baseline",
     "og:default": "npx tsx scripts/generate-default-og.ts"

--- a/playwright.vrt.config.ts
+++ b/playwright.vrt.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
   reporter: "html",
   snapshotPathTemplate: "vrt/__screenshots__/{projectName}/{arg}{ext}",
   expect: {
+    timeout: 30000,
     toHaveScreenshot: {
       maxDiffPixelRatio: 0.01,
       animations: "disabled",

--- a/playwright.vrt.config.ts
+++ b/playwright.vrt.config.ts
@@ -1,0 +1,32 @@
+import { defineConfig } from "@playwright/test";
+
+const dist = process.env.VRT_DIST ?? "dist";
+
+export default defineConfig({
+  testDir: "./vrt",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: "html",
+  snapshotPathTemplate: "vrt/__screenshots__/{projectName}/{arg}{ext}",
+  expect: {
+    toHaveScreenshot: {
+      maxDiffPixelRatio: 0.01,
+      animations: "disabled",
+      caret: "hide",
+    },
+  },
+  use: {
+    baseURL: "http://localhost:4173",
+  },
+  projects: [
+    { name: "desktop", use: { viewport: { width: 1280, height: 800 } } },
+    { name: "mobile", use: { viewport: { width: 390, height: 844 } } },
+  ],
+  webServer: {
+    command: `npx serve ${dist} -l 4173`,
+    port: 4173,
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/vrt/pages.spec.ts
+++ b/vrt/pages.spec.ts
@@ -22,6 +22,9 @@ const pages = [
 for (const p of pages) {
   test(p.name, async ({ page }) => {
     await page.goto(p.path, { waitUntil: "networkidle" });
+    await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+    await page.waitForLoadState("networkidle");
+    await page.evaluate(() => window.scrollTo(0, 0));
     await expect(page).toHaveScreenshot(`${p.name}.png`, { fullPage: true });
   });
 }

--- a/vrt/pages.spec.ts
+++ b/vrt/pages.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from "@playwright/test";
+
+const pages = [
+  { name: "home", path: "/" },
+  { name: "columns-index", path: "/columns" },
+  { name: "column-detail", path: "/columns/active-deep-learning-evidence" },
+  { name: "strategy-detail", path: "/strategies/ai-in-education" },
+  { name: "seasonal-july", path: "/seasonal/july" },
+  { name: "subjects-index", path: "/subjects" },
+  { name: "concerns-index", path: "/concerns" },
+  { name: "guide-index", path: "/guide" },
+  { name: "glossary", path: "/guide/glossary" },
+  { name: "about", path: "/about" },
+  { name: "faq", path: "/faq" },
+  { name: "voices", path: "/voices" },
+  { name: "policy-evidence", path: "/policy-evidence" },
+  { name: "changelog", path: "/changelog" },
+  { name: "search", path: "/search" },
+  { name: "not-found", path: "/404" },
+];
+
+for (const p of pages) {
+  test(p.name, async ({ page }) => {
+    await page.goto(p.path, { waitUntil: "networkidle" });
+    await expect(page).toHaveScreenshot(`${p.name}.png`, { fullPage: true });
+  });
+}


### PR DESCRIPTION
## 概要

共有レイアウト(`src/layouts/Layout.astro`)・共有コンポーネント(`src/components/`)・グローバル CSS(`src/styles/global.css`)の改修で生じる視覚回帰を検出する VRT を Playwright ベースで追加する。既存の機能テスト(`e2e/`)とは別系統で併走させる。

## 仕組み

- **視覚面 PR だけ起動**: `.github/workflows/vrt.yml` の `paths` フィルタ(`src/layouts/**`・`src/components/**`・`src/styles/**`・`astro.config.*`・VRT 関連ファイル)。コンテンツのみ(`src/content/**`)の PR では起動しない。
- **2 ビルド差分(案A)**: CI 内で main と PR を両方ビルドし、同一 Linux ジョブで撮影・比較する。ベースラインはコミットしないため、リポジトリの肥大化と macOS↔Linux のフォント描画差を回避する(本サイトは Web フォント不使用・ADR 0010)。
- **対象**: テンプレート代表 16 URL × desktop(1280) / mobile(390)。

## 構成

- `playwright.vrt.config.ts` / `vrt/pages.spec.ts`
- `.github/workflows/vrt.yml`(Action は SHA ピン留め、`permissions: contents: read`、`pull_request` トリガー)
- `docs/decisions/0024-visual-regression-testing.md`
- `package.json` に `npm run vrt`、`.gitignore` にベースライン除外

## ローカル検証

`npm run build` → `npm run vrt -- --update-snapshots`(32 passed)→ `npm run vrt`(32 passed、同一ビルドに対し差分 0 で決定性を確認)。

## 補足

- VRT は視覚変更 PR でしか起動しないため、main ブランチ保護の required status checks には追加しない(情報提供。マージ可否は編集者判断)。
- 本 PR は edu-evidence でのパイロット。確立後に edu-watch・edu-law・portfolio へミラーする。
