### PR TITLE
content: add NELI Preschool and Talking Time trials to oral-language strategy

### DIFF
--- a/src/content/strategies/oral-language.md
+++ b/src/content/strategies/oral-language.md
@@ -15,7 +15,7 @@ evidence:
     monthsGained: 6
     strength: 5
     note: "EEF Toolkit で +6ヶ月・エビデンス★5。幼児期 +7、小学校 +6、中学校 +5。週3回以上の頻繁なセッションが効果的。話すことと聞くことの両方に焦点を当てる。"
-lastVerified: "2026-05-30"
+lastVerified: "2026-07-18"
 methodology:
   studies: 222
   sampleSize: "幼児〜中等教育(2025年5月 EEF 更新で 188→222 研究)"
@@ -55,6 +55,7 @@ culturalContext: |
 - 効果は低学年・中学年で特に大きく、語彙の少ない子に対する効果も顕著です。
 - 構造化された活動(役割・手順がある)の方が、自由な会話より効果が大きい傾向があります。
 - 英国では、幼児(4〜5歳)向けの構造化された言語プログラム(NELI)を全国規模で実施した評価があります。参加した子どもの言語スキルはおよそ4ヶ月相当先に進み、社会経済的に不利な家庭の子どもではおよそ7ヶ月相当とさらに大きく伸びました。356校・約1万人規模の評価で、試験的な環境ではなく通常の実施でこの効果が保たれた点が重要です。
+- 就学前の個別プログラムでも独立した評価が積み重なっています。「NELI Preschool」は、3〜4歳のナーサリー向けに絵本の共有読みを通じて語彙を育てる20週間の言語プログラムで、参加児の言語をおよそ2ヶ月分前進させました。3〜5歳向けの「Talking Time」(小集団での言語活動と職員研修)はおよそ1ヶ月分でした。いずれも評価の確実性は高く、上記4〜5歳・全国規模の NELI 評価とは別の試験です。これらは個々のプログラムを対象にした評価の値で、見出しの「+6ヶ月」はこの領域の多数の研究を束ねた平均です。個別プログラムの月数が平均より小さくても、口頭言語の指導が効かないという意味ではありません。
 
 ## 注意したいこと
 
@@ -67,6 +68,8 @@ culturalContext: |
 - Law, J., Garrett, Z., & Nye, C. (2003). [Speech and language therapy interventions for children](https://doi.org/10.1002/14651858.CD004110). *Cochrane Database of Systematic Reviews*. — 口頭言語介入の効果を系統的にレビュー。語彙と表現に正の効果を確認。
 - [Oral Language Interventions](https://educationendowmentfoundation.org.uk/education-evidence/teaching-learning-toolkit/oral-language-interventions). Education Endowment Foundation, *Teaching and Learning Toolkit*. — 口頭言語の指導で +6 ヶ月、エビデンス強度 ★5(小学校 +6 ヶ月、幼児 +7 ヶ月、中等 +5 ヶ月)。構造化された対話活動の効果を集約。
 - Smith, A., Staunton, R., Sahasranaman, A., & Worth, J. (2023). [Impact Evaluation of Nuffield Early Language Intervention (NELI) Wave Two](https://educationendowmentfoundation.org.uk/projects-and-evaluation/projects/nuffield-early-language-intervention-scale-up-impact-evaluation). National Foundation for Educational Research / Education Endowment Foundation. — 全国規模(356校・10,759人)で実施した幼児向け構造化言語プログラムの評価。全児童で +4 ヶ月(効果量 0.29)、社会経済的に不利な層では +7 ヶ月(効果量 0.56)。評価の確実性は中〜高で、通常環境での大規模実施でも効果が維持された。
+- [NELI Preschool(2023–24 Trial)](https://educationendowmentfoundation.org.uk/projects-and-evaluation/projects/neli-preschool-2023-24-trial). Education Endowment Foundation(独立評価: National Foundation for Educational Research)。— 3〜4歳のナーサリー向けに絵本の共有読みを通じて語彙を育てる20週間の言語プログラム。独立評価で全体 +2 ヶ月、評価の確実性は高い。上記 NELI Wave Two(4〜5歳・全国規模)とは別のトライアル。
+- [Talking Time(2023–24 Trial)](https://educationendowmentfoundation.org.uk/projects-and-evaluation/projects/talking-time-2023-24-trial). Education Endowment Foundation(独立評価: National Institute of Economic and Social Research)。— 3〜5歳向けに小集団での言語活動と職員研修を組み合わせたプログラム。独立評価で +1 ヶ月、評価の確実性は高い。EYPP 対象児や英語を母語としない児では約2ヶ月分と大きめだったが、対象人数が少なく確実性は下がる。
 
 ### 関連読み物
 


### PR DESCRIPTION
## 概要

口頭言語(oral-language)戦略に、EEF の**就学前トライアル2件**のエビデンスを追記します。既存の NELI Wave Two 評価(幼児 4〜5歳・全国規模)に続き、就学前(3〜5歳)を対象にした個別プログラムの独立評価が積み重なってきたため、本文と参考研究に反映します。

## 変更内容

- **本文「研究からわかっていること」**に 1 バレット追加:
  - 「NELI Preschool」(3〜4歳・絵本の共有読みを通じて語彙を育てる 20 週間の言語プログラム)= 独立評価で **+2 ヶ月**、評価の確実性は高い(独立評価: NFER)
  - 「Talking Time」(3〜5歳・小集団の言語活動+職員研修)= **+1 ヶ月**、評価の確実性は高い(独立評価: NIESR)
  - 見出しの「+6 ヶ月」はこの領域の多数研究を束ねた平均であり、個別プログラム単一試験の月数とは別である旨を明示(「効果が小さい」という誤読の防止)
  - 既存の NELI Wave Two(4〜5歳・356 校・約 1 万人)とは**別トライアル**であることを明記
- **「主な参考研究」**に上記 2 件の EEF プロジェクトページを追加(独立評価機関を帰属)
- frontmatter `lastVerified` を 2026-05-30 → 2026-07-18 に更新。見出し `monthsGained: 6` は据え置き。

## 検証

- 数値(+2 / +1・確実性・独立評価機関・対象年齢・別トライアル)は EEF 公式プロジェクトページを**実ブラウザで逐語照合**して確定(EEF は全ページ Cloudflare 保護のため curl/WebFetch 不可)。「NELI Preschool +3」という旧 efficacy 研究の数値とは別物であることも確認済み。
- 3 段階レビュー: `edu-content-reviewer` = GO / `edu-adversarial-verifier` = 指摘 3 点を修正反映(①活動記述を一次資料どおり「絵本の共有読み」に訂正 ②確実性を語表記に統一 ③Talking Time の EYPP・EAL 児での大きめの効果と確実性低下を補足)。
- 機械チェック: 型 / textlint / monthsGained 整合性 / lastVerified 期限 / source リンク = 全緑。

changelog なし(既存戦略ページ内のエビデンス追補のため)。関連 issue なし。