### PR TITLE
chore(dependabot): ignore astro/@astrojs/react major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,15 @@ updates:
     ignore:
       - dependency-name: "typescript"
         update-types: ["version-update:semver-major"]
+      # astro 7 は既定の Markdown プロセッサが "Sätteri" に切り替わり、
+      # @astrojs/markdown-remark を同梱しなくなるため、現行の
+      # markdown.remarkPlugins / rehypePlugins 設定を壊す
+      # (コンパイラも Rust 実装に移行済み)。移行方針を検討するまで、
+      # astro / @astrojs/react の major 更新を除外する。
+      - dependency-name: "astro"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@astrojs/react"
+        update-types: ["version-update:semver-major"]
     groups:
       astro-ecosystem:
         patterns:


### PR DESCRIPTION
Astro 7 makes "Sätteri" the default Markdown processor, which no longer bundles `@astrojs/markdown-remark`. This breaks builds that configure `markdown.remarkPlugins` / `rehypePlugins`, which this project does. The compiler has also moved to a Rust implementation. Migrating to Astro 7 and the accompanying `@astrojs/react` 6 requires reviewing these breaking changes first, so the migration is intentionally deferred.

A grouped Dependabot PR bumping `astro` 6→7 and `@astrojs/react` 5→6 keeps recurring since Dependabot has no way to know the bump is deferred (most recently #353). This adds `ignore` entries for `astro` and `@astrojs/react` restricted to major version updates, so Dependabot stops proposing this specific bump until the migration is planned. Minor and patch updates for both packages are unaffected.

PR #353 is superseded by this change and is being closed separately.