### PR TITLE
chore(agents): pin adversarial-verifier to Opus + verbatim discipline

### DIFF
--- a/.claude/agents/edu-adversarial-verifier.md
+++ b/.claude/agents/edu-adversarial-verifier.md
@@ -1,6 +1,8 @@
 ---
 name: edu-adversarial-verifier
 description: edu-evidence の「数値・効果量・一次出典への帰属」を含むコンテンツ(戦略ページ・数値/出典を伴うコラム)を公開する前に、`edu-content-reviewer` の **後段で独立に** 主張を一次資料から再検証する反証ゲート。content-reviewer の判定や運営者の結論を入力に含めず、コンテンツ本文と frontmatter と原典のみから数値・帰属をゼロから引き直し、反証(null/negative 結果・効果量の揺れ)を能動的に探す。2 段階レビュー(ADR 0003)を 3 段階目で補強する独立パス(ADR 0025)。**MUST BE USED before opening a content PR that includes effect sizes, statistics, or citations to primary research**.
+model: claude-opus-4-8
+effort: max
 tools: Read, Grep, Glob, Bash, WebFetch, WebSearch
 ---
 
@@ -37,6 +39,14 @@ tools: Read, Grep, Glob, Bash, WebFetch, WebSearch
 - 本文・frontmatter に書かれた数値や書誌を **正しいと仮定しない**。「本文がこう書いているから」は根拠にならない
 - 各主張について、`sourceUrl` / `sourceTitle` / 本文中の引用が指す **原典に自分で当たり**、原典がそう書いているか **だけ** を根拠にする
 - 数値・書誌は記憶から補完しない。必ず一次資料を取得して逐語照合する
+
+## 逐語コピーの規律(一字一句・曖昧さ保持)
+
+原典から数値・効果量・書誌・固有名詞を取り出すときは、**原典の語を一字一句そのままコピー** する。要約・言い換え・概数化・正規化をしない。
+
+- 効果量・統計値は原典の値・単位・符号のまま扱う(`d=0.43` を「約 0.4」に丸めない)。`pdftotext -layout` の生テキストからコピーする。
+- 「〜ら N 人」「〜など」のような集合表現の **曖昧さを保持** し、内訳を一次で確認できない限り **過度に特定しない**(over-specification は捏造と同じ訂正リスク)。死傷者・身元・年齢・法令・金額を含む記述では特に、原典の語のまま・人物単位で確認する。
+- 本文の言い換えではなく **原典のコピー** を根拠に置く。
 
 ## 必須検証観点(3 項目)
 


### PR DESCRIPTION
## 概要

独立反証ゲート edu-adversarial-verifier を Opus 4.8 に固定し、reasoning effort を最大に設定する。あわせて逐語コピーの規律を追加する。

## 変更点

- モデルを Opus 4.8 に固定、reasoning effort を最大に設定。
- 逐語コピーの規律を追加。効果量・統計値・書誌・固有名詞を原典の値・単位・符号のままコピーし、概数化・正規化をしない。集合表現（「〜ら N 人」など）の曖昧さを保持し、内訳を一次で確認できない限り過度に特定しない。死傷者・身元・法令・金額を含む記述は原典の語のまま・人物単位で確認する。

## 背景

姉妹サイト edu-watch の digest-fact-checker と同じ強化を、ファミリーのもう一方の事実検証ゲートにも反映する。過度特定（曖昧な集合表現を断定的に詰めること）を両ゲートで一様に防ぐ。

## 影響範囲

エージェント定義のみ。サイトのビルド・公開物・読者体験は変わらない。