### PR TITLE
fix(deps): force js-yaml to non-vulnerable versions to resolve CVE-2026-53550

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6637,9 +6637,9 @@
       }
     },
     "node_modules/gray-matter/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7803,9 +7803,19 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -10231,9 +10241,9 @@
       }
     },
     "node_modules/prh/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,24 @@
   "overrides": {
     "esbuild": "^0.28.1",
     "vite": "^7.3.5",
-    "@babel/core": "^7.29.6"
+    "@babel/core": "^7.29.6",
+    "astro": {
+      "js-yaml": "^4.2.0"
+    },
+    "@astrojs/internal-helpers": {
+      "js-yaml": "^4.2.0"
+    },
+    "@textlint/linter-formatter": {
+      "js-yaml": "^4.2.0"
+    },
+    "rc-config-loader": {
+      "js-yaml": "^4.2.0"
+    },
+    "gray-matter": {
+      "js-yaml": "^3.15.0"
+    },
+    "prh": {
+      "js-yaml": "^3.15.0"
+    }
   }
 }


### PR DESCRIPTION
`js-yaml` is a transitive dependency (not declared directly in package.json), pulled in through two independent chains: `astro` / `@astrojs/internal-helpers` / `@textlint/linter-formatter` / `rc-config-loader` resolve a shared top-level copy, while `gray-matter` and `prh` (via `textlint-rule-prh`) each carry their own nested copy.

GHSA-h67p-54hq-rp68 / CVE-2026-53550 describes a quadratic-complexity denial-of-service in js-yaml's merge-key (`<<`) handling, reachable when parsing YAML containing many repeated aliases in a merge sequence. The advisory lists two affected ranges, which map to two separate Dependabot alerts against this lockfile:

- Alert 34 (runtime scope): `js-yaml` >=4.0.0,<=4.1.1 — the shared top-level copy, resolved at 4.1.1. Fixed in 4.2.0.
- Alert 35 (development scope): `js-yaml` <3.15.0 — the gray-matter/prh copies, resolved at 3.14.2. Fixed in 3.15.0.

Both are fixed here via npm `overrides`, scoped by parent package rather than a single blanket override on `js-yaml`. A blanket override would force gray-matter's and prh's nested copies onto the 4.x line too; gray-matter's bundled code calls the js-yaml v3 API (`yaml.safeLoad` / `yaml.safeDump`), which js-yaml 4.x keeps as functions that throw at call time instead of parsing. Since gray-matter is used by the project's `remarkStrategyRef` build plugin as well as several content-check scripts, a blanket override breaks every markdown frontmatter parse in the project. Scoping the override lets the four packages that already require `^4.1.1` move to `^4.2.0`, while `gray-matter` and `prh` move only to `^3.15.0`, which stays within both packages' own declared `js-yaml` ranges.

After `npm install`, all three physical `js-yaml` resolutions in package-lock.json are non-vulnerable (top-level 4.3.0; gray-matter's and prh's nested copies 3.15.0). `npm run check` (typecheck), `npm run build` (production build — exercises the gray-matter-dependent remark plugin across all content), `npm run check:text` (textlint, exercises prh), and `npm run check:consistency` (direct gray-matter usage) all pass with no new failures.

Resolves Dependabot security alerts 34 and 35.