### PR TITLE
ci: run the content checks on every pull request

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,60 @@
+name: Content Checks
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: checks-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  checks:
+    name: Content and consistency checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+        with:
+          node-version: "24"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      # 以降は if: !cancelled() を付けて、1 本落ちても残りの結果が見えるようにする。
+      # 落ちたステップがあればジョブ全体は失敗する。
+      # リンク切れ検査(check:links / check:links:source)はネットワーク依存で
+      # 不安定なため、既存の link-check.yml(週次)に任せてここでは走らせない。
+
+      - name: Astro type check
+        run: npm run check
+
+      - name: textlint
+        if: ${{ !cancelled() }}
+        run: npm run check:text
+
+      - name: Reader literacy
+        if: ${{ !cancelled() }}
+        run: npm run check:reader-literacy
+
+      - name: Sentence length
+        if: ${{ !cancelled() }}
+        run: npm run check:sentence-length
+
+      - name: monthsGained consistency
+        if: ${{ !cancelled() }}
+        run: npm run check:consistency
+
+      - name: Evidence strength consistency
+        if: ${{ !cancelled() }}
+        run: npm run check:evidence-strength
+
+      - name: lastVerified staleness
+        if: ${{ !cancelled() }}
+        run: npm run check:stale

--- a/.textlintrc.json
+++ b/.textlintrc.json
@@ -43,6 +43,7 @@
       "ja-space-around-strong": false,
       "ja-space-around-emphasis": false,
       "ja-no-space-around-parentheses": false,
+      "ja-no-space-around-slash": false,
       "ja-no-space-between-full-width": true,
       "ja-nakaguro-or-halfwidth-space-between-katakana": false
     },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,8 +30,9 @@ npm run a11y:baseline      # axe-core で a11y 違反一覧を再生成(dev 起�
 npm run check              # Astro型チェック
 npm run check:text         # textlint日本語校正
 npm run check:consistency  # monthsGained 整合性チェック
+npm run check:evidence-strength # エビデンス強度(★)整合性チェック
 npm run check:stale        # lastVerified 期限切れチェック
-npm run check:all          # 上記チェックを一括実行
+npm run check:all          # 上記チェックを一括実行(CI の Content Checks でも実行)
 ```
 
 ## プロジェクト構造


### PR DESCRIPTION
## 概要

check スクリプトは **CI から 1 本も呼ばれていませんでした**。PR #401 で数ヶ月放置されていたエビデンス評価の誤りを是正し、PR #403 でその種類の誤りを検出するスクリプトを追加しましたが、**自動では走らない**ため同じ乖離がまた積み上がります。これを塞ぎます。

障害が 2 つあり、両方を扱います。

## 1. `check:all` が textlint で止まっていた

`npm run check:all` は `&&` 連結で、`check:text` が失敗するとその後（`check:reader-literacy` / `check:sentence-length` / `check:consistency` / `check:evidence-strength` / リンク検査）が **一度も走りませんでした**。

失敗 64 件は**すべて同一ルール `ja-spacing/ja-no-space-around-slash`**（30 ファイル）で、100% 自動修正可能でした。しかし中身を見ると、**64 件すべてが「複数語の項目をスラッシュで区切る」用法**です。

| 現在 | 自動修正すると |
|---|---|
| `NFER / Education Endowment Foundation` | `NFER/Education Endowment Foundation` |
| `理科専科 20 校 / 算数専科 20 校 / 加配なし 20 校` | `理科専科 20 校/算数専科 20 校/加配なし 20 校` |
| `Roorda et al. 2011 / Cornelius-White 2007` | `Roorda et al. 2011/Cornelius-White 2007` |
| `子どもの様子に応じて支援を変える / 段階的に支援を外す` | `子どもの様子に応じて支援を変える/段階的に支援を外す` |

このルールは「賛成/反対」のような**短い日本語の語**を想定したもので、本文の用法とは合っていません。自動修正すると区切りが詰まって読みにくくなるため、**ルールを無効化**しました。`preset-ja-spacing` では既に 6 つのルール（`ja-space-between-half-and-full-width` / `ja-space-around-link` / `ja-space-around-strong` / `ja-space-around-emphasis` / `ja-no-space-around-parentheses` / `ja-nakaguro-or-halfwidth-space-between-katakana`）が同じ形で無効化されており、その並びに加える形です。

これで **`npm run check:all` が初めて最後まで通り exit=0 になりました**。

## 2. 新しい workflow `Content Checks`

`.github/workflows/checks.yml` を追加し、`main` への push と PR で以下 7 本を実行します。

| ステップ | 内容 |
|---|---|
| `npm run check` | Astro 型チェック |
| `npm run check:text` | textlint |
| `npm run check:reader-literacy` | 英略語の glossary 未登録など |
| `npm run check:sentence-length` | 長文検出 |
| `npm run check:consistency` | `monthsGained` の整合 |
| `npm run check:evidence-strength` | エビデンス強度（★）の整合（#403 で追加） |
| `npm run check:stale` | `lastVerified` の期限切れ |

**各ステップに `if: ${{ !cancelled() }}` を付けています。** 1 本落ちても残りの結果が見えるようにするためで、落ちたステップがあればジョブ全体は失敗します。`always()` ではなく `!cancelled()` にしたのは、`concurrency.cancel-in-progress: true` を設定しておりキャンセルが実際に発生するためです。

**リンク切れ検査（`check:links` / `check:links:source`）は含めていません。** ネットワーク依存で不安定なうえ、既存の `link-check.yml`（週次）が担当しているためです。

## 検証

導入時点で **CI が回す 7 本すべて exit=0** です。

```
check                      exit=0
check:text                 exit=0        ← ルール無効化前は exit=1
check:reader-literacy      exit=0
check:sentence-length      exit=0
check:consistency          exit=0
check:evidence-strength    exit=0
check:stale                exit=0
```

`npm run check:all` も exit=0（リンク検査まで到達し、新規 broken 0 件）。`npm run build` 成功。**この PR 自体が workflow の実地テストになります。**

workflow に untrusted input の展開はありません（`${{ }}` は concurrency group の `github.ref` のみで、`run:` 内では一切使っていません）。actions は既存 workflow と同じく SHA ピン留めです。

## 付随

`CLAUDE.md` のコマンド一覧に `check:evidence-strength` を追記しました（#403 で追加した際に漏れていました）。

## 本 PR に含めなかったもの

- **`check-consistency.ts` の行番号オフセットのずれ**（`frontmatter 行数 + 2` で 1 行下を報告する）— #403 で新スクリプト側は `+1` に是正済み。既存側の変更は挙動が変わるため別途
- **required check への昇格** — main のブランチ保護（ADR 0022）に `Content Checks` を必須として加えるかは運用判断なので、まずは通常の check として様子を見る想定です

🤖 Generated with [Claude Code](https://claude.com/claude-code)
