### PR TITLE
fix(content): correct Cooper (2006) meta-analysis study count from ~50 to 32 in homework column

### DIFF
--- a/src/content/columns/homework-quantity-myth.md
+++ b/src/content/columns/homework-quantity-myth.md
@@ -19,7 +19,7 @@ relatedStrategies: ["homework", "feedback", "individualised-instruction"]
 
 ## 研究が示していること
 
-Cooper et al. (2006) の約50研究のメタ分析では、宿題と学力の関係は以下の通りでした。
+Cooper et al. (2006) のメタ分析(宿題時間と学力の相関を分析した 32 研究)では、宿題と学力の関係は以下の通りでした。
 
 - **中学・高校** では宿題と学力に明確な正の相関
 - **小学校** では関係が弱く、効果が限定的

--- a/src/content/strategies/homework.md
+++ b/src/content/strategies/homework.md
@@ -78,7 +78,7 @@ culturalContext: |
 
 ## 主な参考研究
 
-- Cooper, H., Robinson, J. C., & Patall, E. A. (2006). [Does homework improve academic achievement?](https://doi.org/10.3102/00346543076001001) *Review of Educational Research*, 76(1), 1–62. — 約50研究のメタ分析。宿題と学力の関係は正だが、小学校段階では中高に比べて効果が小さいことを示した。
+- Cooper, H., Robinson, J. C., & Patall, E. A. (2006). [Does homework improve academic achievement?](https://doi.org/10.3102/00346543076001001) *Review of Educational Research*, 76(1), 1–62. — 宿題時間と学力の相関を分析した 32 研究などを統合したメタ分析。宿題と学力の関係は正だが、小学校段階では中高に比べて効果が小さいことを示した。
 - Fan, H., Xu, J., Cai, Z., He, J., & Fan, X. (2017). [Homework and students' achievement in math and science](https://doi.org/10.1016/j.edurev.2016.11.003). *Educational Research Review*, 20, 35–54. — 数学・理科に限定したメタ分析。宿題の量より質(フィードバック付き)が重要であることを確認。
 - Fernández-Alonso, R., Suárez-Álvarez, J., & Muñiz, J. (2015). Adolescents' homework performance in mathematics and science. *Journal of Educational Psychology*, 107(4), 1075–1092. — 宿題の最適な時間は1日60〜70分程度で、それ以上は効果が頭打ちになることを示した。
 


### PR DESCRIPTION
## 修正内容

宿題コラムと宿題戦略ページで、Cooper et al. (2006) のメタ分析を「約50研究」と記していた箇所を実数へ是正します。

- `src/content/columns/homework-quantity-myth.md` L22 — 「約50研究のメタ分析」→「メタ分析(宿題時間と学力の相関を分析した 32 研究)」
- `src/content/strategies/homework.md` L81(参考研究) — 「約50研究のメタ分析」→「宿題時間と学力の相関を分析した 32 研究などを統合したメタ分析」

## 一次照合

Cooper, Robinson & Patall (2006) *Review of Educational Research*, 76(1), 1–62 の原典で確認しました。

- 宿題時間と学力の相関を分析した対象は **32研究**(69相関・35サンプル)。原典 p.29「uncovered 32 studies ... correlations」。
- 「約50」は Cooper (1989) の旧レビューが扱った研究数(原典 p.4「Cooper found 50 studies」)であり、2006年版と取り違えた誤帰属でした。
- なお2006年原典には別途「69の相関のうち50が正の方向」という記述がありますが、これは相関の向きの内訳であって研究数ではありません(混同しやすい第二の「50」)。

## 内部整合

戦略ページの methodology は既に「相関32研究」として正しく記載されており、本文・参考欄をこれに整合させることで、本文(約50)と methodology(32)の内部不整合も解消します。

## 影響範囲

数値の帰属先の訂正であり、宿題の効果に関する結論は変わりません。効果量(monthsGained)・changelog・最終検証日(lastVerified)は不変です。