### PR TITLE
docs(adr): record promoting Content Checks to a required check

### DIFF
--- a/docs/decisions/0028-content-checks-required.md
+++ b/docs/decisions/0028-content-checks-required.md
@@ -1,0 +1,55 @@
+# 0028. Content Checks を main の required check に昇格する
+
+- 状態: 採用
+- 日付: 2026-07-28
+- 関連 PR: #403(チェックスクリプト追加)/ #404(CI 実行)
+- 関連: [`ADR 0022`](0022-dependabot-auto-merge-policy.md)(main ブランチ保護の初期設定。本 ADR で `contexts` を追加する)
+
+## 背景
+
+PR #401 で、EEF が 5 段階中 4(一部は 3)としている確実性評価を、サイトが「EEF で ★5」と表示していた乖離を是正した。この誤りは 5 つの戦略ページにまたがり、**数ヶ月にわたって本番に残っていた**。
+
+残った理由は単純で、**★ を検証する仕組みが存在しなかった**ことにある。`scripts/check-consistency.ts` は `monthsGained` しか見ておらず、他のどのスクリプトも ★ を見ていなかった。
+
+そこで PR #403 で `scripts/check-evidence-strength.ts` を追加し、PR #404 で `.github/workflows/checks.yml`(`Content Checks`)から 7 本のチェックを PR ごとに自動実行するようにした。
+
+ただしこの時点では、チェックが赤くなっても **マージ自体は可能** だった。同じ種類の放置を構造的に防ぐには、失敗を検知するだけでなく、失敗したまま main に入れないようにする必要がある。
+
+## 検討した選択肢
+
+1. **通常の check のまま運用する** — マージ可否は編集者の判断に委ねる。導入コストはゼロだが、放置の再発防止は人間の規律に依存したままで、#401 が起きた状況と本質的に変わらない
+2. **required check に昇格する** — チェックが赤い PR はマージできなくなる。Dependabot の auto-merge も同じ条件に従う
+3. **昇格に加えて `required_status_checks.strict` も有効にする** — マージ前に main の最新を取り込むことを強制する。チェックの信頼度は上がるが、ADR 0022 が明示的に避けた設定
+
+## 決定
+
+選択肢 2 を採る。`required_status_checks.contexts` に `Content and consistency checks` を追加する。
+
+```
+required_status_checks.contexts: ["Playwright E2E", "Content and consistency checks"]
+required_status_checks.strict:   false
+```
+
+`gh api PATCH /repos/{owner}/{repo}/branches/main/protection/required_status_checks` でサブリソースのみを更新し、ADR 0022 が定めた他の設定(`enforce_admins: false` / `required_pull_request_reviews: null` / `restrictions: null` / `allow_force_pushes: false` / `allow_deletions: false`)はそのまま維持する。
+
+`strict` は **false のまま**にする。ADR 0022 が述べているとおり、strict にすると Dependabot PR が main の更新のたびに rebase を要求され、auto-merge が連鎖的に詰まるためである。
+
+context に指定する文字列は、workflow 名の `Content Checks` ではなく **job 名の `Content and consistency checks`** である。GitHub は job 名を status check の context として報告するため、workflow 名を指定すると永久に満たされない required check ができてしまう。
+
+## 帰結
+
+### 利点
+
+- チェックが失敗している PR は main にマージできなくなり、#401 のような乖離が「気づかれないまま本番に残る」経路が塞がる
+- 対象は 7 本(Astro 型チェック / textlint / 読者リテラシー / 長文検出 / `monthsGained` 整合 / エビデンス強度整合 / `lastVerified` 期限切れ)で、いずれも昇格時点で green
+
+### コスト
+
+- **Dependabot の auto-merge もこのチェックの通過が条件になる**。ADR 0022 の auto-merge は required CI が green のときに発火するため、依存更新が Astro 型チェックや textlint を壊した場合、その PR は自動マージされず滞留する。これは望ましい挙動だが、滞留が常態化するようなら運用の見直しが要る
+- リンク切れ検査(`check:links` / `check:links:source`)は `Content Checks` に含めていないため、required の対象外である。これはネットワーク依存で不安定なためで、週次の `link-check.yml` が引き続き担当する
+
+## 撤回 / 再検討の条件
+
+- Dependabot PR の滞留が常態化し、依存更新の適用が遅れることが実害になった場合
+- `Content Checks` が、コンテンツの問題ではない理由(CI 環境側の不安定さなど)で頻繁に赤くなる場合
+- `enforce_admins` を `true` に昇格させる判断をする場合は、ADR 0022 が述べているとおり別 ADR で扱う

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -65,3 +65,4 @@
 - [0025. content-reviewer の後段に独立反証ゲートを追加(2 段階 → 3 段階レビュー)](0025-adversarial-verification-gate.md)
 - [0026. Cloudflare Web Analytics を手動スニペット方式で導入し CSP を最小限緩和する](0026-web-analytics-beacon-and-csp.md)
 - [0027. Astro 7 へ移行し、Markdown は `processor: unified()` で従来パイプラインを維持する](0027-astro-7-migration.md)
+- [0028. Content Checks を main の required check に昇格する](0028-content-checks-required.md)


### PR DESCRIPTION
## 概要

PR #404 で追加した workflow の job `Content and consistency checks` を、main のブランチ保護の **required check に昇格**しました。その決定を ADR 0028 として記録します。

設定変更は既に適用済みです。

```
required_status_checks.contexts: ["Playwright E2E", "Content and consistency checks"]
required_status_checks.strict:   false
```

## なぜ ADR を新規に起こすか

**[ADR 0022](https://github.com/Hayato-Isagawa/edu-evidence/blob/main/docs/decisions/0022-dependabot-auto-merge-policy.md) が本文で `required_status_checks.contexts = ["Playwright E2E"]` と明記しており、今回の変更で記述と実態がずれました。**

`CLAUDE.md` は ADR を不変としているため 0022 は書き換えず、0028 から 0022 を参照する形で関係を示しています。0022 を信じて読んだ人が誤らないようにするのが目的です。

## 決定の動機

PR #401 で是正した EEF 確実性評価の誤りは、5 つの戦略ページにまたがって**数ヶ月本番に残っていました**。理由は「★ を検証する仕組みが無かった」ことです。

- PR #403 — 検出スクリプト `scripts/check-evidence-strength.ts` を追加
- PR #404 — `Content Checks` workflow で PR ごとに自動実行

ただしこの時点では **チェックが赤くてもマージ自体は可能**でした。同じ放置を構造的に防ぐには、検知するだけでなく、失敗したまま main に入れないようにする必要があります。

## 決定内容で明記したこと

**`strict` は false のまま**にしました。ADR 0022 が述べているとおり、strict にすると Dependabot PR が main の更新のたびに rebase を要求され、auto-merge が連鎖的に詰まるためです。

**context に指定する文字列は job 名の `Content and consistency checks`** です。workflow 名の `Content Checks` ではありません。GitHub は job 名を status check の context として報告するため、workflow 名を指定すると**永久に満たされない required check** ができてしまいます。実際に `gh pr checks` の出力で確認しました。

設定は `gh api PATCH .../branches/main/protection/required_status_checks` でサブリソースのみを更新しており、ADR 0022 が定めた他の設定（`enforce_admins: false` / `required_pull_request_reviews: null` / `restrictions: null` / `allow_force_pushes: false` / `allow_deletions: false`）はすべて元の値のまま保たれていることを変更後に確認済みです。

## 帰結として記録したコスト

**Dependabot の auto-merge も、このチェックの通過が条件になりました。** ADR 0022 の auto-merge は required CI が green のときに発火するため、依存更新が Astro 型チェックや textlint を壊した場合、その PR は自動マージされず滞留します。望ましい挙動ですが、滞留が常態化するようなら見直しが要るため「撤回 / 再検討の条件」に明記しました。

リンク切れ検査は `Content Checks` に含めていないため required の対象外です（ネットワーク依存で不安定なため、週次の `link-check.yml` が引き続き担当）。

## 検証

ADR の記述とブランチ保護の実態が一致することを確認しました。

```
$ gh api .../branches/main/protection --jq '.required_status_checks | {strict, contexts}'
{"contexts":["Playwright E2E","Content and consistency checks"],"strict":false}
```

`npm run check:all` exit=0 / `npm run build` 成功。

**この PR が昇格後の最初の PR になるため、`Content and consistency checks` が required として要求されることが実地で確認できます。**

## 含めなかったもの

- **ADR 0022 の書き換え** — `CLAUDE.md` により ADR は不変
- **`strict: true` への変更** — ADR 0022 が明示的に避けた設定
- **`enforce_admins: true` への昇格** — ADR 0022 が「運用安定後に別 ADR で判断」としており、本件とは別の決定

🤖 Generated with [Claude Code](https://claude.com/claude-code)