### PR TITLE
ci(link-check): accept 405/406 status codes to stop UA-gated false positives

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -56,7 +56,7 @@ jobs:
             --cache
             --max-cache-age 1d
             --root-dir ${{ github.workspace }}/dist
-            --accept 200,201,202,203,204,206,301,302,303,307,308,403,429,503,520
+            --accept 200,201,202,203,204,206,301,302,303,307,308,403,405,406,429,503,520
             --exclude 'doi\.org/10\.1037'
             --exclude 'doi\.org/10\.5951'
             --exclude 'us\.corwin\.com'


### PR DESCRIPTION
## 概要
週次リンクチェック(lychee)の誤検知 Issue #333 の恒久対処。検出された 3 URL はすべて生存を確認済みで、コンテンツ修正は不要。`.github/workflows/link-check.yml` の `--accept` に 405/406 を追加し、bot ブロック由来の誤検知が Issue 化されないようにする。

## 背景
2026-06-29 の自動リンクチェックが以下を「リンク切れ」として検出し Issue #333 を作成した。

| URL | 使用箇所 | lychee の結果 |
|---|---|---|
| `j-sla.or.jp/.../dokusyotyousa.html` | `reading-quantity-myth.md` / `about.astro` | TIMEOUT ×2 |
| `gov.wales/.../…free-school-meals-…-interim-report.pdf` | `school-lunch-free-followup.md` | 405 |
| `synodos.jp/opinion/education/12530/` | `reducing-class-size.md` | TIMEOUT |

2026-07-05 に 3 URL を再検証したところ、いずれもブラウザ UA で HTTP 200 を返し生存していた。

- **gov.wales**(唯一の "Error"): 非ブラウザ UA を拒否する WAF。Chrome UA → 200、lychee/bot UA → 403〜405。lychee レポート自身も "Rejected status code: 405 …(configurable with 'accept' option)" と示唆している。
- **j-sla / synodos**: 一時的タイムアウト。再検証では 0.29s / 0.37s で応答。HTTP status ではないため `--accept` では吸収できない別枠(再発は散発的)。

`--accept` は同じ bot ブロック対策として 403/429/503/520 を既に許容していたが、gov.wales が返す 405 が抜けていた。

## 変更内容
`--accept` に `405,406` を追加。

- 405 = Method Not Allowed(HEAD 不可)、406 = Not Acceptable。いずれも「リソースは在るが、この UA / メソッドを拒否」を意味し、死リンク(404 / 410 / DNS 失敗)とは異なる。
- 既存の 403 許容と同一の意図(出版社・公的機関サイトの bot ブロック)に沿う。

## 影響範囲
- コンテンツ・changelog の変更なし(全リンク生存のため修正不要)。
- 理論上 405/406 を返す真の死リンクを見逃す可能性はあるが、死リンクは通常 404/410 で現れるため副作用は小さい。
- タイムアウト 2 件は本 PR の対象外(一時的・status 非該当)。

## 検証
- gov.wales PDF: `curl -A "<Chrome UA>"` → 200 / `curl -A "lychee/…"` → 403(HEAD・GET とも)。UA ゲーティングを確認。
- j-sla / synodos: Chrome UA で 200(0.29s / 0.37s)。
- 3 URL とも `src/content` / `src/pages` 上の書誌・引用が正しいことを確認済み。

Closes #333
