### PR TITLE
ci(link-check): add gov.wales interim-report URL to known-issues baseline

### DIFF
--- a/scripts/links-known-issues.json
+++ b/scripts/links-known-issues.json
@@ -6,6 +6,7 @@
   "https://pubs.nctm.org/view/journals/jrme/48/3/article-p261.xml": 403,
   "https://schoolmealscoalition.org/sites/default/files/2024-05/Brennan_etal_2022_School_Meals_Case_Study_Scotland.pdf": 403,
   "https://schoolmealscoalition.org/sites/default/files/2024-05/Kuusipalo_Manninen_2023_Food_Meals_Case_Study_Finland.pdf": 403,
+  "https://www.gov.wales/sites/default/files/statistics-and-research/2026-02/evaluation-of-welsh-governments-universal-free-school-meals-policy-interim-report.pdf": 403,
   "https://www.jstor.org/stable/4609267": 403,
   "https://www.sbcr.jp/product/4815633417/": 403,
   "https://www.sciencedirect.com/science/article/pii/S0167629624000821": 403,


### PR DESCRIPTION
## 概要
`npm run check:links` で www.gov.wales の PDF が broken 判定されていたが、CloudFront がボット UA を 403 で弾く既知の偽陽性。ブラウザ / curl では HTTP 200 を返す。他のボット対策ドメイン(doi.org / jstor.org 等)と同様に known-issues baseline へ登録し、NEW broken 判定から除外する。

## 対象 URL
https://www.gov.wales/sites/default/files/statistics-and-research/2026-02/evaluation-of-welsh-governments-universal-free-school-meals-policy-interim-report.pdf

- linkinator(bot UA): 403
- ブラウザ / curl(browser・default UA とも): 200 / application/pdf / 約 591KB
- 参照元: `src/content/columns/school-lunch-free.md`
- 一次資料(ICF / Arad によるウェールズ給食無償化政策の中間評価)は実在

## 確認
`npm run check:links` → 新規 broken 0 / exit 0(緑)