### PR TITLE
fix(charts): render postwar-peaks chart and make y-axis labels vertical

### DIFF
--- a/src/content/columns/juvenile-delinquency-japan-reality.md
+++ b/src/content/columns/juvenile-delinquency-japan-reality.md
@@ -15,7 +15,7 @@ relatedStrategies:
   - behaviour-interventions
   - social-emotional-learning
 charts:
-  postwarPeaks:
+  postwar-peaks:
     type: bar
     title: 戦後の少年非行 3 つのピーク
     xLabels: ["昭和26年", "昭和39年", "昭和58年"]
@@ -39,7 +39,7 @@ charts:
 
 法務省『犯罪白書(令和 7 年版)』第 3 編第 1 章第 1 節は、少年による刑法犯と危険運転致死傷・過失運転致死傷等を含む検挙人員の戦後の推移について、3 つの大きなピークを記録しています。
 
-{{chart:postwarPeaks}}
+{{chart:postwar-peaks}}
 
 - **昭和 26 年(第一の波)** 16 万 6,433 人 — 戦後混乱期の貧困を背景にした第一の波
 - **昭和 39 年(第二の波)** 23 万 8,830 人 — 高度経済成長期の都市流入と少年人口増加を背景にした第二の波

--- a/src/lib/chart-svg.ts
+++ b/src/lib/chart-svg.ts
@@ -182,10 +182,10 @@ function renderAxisLabels(
     );
   }
   if (yAxisLabel) {
-    const cx = Y_AXIS_LABEL_X;
-    const cy = PADDING.top + innerH / 2;
+    const x = Y_AXIS_LABEL_X;
+    const y = PADDING.top + innerH / 2;
     parts.push(
-      `<text x="${cx}" y="${cy}" text-anchor="middle" font-size="11" fill="var(--color-sub)" transform="rotate(-90 ${cx} ${cy})">${escapeHtml(yAxisLabel)}</text>`,
+      `<text x="${x}" y="${y}" text-anchor="middle" dominant-baseline="central" font-size="11" fill="var(--color-sub)" style="writing-mode: vertical-rl; text-orientation: upright;">${escapeHtml(yAxisLabel)}</text>`,
     );
   }
   return parts.join("\n    ");

--- a/src/pages/changelog.astro
+++ b/src/pages/changelog.astro
@@ -21,6 +21,21 @@ interface ChangelogEntry {
 
 const entries: ChangelogEntry[] = [
   {
+    date: "2026-07-23",
+    items: [
+      {
+        type: "fix",
+        text: "少年非行のコラムで、本来の棒グラフ「戦後の少年非行 3 つのピーク」が表示されず記号のまま残っていた問題を修正しました。あわせて各グラフの縦軸ラベルを縦書き表示にして読みやすくしました",
+        links: [
+          {
+            label: "日本の少年非行の実像",
+            href: "/columns/juvenile-delinquency-japan-reality",
+          },
+        ],
+      },
+    ],
+  },
+  {
     date: "2026-07-19",
     items: [
       {


### PR DESCRIPTION
## 背景 / 問題

少年非行のコラム `juvenile-delinquency-japan-reality.md` で、本文の `{{chart:postwarPeaks}}` が本番ページ上で**リテラル文字列のまま表示**され、棒グラフ「戦後の少年非行 3 つのピーク」が描画されていなかった。

原因は content 側の命名規約違反:
- `src/plugins/remark-chart.mjs` の正規表現 `/\{\{chart:([a-z0-9-]+)\}\}/g` は **kebab-case のみ**許可（プラグインの契約も kebab-case）。
- content 全体の chart プレースホルダ 6 個のうち 5 個は kebab-case で、`postwarPeaks` だけが camelCase の逸脱だったため非マッチ。
- astro6 時代から存在する既存バグ（astro7 移行とは無関係）。

あわせて、目視レビューで y 軸ラベルの単一文字「人」が `transform="rotate(-90)"` により**横倒し**になっていたため、縦書き表示に是正した。

## 変更内容

1. **`src/content/columns/juvenile-delinquency-japan-reality.md`** — chart キーを `postwarPeaks` → `postwar-peaks` に rename（frontmatter 定義 + 本文プレースホルダの 2 箇所）。数値・出典・本文は不変（純粋なキー rename）。
2. **`src/lib/chart-svg.ts`** `renderAxisLabels` — y 軸ラベルを `rotate(-90)` から `writing-mode: vertical-rl; text-orientation: upright`（縦書き正立）に変更。**`yAxisLabel` を持つ全 6 チャートに影響**（意図的な統一）。
3. **`src/pages/changelog.astro`** — ユーザー可視の fix を 1 エントリ追記。

## 検証（ローカル dev, port 4321）

- 変更1: 対象 URL HTTP 200 / リテラル `{{chart:` 残留 = 0 / `data-chart-id="postwar-peaks"` 生成 = 1 / remark-chart warning なし。
- 変更2: 全 6 チャートで `writing-mode: vertical-rl` 反映 = 1・`rotate(-90)` 残留 = 0。単一文字「人」・「遅れ(ヶ月)」・最長「不登校児童生徒数(人)」（11文字）を実描画で確認。いずれも正立・overflow / clip なし。半角括弧も読める。
- 目視サインオフ取得済み。

## 影響範囲 / 補足

- `data-chart-id` 属性値が変わるが、この属性を参照する CSS/JS は存在しない（grep 確認）ため副作用なし。
- y 軸ラベルの縦書き化は全 6 チャート共通の見た目変更。VRT は `src/content/**` 変更では起動しないが、`src/lib/**` は VRT 対象外のため required check には影響しない。