### PR TITLE
fix(content): reattribute UIFSM bodyweight effect size to Holford & Rabe (2022)

### DIFF
--- a/src/content/columns/school-lunch-free-followup.md
+++ b/src/content/columns/school-lunch-free-followup.md
@@ -61,7 +61,7 @@ series:
 
 ### 英国: 全員一律化で小 1 の肥満率が下がった
 
-イングランドは 2014 年から **UIFSM**(Universal Infant Free School Meals、5–7 歳全員)を実施しています。Holford & Rabe (2024) の [*Journal of Health Economics*](https://www.sciencedirect.com/science/article/pii/S0167629624000821) は、政策前後の National Child Measurement Programme データを分析した研究です。UIFSM 導入後、小 1 で **BMI が約 0.041 SD 低下、肥満率が 0.7 ポイント低下** という結果です。SD は標準偏差換算の効果量で 0.2 程度から「小」が目安、0.041 SD は集団平均の微小な変化、0.7 ポイントは実数の有病率差です。低所得地域でより大きな改善が見られた点は重要です。
+イングランドは 2014 年から **UIFSM**(Universal Infant Free School Meals、5–7 歳全員)を実施しています。Holford & Rabe (2022) の [*Journal of Public Economics Plus*](https://www.sciencedirect.com/science/article/pii/S2666551422000031) は、政策前後の National Child Measurement Programme データを分析した研究です。UIFSM 導入後、小 1 で **BMI が約 0.043 SD 低下、肥満率が 0.7 ポイント低下** という結果です。SD は標準偏差換算の効果量で 0.2 程度から「小」が目安、0.043 SD は集団平均の微小な変化、0.7 ポイントは実数の有病率差です。
 
 ### 韓国: 生徒間の暴力行為が 35% 減った
 
@@ -149,7 +149,7 @@ series:
 
 - Babad, E. Y., Inbar, J., & Rosenthal, R. (1982). [Pygmalion, Galatea, and the Golem: Investigations of biased and unbiased teachers](https://doi.org/10.1037/0022-0663.74.4.459). *Journal of Educational Psychology*, 74(4), 459–474. — 教師期待バイアスの負の側面(ゴーレム効果)を実験的に検証した古典研究。
 - Lundborg, P., Rooth, D.-O., & Alex-Petersen, J. (2022). [Long-Term Effects of Childhood Nutrition: Evidence from a School Lunch Reform](https://doi.org/10.1093/restud/rdab028). *Review of Economic Studies*, 89(2), 876–908. — スウェーデン段階導入を自然実験として活用。生涯所得 +3%、低所得層 +6%、身長 +0.5〜0.7cm(性別差あり)、教育年数 +0.3 年。
-- Holford, A., & Rabe, B. (2024). [Universal free school meals and children's bodyweight. Impacts by age and duration of exposure](https://www.sciencedirect.com/science/article/pii/S0167629624000821). *Journal of Health Economics*, 98, 102937. — 英 UIFSM 導入で小 1 の BMI -0.041 SD、肥満率 -0.7pt。
+- Holford, A., & Rabe, B. (2022). [Going universal. The impact of free school lunches on child body weight outcomes](https://www.sciencedirect.com/science/article/pii/S2666551422000031). *Journal of Public Economics Plus*, 3, 100016. — 英 UIFSM 導入で小 1 の BMI -0.043 SD、肥満率 -0.7pt。
 - Altindag, D. T., Baek, D., Lee, H., & Merkle, J. (2020). [Free Lunch for All? The Impact of Universal School Lunch on Student Misbehavior](https://doi.org/10.1016/j.econedurev.2019.101945). *Economics of Education Review*, 74: 101945. — 韓国の Free School Meal Program 段階導入を自然実験として分析。無償給食対象校で生徒間の暴力行為(physical fights)が約 35% 減少。
 - Toossi, S. (2024). State Universal Free School Meal Policies Reduced Food Insufficiency Among Children in the 2022–2023 School Year. USDA Economic Research Service [*Amber Waves* (2024-06)](https://www.ers.usda.gov/amber-waves/2024/june/state-universal-free-school-meal-policies-reduced-food-insufficiency-among-children-in-the-2022-2023-school-year) によるレビュー. — CA・ME 等の州別恒久化による子どもの食料不足発生率の低下。
 - Patterson, E., & Schäfer Elinder, L. (2015). [Improvements in school meal quality in Sweden after the introduction of new legislation—a 2-year follow-up](https://doi.org/10.1093/eurpub/cku184). *European Journal of Public Health*, 25(4), 655–660. — スウェーデン栄養基準法制化(2011)前後 2 年で 4 項目を追跡し、有意改善は食物繊維(68% → 80%)と鉄(70% → 75%)の 2 項目のみ。脂質質・ビタミン D は変化なし。


### PR DESCRIPTION
## 概要

コラム「給食無償化のその後」の英国節と参考文献で、UIFSM（2014 年英国全国政策・5–7 歳）の子どもの体重への効果の出典を訂正する。

## 背景

当該箇所は効果を Holford & Rabe (2024)『Journal of Health Economics』98, 102937 に帰属していた。しかしこの論文はロンドン 4 区の地方自治体独自スキームを分析したもので、全国 UIFSM を対象としていない。記載の数値・枠組（全国 UIFSM・4–5 歳・肥満率 −0.7pt）は、全国 UIFSM を分析した Holford & Rabe (2022)「Going universal. The impact of free school lunches on child body weight outcomes」『Journal of Public Economics Plus』3, 100016 の見出しと一致する。著者は同じだが、論文・年・掲載誌・効果量の桁が異なる誤帰属だった。

## 変更点

- 本文・参考文献の引用を 2022 年「Going universal」（J Pub Econ Plus 3, 100016）へ付け替え、URL を同論文のもの（ゴールドオープンアクセス）に統一。
- BMI の効果量を **−0.041 SD → −0.043 SD** に訂正。−0.043 は原典（ワーキングペーパー版の要旨・結論・Table 4、および著者所属機関 ISER の公刊論文ページ）で逐語確認。−0.041 はいずれの論文にも効果量として現れない。
- 末尾の「低所得地域でより大きな改善が見られた点は重要です」を削除。2022 年論文の異質性分析は逆の結果（効果は従来の無償対象外＝比較的余裕のある層に集中）を示す。

## 検証

- 肥満率 −0.7 ポイントは原典で逐語確認済み（変更なし）。
- 効果量 −0.043 SD はワーキングペーパー版と ISER 公刊論文ページで一致。公刊版本体の表は出版社のボット対策で取得できず、表レベルの逐語照合は未了。
- `astro check`（0 errors / 0 warnings）・`textlint`・整合性チェックいずれも通過。
- lastVerified は同日訂正のため 2026-07-02 のまま据え置き。
