### PR TITLE
feat: add Cloudflare Web Analytics beacon with manual snippet

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -4,7 +4,7 @@
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: camera=(), microphone=(), geolocation=()
   X-XSS-Protection: 0
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; connect-src 'self' https://static.cloudflareinsights.com; frame-src 'none'; object-src 'none'; base-uri 'self'
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; connect-src 'self' https://static.cloudflareinsights.com https://cloudflareinsights.com; frame-src 'none'; object-src 'none'; base-uri 'self'
   Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
 
 /_astro/*

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -92,6 +92,13 @@ const escapeLd = (obj: object): string => JSON.stringify(obj).replace(/</g, "\\u
     {breadcrumbJsonLd && (
       <script type="application/ld+json" set:html={escapeLd(breadcrumbJsonLd)} />
     )}
+
+    <!-- Cloudflare Web Analytics -->
+    <script
+      is:inline
+      type="module"
+      src="https://static.cloudflareinsights.com/beacon.min.js"
+      data-cf-beacon='{"token": "14afdc722e86475ca003f42c859d679d"}'></script>
   </head>
   <body class="bg-[var(--color-bg)] text-[var(--color-ink)]" data-menu="closed">
     <a href="#main-content" class="skip-link">本文へスキップ</a>


### PR DESCRIPTION
## 概要

Layout の `</head>` 直前に Cloudflare Web Analytics のビーコンを手動スニペットで追加する(edu-evidence.org 用サイトトークン)。あわせて CSP の connect-src にビーコン送信先 `https://cloudflareinsights.com` を追加。

## 背景

Web Analytics はエッジ自動注入で 3 ヶ月前から動作していたように見えたが、WA サイトのセットアップモード不整合により RUM 収集エンドポイントがビーコン POST を 503 で拒否し、記録イベントは 0 件だった(DevTools 実測 + [Cloudflare community の既知問題](https://community.cloudflare.com/t/web-analytics-beacon-consistently-fails-at-cdn-cgi-rum-404-503-zero-events-r/938474))。ダッシュボード側は本日、自動注入を停止し「JS スニペットのインストールで有効」モードへ移行済み。自動注入の停止は次回デプロイ時に反映されるため、本 PR のデプロイで「注入停止」と「スニペット有効化」が同時に切り替わり、二重計測は発生しない。

## Security note

外部スクリプトだが SRI(integrity)は意図的に付与しない。beacon.min.js は Cloudflare が継続更新する evergreen スクリプトで、ハッシュ固定は CF 側更新のたびにロード失敗＝無音の計測停止(今回の障害と同型)を再発させる。読込元は CSP の script-src で `static.cloudflareinsights.com` に固定済みで、ホスティング(CF Pages)と同一信頼境界のため SRI の追加防御効果は限定的。

## 確認

- `npm run check` 0 errors / 0 warnings
- デプロイ後: `POST https://cloudflareinsights.com/cdn-cgi/rum` が 204 を返すこと、ダッシュボードにイベントが記録されること(反映まで〜10 分)を実測確認する

🤖 Generated with [Claude Code](https://claude.com/claude-code)