### PR TITLE
ci: purge Cloudflare edge cache after Pages deploy

### DIFF
--- a/.github/workflows/cf-purge.yml
+++ b/.github/workflows/cf-purge.yml
@@ -1,0 +1,81 @@
+# Purge the Cloudflare edge cache after a Cloudflare Pages deployment goes live.
+#
+# Why: HTML pages on edu-evidence.org are edge-cached via a Cache Rule
+# (Edge TTL 10 min). A Cloudflare Pages deploy does NOT purge a zone-level
+# Cache Rule cache, so without this a content fix could be served stale until
+# the Edge TTL expires. This waits for the Pages deployment of the pushed
+# commit to reach "success", then purges the zone so the corrected HTML is
+# served immediately.
+#
+# Required repository secrets:
+#   CLOUDFLARE_API_TOKEN  - token scoped to this zone with
+#                           Account > Cloudflare Pages: Read
+#                           and  Zone > Cache Purge: Edit
+#   CLOUDFLARE_ACCOUNT_ID - Cloudflare account id
+#   CLOUDFLARE_ZONE_ID    - edu-evidence.org zone id
+name: Purge Cloudflare cache on deploy
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  # A later push's purge supersedes an in-flight one (purge is zone-wide).
+  group: cf-purge
+  cancel-in-progress: true
+
+jobs:
+  purge:
+    name: Wait for Pages deploy, then purge cache
+    runs-on: ubuntu-latest
+    steps:
+      - name: Purge after deployment is live
+        env:
+          CF_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CF_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CF_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${CF_API_TOKEN}" ] || [ -z "${CF_ACCOUNT_ID}" ] || [ -z "${CF_ZONE_ID}" ]; then
+            echo "::error::Missing CLOUDFLARE_API_TOKEN / CLOUDFLARE_ACCOUNT_ID / CLOUDFLARE_ZONE_ID secret"
+            exit 1
+          fi
+
+          sha="${GITHUB_SHA}"
+          api="https://api.cloudflare.com/client/v4"
+          live=0
+
+          # Poll the Pages deployments API until this commit's production
+          # deployment reports success (max ~10 min).
+          for i in $(seq 1 40); do
+            status=$(curl -sS -H "Authorization: Bearer ${CF_API_TOKEN}" \
+              "${api}/accounts/${CF_ACCOUNT_ID}/pages/projects/edu-evidence/deployments?per_page=10" 2>/dev/null \
+              | jq -r --arg sha "$sha" \
+                'first(.result[]? | select(.environment == "production" and .deployment_trigger.metadata.commit_hash == $sha) | .latest_stage.status) // "pending"' \
+              2>/dev/null || echo "pending")
+            echo "attempt ${i}: deployment status = ${status}"
+            case "${status}" in
+              success) live=1; break ;;
+              failure|canceled) echo "deployment did not succeed (${status}); skipping purge"; exit 0 ;;
+              *) sleep 15 ;;
+            esac
+          done
+
+          if [ "${live}" -ne 1 ]; then
+            echo "::warning::Timed out waiting for deployment ${sha}; skipping purge"
+            exit 0
+          fi
+
+          echo "Deployment live; purging zone cache"
+          resp=$(curl -sS -X POST \
+            -H "Authorization: Bearer ${CF_API_TOKEN}" \
+            -H "Content-Type: application/json" \
+            "${api}/zones/${CF_ZONE_ID}/purge_cache" \
+            --data '{"purge_everything":true}')
+          echo "${resp}" | jq -e '.success == true' >/dev/null \
+            || { echo "::error::Purge failed: ${resp}"; exit 1; }
+          echo "Cache purged."


### PR DESCRIPTION
## 背景
edu-evidence.org の HTML は現状エッジキャッシュされず（`cf-cache-status: DYNAMIC`）、実リクエストが毎回 Pages オリジンへ fetch されて TTFB が 0.8〜2.8s と遅い。対策として zone Cache Rule で HTML をエッジキャッシュ化する（Edge TTL 10 分）。

Cloudflare Pages のデプロイは zone レベル Cache Rule のキャッシュを自動 purge しない。このため、コンテンツ修正をデプロイしても Edge TTL 満了まで旧版が配信されうる。

## 変更
main への push 後、該当コミットの production デプロイが success になるのを待ってから zone を purge する GitHub Actions workflow を追加する。

- Pages Deployments API をポーリング（最大約 10 分）し、`environment == "production"` かつ `deployment_trigger.metadata.commit_hash == GITHUB_SHA` の `latest_stage.status` を確認する
- success のときのみ `purge_everything` を実行する
- failure / canceled / タイムアウト時は purge をスキップする（デプロイ完了前に purge して旧版を再キャッシュする事故を防ぐ）

## マージ前に必要な設定
リポジトリ secrets を 3 つ登録する。

- `CLOUDFLARE_API_TOKEN` — 当ゾーンにスコープした Account › Cloudflare Pages: Read ＋ Zone › Cache Purge: Edit の最小権限トークン
- `CLOUDFLARE_ACCOUNT_ID`
- `CLOUDFLARE_ZONE_ID`

## 補足
対をなす Cloudflare 側の設定（HTML の Cache Rule 作成、Early Hints 無効化）はダッシュボードで別途適用する。適用範囲は当面 edu-evidence.org のみで、law / watch は現状維持とする。

🤖 Generated with [Claude Code](https://claude.com/claude-code)