### PR TITLE
ci: align workflow Node version to local (22 → 24)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: "22"
+          node-version: "24"
           cache: "npm"
 
       - name: Install dependencies

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: "22"
+          node-version: "24"
           cache: "npm"
 
       - name: Install dependencies

--- a/.github/workflows/stale-check.yml
+++ b/.github/workflows/stale-check.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: "22"
+          node-version: "24"
           cache: "npm"
 
       - name: Install dependencies


### PR DESCRIPTION
## 概要

GitHub Actions の Node セットアップバージョンをローカル環境に揃える。

## 背景

ローカルは `.tool-versions` で `nodejs 24.17.0` に固定し、`package.json` の `engines.node` は `>=24.0.0`。一部の workflow が Node 22 を指定しており、この engines 制約に反していた。

## 変更

`e2e.yml` / `link-check.yml` / `stale-check.yml` の `node-version` を `"22"` から `"24"` に変更。`vrt.yml` は既に `"24"` のため変更なし。これで 4 つの workflow すべてが Node 24 で揃う。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
