### PR TITLE
fix(search): improve Pagefind dark-mode contrast (input, results, placeholder, icon)

### DIFF
--- a/src/pages/changelog.astro
+++ b/src/pages/changelog.astro
@@ -21,6 +21,16 @@ interface ChangelogEntry {
 
 const entries: ChangelogEntry[] = [
   {
+    date: "2026-07-19",
+    items: [
+      {
+        type: "fix",
+        text: "ダークモードの検索ページで、検索アイコン・案内文字・入力欄・検索結果が背景に沈んで読みづらかった問題を修正しました",
+        links: [{ label: "検索", href: "/search/" }],
+      },
+    ],
+  },
+  {
     date: "2026-07-18",
     items: [
       {

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -75,7 +75,7 @@ import Layout from "../layouts/Layout.astro";
     .pagefind-ui .pagefind-ui__search-input {
       padding: 0.875rem 1rem 0.875rem 1rem;
       font-size: 1rem;
-      background: var(--color-card);
+      background: var(--color-card) !important;
       border: 1px solid var(--color-line);
       border-radius: 0.5rem;
       color: var(--color-ink);
@@ -89,8 +89,18 @@ import Layout from "../layouts/Layout.astro";
       box-shadow: 0 0 0 3px color-mix(in oklab, var(--color-accent) 20%, transparent);
       outline: none;
     }
+    .pagefind-ui .pagefind-ui__search-input::placeholder {
+      color: var(--color-sub) !important;
+      opacity: 1 !important;
+    }
+    /* Search icon (mask-image + background-color) */
+    .pagefind-ui .pagefind-ui__form::before {
+      background-color: var(--color-sub) !important;
+      opacity: 1 !important;
+    }
     .pagefind-ui .pagefind-ui__search-clear {
-      color: var(--color-sub);
+      color: var(--color-sub) !important;
+      background: transparent !important;
     }
     .pagefind-ui .pagefind-ui__search-clear:hover {
       color: var(--color-accent);
@@ -162,7 +172,7 @@ import Layout from "../layouts/Layout.astro";
       letter-spacing: -0.01em;
     }
     .pagefind-ui .pagefind-ui__result-link {
-      color: var(--color-ink);
+      color: var(--color-ink) !important;
       text-decoration: none !important;
       background-image: linear-gradient(var(--color-accent), var(--color-accent));
       background-size: 0% 1px;
@@ -176,7 +186,7 @@ import Layout from "../layouts/Layout.astro";
     .pagefind-ui .pagefind-ui__result-link:hover,
     .pagefind-ui .pagefind-ui__result-link:focus,
     .pagefind-ui .pagefind-ui__result-link:focus-visible {
-      color: var(--color-accent);
+      color: var(--color-accent) !important;
       background-size: 100% 1px;
     }
     .pagefind-ui .pagefind-ui__result-link:focus-visible {


### PR DESCRIPTION
## 概要

ファミリー横断のダークモード検索（Pagefind）視認性修正の最後の1件（本家 evi）。evi の `src/pages/search.astro` は **7宣言すべてが未適用の pre-fix 状態**で、ユーザーが最初に報告した「ダークで検索結果リンクが見えにくい」問題が **本番に残存**していた（別途の evi 作業は content で search 無関係だったため）。マージ済みの edu-law #126 と一字一句同一の修正をミラーする。

## 変更

`src/pages/search.astro` の `<style is:global>` を law #126 と同一化（`!important` は Pagefind がランタイム注入する CSS／変数を上書きする正当用途）:

- ① `__search-input` `background` に `!important`
- ② `__search-clear` `color` に `!important` ／ ③ `background: transparent !important` を追加
- ④ `__result-link` `color: var(--color-ink) !important`（＝報告バグの本体）／ ⑤ hover/focus/focus-visible を `color: var(--color-accent) !important`
- ⑥ `__search-input::placeholder` `color: var(--color-sub) !important; opacity: 1 !important;`（新規）
- ⑦ `__form::before`（虫眼鏡アイコン、mask-image + background-color）`background-color: var(--color-sub) !important; opacity: 1 !important;`（新規）

`src/pages/changelog.astro`: 2026-07-19 に fix 1行を追加（law と同一の包括文言）。

## 検証（chrome-devtools 実測・両モード）

| モード | 結果リンク | プレースホルダー | 検索アイコン | 入力文字 |
|---|---|---|---|---|
| ダーク | **11.87:1** | **6.06:1** | **6.06:1** | 10.56:1 |
| ライト | 16.52:1 | 5.36:1 | 5.36:1 | 17.4:1 |

- いずれも WCAG AA（本文 ≥4.5 / 図形 ≥3）。opacity を合成した実効色で測定・アイコンは mask-image セットを確認。ダーク値は law/watch と完全一致。
- evi は data-theme 属性駆動のため、実測は data-theme=dark で行った（この検証環境の localStorage に theme:"light" が残存していたため）。
- `npm run check` 0 errors、`npm run build` 281 ページ索引成功。
- ローカル preview（ダーク・ライト両モード）で目視サインオフ済み。
- VRT ゲートは src/layouts / src/components / src/styles 不変のため非該当。

## 関連

- edu-law #126（同一7宣言、マージ済み・本 PR のミラー元）
- edu-watch #405（watch 側の同修正、placeholder/icon 追補、OPEN）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
