### PR TITLE
docs: correct stale counts in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,8 +23,8 @@ npm ci                     # 依存をロックから復元
 
 ```bash
 npm run dev                # 開発サーバー(localhost:4321)
-npm run build              # 本番ビルド(OG画像73枚 + Pagefindインデックス生成、約2分)
-npm run test:e2e           # Playwright E2Eテスト(37テスト・8ファイル、ビルド後に実行)
+npm run build              # 本番ビルド(OG画像74枚 + Pagefindインデックス生成、約2分)
+npm run test:e2e           # Playwright E2Eテスト(42テスト・9ファイル、ビルド後に実行)
 npm run a11y:baseline      # axe-core で a11y 違反一覧を再生成(dev 起動後 `node scripts/a11y-baseline.mjs http://localhost:<port>`)
 npm run check              # Astro型チェック
 npm run check:text         # textlint日本語校正
@@ -35,8 +35,8 @@ npm run check:all          # 上記チェックを一括実行
 
 ## プロジェクト構造
 
-- `src/content/strategies/*.md` — 73の指導法(frontmatter + markdown body)
-- `src/content/columns/*.md` — コラム20本
+- `src/content/strategies/*.md` — 74の指導法(frontmatter + markdown body)
+- `src/content/columns/*.md` — コラム30本
 - `src/pages/` — Astroページ(ルーティング)
 - `src/components/StrategyRow.astro` — 戦略カードコンポーネント
 - `src/layouts/Layout.astro` — 共通レイアウト(ヘッダー・フッター・ツールチップJS)


### PR DESCRIPTION
リポジトリ実態と乖離していた `CLAUDE.md` の数値を現状へ更新。

- 指導法 73 → 74（`src/content/strategies/*.md` 実数）
- コラム 20 → 30（`src/content/columns/*.md` 実数）
- OG画像 73 → 74枚（`og/[...slug].png.ts` が strategies コレクションを 1:1 生成）
- E2E 37テスト・8ファイル → 42テスト・9ファイル（`npx playwright test --list` の Total）

ドキュメントのみの変更で、コード・ビルド・テストへの影響なし。
