### PR TITLE
fix(content): correct scaffolding effect size and MEXT room-shortage announcement month in special-needs column

### DIFF
--- a/src/content/columns/special-needs-8-8-percent.md
+++ b/src/content/columns/special-needs-8-8-percent.md
@@ -27,7 +27,7 @@ relatedStrategies: ["scaffolding", "feedback", "metacognition", "universal-desig
 
 ## 受け皿の問題 — 特別支援学校の教室不足
 
-2026 年 3 月、文科省は令和 7 年(2025 年)10 月時点の **特別支援学校の不足教室数 3,192** と発表しました。前回比 −167 教室と改善傾向ではありますが、依然として深刻です。
+2026 年 4 月、文科省は令和 7 年(2025 年)10 月時点の **特別支援学校の不足教室数 3,192** と発表しました。前回比 −167 教室と改善傾向ではありますが、依然として深刻です。
 
 つまり構造として:
 
@@ -61,7 +61,7 @@ Five-a-day の各原則は、本サイトの戦略と次のように対応しま
 |---|---|---|
 | 明示的指導 | [直接教授法(明示的指導)](/strategies/direct-instruction) | +5ヶ月 |
 | メタ認知方略 | [メタ認知の指導](/strategies/metacognition) | +8ヶ月 |
-| 足場かけ | [足場かけ](/strategies/scaffolding) | +5ヶ月 |
+| 足場かけ | [足場かけ](/strategies/scaffolding) | +4ヶ月 |
 | 柔軟なグルーピング | [少人数指導](/strategies/small-group-tuition) / [個別指導](/strategies/one-to-one-tuition) | +4 / +5ヶ月 |
 | テクノロジー活用 | [ICT活用](/strategies/digital-technology) | +4ヶ月 |
 


### PR DESCRIPTION
コラム「通常学級の 8.8%」（`special-needs-8-8-percent`）の事実2点を一次情報で再検証し訂正した。

## 訂正1: 足場かけの効果量 +5ヶ月 → +4ヶ月

「Five-a-day」対応表の「足場かけ」行を、戦略ページ `scaffolding` の効果量（+4ヶ月）に揃えた。戦略側は Belland et al. (2017) のメタ分析（Hedges' g = 0.46）を代表値として +4ヶ月を採り、Hattie の d = 0.82 は上端寄りの推定として代表値には用いない旨を明記している。対応表の他5行（明示的指導・メタ認知・少人数指導・個別指導・ICT活用）は各戦略ページと一致しており、不一致は足場かけの1行のみだった。

## 訂正2: 特別支援学校の教室不足の発表月 2026年3月 → 2026年4月

文部科学省「公立特別支援学校における教室不足調査（令和7年10月1日現在）」の公表日は令和8年（2026年）4月10日。報道発表ページと結果PDF本文の双方に「令和8年4月10日」と明記されている。旧「2026年3月」は結果PDFのファイル名に含まれる日付（`20260324` ＝ ファイル登録日）であって、公表日ではない。

不足教室数「3,192」・前回比「−167（減少）」・基準時点「令和7年10月1日現在」は原典と一致しており、変更していない。

出典（curl + pdftotext による逐語照合）:
- 報道発表: https://www.mext.go.jp/b_menu/houdou/mext_01618.html
- 結果PDF: https://www.mext.go.jp/content/20260324-mxt_sisetujo-000048497_01.pdf

## 対象ファイル

- `src/content/columns/special-needs-8-8-percent.md`（2行）

本文の細部訂正のため、`lastVerified` と changelog は据え置いている。
