### PR TITLE
docs: backfill ADR for Web Analytics beacon and CSP change

### DIFF
--- a/docs/decisions/0026-web-analytics-beacon-and-csp.md
+++ b/docs/decisions/0026-web-analytics-beacon-and-csp.md
@@ -1,0 +1,32 @@
+# 0026. Cloudflare Web Analytics を手動スニペット方式で導入し CSP を最小限緩和する
+
+- 状態: 採用
+- 日付: 2026-07-12(決定・実施)。本 ADR は 2026-07-15 の追認記録(実施時に起票漏れ)
+- 関連 PR: #366
+- 関連 ADR: okinawa-in-data `docs/decisions/0002`(同方式の初出 ADR)/ 姉妹ミラー: edu-watch 0062・edu-law 0024・isagawa-hayato-portfolio 0006
+
+## 背景
+
+2026-07 の到達度改善診断で「計測」が最弱軸(実訪問データが取得できていない)と判明した。Web Analytics(WA)自体は過去に設定済みだったが、**WA サイトのセットアップモード(自動)とビーコン注入の組合せ不整合により、RUM 収集の POST が 503 で拒否され約 3 ヶ月イベント 0 件**という無音故障を起こしていた(DevTools 実測+コミュニティ既知問題として確認。CSP 原因説は検証の結果反証)。
+
+## 検討した選択肢
+
+1. **Pages 統合の自動注入(従来構成)** — サイト設定モードとの不整合が無音故障の温床。廃止
+2. **手動モードの WA サイト+静的スニペット** — 注入経路が単一で、リポジトリで追跡可能。採用
+3. **ビーコンへの SRI(integrity)付与** — beacon.min.js は Cloudflare が継続更新する evergreen スクリプトで、ハッシュ固定は CF 側更新のたびに読込失敗=無音の計測停止(上記障害と同型)を招く。読込元は CSP の script-src で単一ホストに固定済みのため不付与
+
+## 決定
+
+1. WA サイト(edu-evidence.org)を「JS スニペットのインストールで有効にする」(手動)モードへ切替え、Cloudflare Pages 統合の Web Analytics 自動注入は無効化する
+2. ビーコンを `src/layouts/Layout.astro` に静的に記載する(`is:inline type="module"`、トークンはリポジトリ管理)
+3. `public/_headers` の CSP は **connect-src へ `https://cloudflareinsights.com` を追加するのみ**(`https://static.cloudflareinsights.com` は script-src / connect-src とも既許可で変更なし)
+
+## 帰結
+
+- デプロイ後に `POST https://cloudflareinsights.com/cdn-cgi/rum` の 204 を実測し、ダッシュボードへのイベント記録も確認(計測のエンドツーエンド復旧、2026-07-12)
+- 全ページに外部スクリプト 1 本(数 KB・cookie なし・ドメイン単位の集計)
+
+## 撤回 / 再検討の条件
+
+- 手動モードのビーコン仕様変更で 503 や読込失敗が再発した場合
+- リファラ内訳などより詳細な計測が必要になり、別基盤へ移行する場合

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -61,3 +61,6 @@
 - [0021. 用語集を src/data/glossary.ts 単一の source of truth に統合する](0021-glossary-single-source-of-truth.md)
 - [0022. Dependabot patch/minor 自動マージ運用と main ブランチ保護](0022-dependabot-auto-merge-policy.md)
 - [0023. changelog の文体(敬体)と粒度をファミリー統一する(edu-law ADR 0022 ミラー)](0023-unify-changelog-register-and-granularity.md)
+- [0024. ビジュアルリグレッションテスト(VRT)を視覚変更 PR に限定して導入](0024-visual-regression-testing.md)
+- [0025. content-reviewer の後段に独立反証ゲートを追加(2 段階 → 3 段階レビュー)](0025-adversarial-verification-gate.md)
+- [0026. Cloudflare Web Analytics を手動スニペット方式で導入し CSP を最小限緩和する](0026-web-analytics-beacon-and-csp.md)


### PR DESCRIPTION
## 概要
2026-07-15 の ADR 活用状況調査で、CSP 変更を伴う Cloudflare Web Analytics 導入(#366、2026-07-12)が ADR 化されていないことが判明。追認 ADR として記録する(ファミリー4リポ同時。本リポが正本、他はミラー)。

## 変更内容
- `docs/decisions/0026-web-analytics-beacon-and-csp.md` 新規(正本): 無音故障の経緯(モード不整合の rum POST 503・約3ヶ月イベント0)・検討した選択肢(自動注入廃止/SRI 不付与の理由)・決定(手動モード+静的ビーコン+connect-src へ cloudflareinsights.com 追加のみ)・検証結果(rum 204+ダッシュボード記録)。事実関係は #366 の実 diff と突合済み
- README 索引の欠落を是正: 0024・0025 を追記+0026 を追加

## 関連
- ミラー: edu-watch 0062 / edu-law 0024 / portfolio 0006(各リポの同時 PR)
- 初出 ADR: okinawa-in-data decisions/0002

🤖 Generated with [Claude Code](https://claude.com/claude-code)