### PR TITLE
docs(adr): consolidate required checks into classic branch protection

### DIFF
--- a/docs/decisions/0029-required-checks-single-source.md
+++ b/docs/decisions/0029-required-checks-single-source.md
@@ -1,0 +1,69 @@
+# 0029. required check を classic ブランチ保護に一本化し、ruleset の重複を解消する
+
+- 状態: 採用
+- 日付: 2026-07-28
+- 関連 PR: #405([`ADR 0028`](0028-content-checks-required.md))
+- 関連: [`ADR 0022`](0022-dependabot-auto-merge-policy.md)(`strict = false` の意図)/ [`ADR 0028`](0028-content-checks-required.md)(**本 ADR で記述を訂正する**)
+
+## 背景
+
+ADR 0028 で `Content and consistency checks` を required check に昇格させたとき、確認したのは **classic ブランチ保護だけ**だった。
+
+その後、Dependabot PR #394(linkinator 7.6.1 → 8.0.2)が `mergeable_state: behind` で詰まっていたため原因を追ったところ、**classic 保護とは別に ruleset `main-protection`(enforcement=active)が存在し、独自の `required_status_checks` を持っていた**ことが分かった。
+
+```
+ruleset の required_status_checks:
+  strict_required_status_checks_policy: true
+  required_status_checks: [{ context: "Playwright E2E" }]
+```
+
+GitHub は classic 保護と ruleset の両方を適用し、より厳しい方を採る。したがって**実効の strict は true** であり、ADR 0022 が「strict にすると Dependabot PR が main の更新のたびに rebase を要求され auto-merge が連鎖的に詰まる」として明示的に false を選んだ設定は、ruleset 側で打ち消されていた。#394 が `behind` で止まっていたのはこれが原因である。
+
+あわせてファミリー 3 リポの構成を実測した(2026-07-28)。
+
+| リポ | classic 保護 | ruleset の rules |
+|---|---|---|
+| **edu-evidence** | strict=false / `Playwright E2E` + `Content and consistency checks` | deletion / non_fast_forward / pull_request / **required_status_checks(strict=true)** |
+| edu-watch | strict=false / `Playwright E2E` + `Persistent denylist consistency` | deletion / non_fast_forward / pull_request |
+| edu-law | strict=false / `Build site` | deletion / non_fast_forward / pull_request |
+
+**「classic 保護と ruleset の併存」自体は 3 リポ共通**で、required check を classic 側に置くのがファミリーの形だった。**edu-evidence の ruleset だけが `required_status_checks` を重複して持っていた**のが逸脱にあたる。
+
+## 検討した選択肢
+
+1. **ruleset にも `Content and consistency checks` を追加し、両方を維持する** — 定義箇所が 2 つのまま残り、片方だけ更新して気づかない事故が再発する。strict=true も残るため #394 の詰まりは解消しない
+2. **ruleset から `required_status_checks` を外し、classic 保護に一本化する** — 姉妹 2 リポと同じ形になる。定義箇所が 1 つになり、ADR 0022 が意図した strict=false が実際に効く
+3. **classic 保護を捨てて ruleset に一本化する** — GitHub の方向性には合うが、3 リポすべての移行が必要で、本件(#394 の詰まり解消)より範囲が大きい
+
+## 決定
+
+選択肢 2 を採る。edu-evidence の ruleset `main-protection` から `required_status_checks` ルールを削除し、required check は classic ブランチ保護のみで定義する。
+
+```
+ruleset  : deletion / non_fast_forward / pull_request
+classic  : required = ["Playwright E2E", "Content and consistency checks"] / strict = false
+```
+
+`gh api PUT /repos/{owner}/{repo}/rulesets/{id}` は定義全体を要求するため、変更前の定義を取得して保存したうえで、`required_status_checks` のみを除いた rules 配列で更新した。他のルール(`deletion` / `non_fast_forward` / `pull_request`)と `conditions` / `bypass_actors` は変更していない。
+
+### ADR 0028 の訂正
+
+ADR 0028 は「`strict` は **false のまま**にする」と記述したが、これは classic 保護のみを見た記述であり、**当時の実効値は ruleset により true だった**。ADR は不変とする運用のため 0028 は書き換えず、本 ADR で訂正する。0028 の他の記述(required への昇格・context 名が job 名であること・Dependabot への影響)は現在も有効である。
+
+## 帰結
+
+### 利点
+
+- required check の定義箇所が 1 つになり、「片方だけ更新して実効値がずれる」事故が構造的に起きなくなる
+- ADR 0022 が意図した strict=false が実際に効くようになり、Dependabot PR が main の更新のたびに詰まることがなくなった。#394 は `behind` → `blocked` に変わり、残る要因は「required 昇格前に作られた PR のため新しい check が一度も走っていない」ことだけになった
+- edu-evidence / edu-watch / edu-law の ruleset が同一構成になり、ファミリー横断で同じ説明が通る
+
+### コスト
+
+- **GitHub は classic ブランチ保護を非推奨の方向に進めており、将来 ruleset へ移す必要が生じうる**。そのときは 3 リポまとめて移行する
+- required check の設定が GitHub の UI 上 2 箇所に分かれて見える状態は変わらない(ruleset にも「Require status checks」の項目自体は存在する)。空であることを確認する運用が要る
+
+## 撤回 / 再検討の条件
+
+- GitHub が classic ブランチ保護を廃止する、または ruleset への移行を強制する場合
+- 姉妹リポ(edu-watch / edu-law)を ruleset 側へ寄せる判断をした場合。そのときは本 ADR も含めて 3 リポ同時に見直す

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -66,3 +66,4 @@
 - [0026. Cloudflare Web Analytics を手動スニペット方式で導入し CSP を最小限緩和する](0026-web-analytics-beacon-and-csp.md)
 - [0027. Astro 7 へ移行し、Markdown は `processor: unified()` で従来パイプラインを維持する](0027-astro-7-migration.md)
 - [0028. Content Checks を main の required check に昇格する](0028-content-checks-required.md)
+- [0029. required check を classic ブランチ保護に一本化し、ruleset の重複を解消する](0029-required-checks-single-source.md)


### PR DESCRIPTION
## 概要

詰まっていた Dependabot PR #394 を調査した結果、**誰も把握していなかった 2 層目の保護**が見つかりました。ADR 0022 / 0028 が記述してきた classic ブランチ保護とは別に、**ruleset `main-protection`（enforcement=active）が独自の `required_status_checks` を持っていました**。

```
ruleset の required_status_checks:
  strict_required_status_checks_policy: true
  required_status_checks: [{ context: "Playwright E2E" }]
```

GitHub は両方を適用してより厳しい方を採るため、**実効の strict は true** でした。ADR 0022 が「strict にすると Dependabot auto-merge が連鎖的に詰まる」として明示的に false を選んだ設定が、ruleset 側で打ち消されていたことになります。#394 が `mergeable_state: behind` で止まっていたのはこれが原因です。

## 姉妹リポと比べると ruleset が異物でした

| リポ | classic 保護 | ruleset の rules |
|---|---|---|
| **edu-evidence** | strict=false / `Playwright E2E` + `Content and consistency checks` | deletion / non_fast_forward / pull_request / **required_status_checks(strict=true)** |
| edu-watch | strict=false / `Playwright E2E` + `Persistent denylist consistency` | deletion / non_fast_forward / pull_request |
| edu-law | strict=false / `Build site` | deletion / non_fast_forward / pull_request |

**「classic 保護と ruleset の併存」自体は 3 リポ共通**で、required check を classic 側に置くのがファミリーの形でした。**edu-evidence の ruleset だけが `required_status_checks` を重複して持っていた**のが逸脱です。

## 対応

ruleset から `required_status_checks` を削除し、required check を classic 保護の 1 箇所に集約しました。

```
ruleset : deletion / non_fast_forward / pull_request      ← 姉妹 2 リポと完全一致
classic : required = ["Playwright E2E", "Content and consistency checks"] / strict = false
```

`gh api PUT .../rulesets/{id}` は定義全体を要求するため、変更前の定義を取得・保存したうえで `required_status_checks` のみを除いた rules 配列で更新しています。`conditions` / `bypass_actors` と他 3 ルールは変更していません。

## ADR 0028 の訂正

**ADR 0028 の「`strict` は false のまま」は誤りでした。** classic 保護のみを見た記述で、当時の実効値は ruleset により true でした。ADR は不変とする運用のため 0028 は書き換えず、本 ADR で訂正します。0028 の他の記述（required への昇格・context 名が workflow 名でなく job 名であること・Dependabot への影響）は現在も有効です。

## 効果の実測

PR #394 の状態が順に解消しました。

| 時点 | `mergeable_state` | 残る要因 |
|---|---|---|
| 調査開始時 | `behind` | ruleset の strict=true |
| ruleset 変更後 | `blocked` | 新 check がこの PR で未実行 |
| `@dependabot rebase` 後 | **`clean`** | なし |

rebase 後の head SHA では 4 本すべてが success です（`Cloudflare Pages` / `Playwright E2E` / **`Content and consistency checks`** / `auto-merge`）。auto-merge は無効のままですが、これは major 更新のため ADR 0022 どおりの正しい挙動です。

## 検証

ADR の記述と実態が一致することを、**2 層とも**確認しました（0028 で記述がずれた再発を防ぐため）。

```
ruleset rules : deletion, non_fast_forward, pull_request
classic       : strict=false contexts=["Playwright E2E","Content and consistency checks"]
```

`npm run check:all` exit=0 / `npm run build` 成功。

## 含めなかったもの

- **ADR 0022 / 0028 の書き換え** — ADR は不変。0029 から参照して訂正
- **姉妹リポの設定変更** — 既に望ましい形なので触っていません
- **classic 保護から ruleset への全面移行** — GitHub の方向性には合いますが 3 リポ同時の移行が要るため、「撤回 / 再検討の条件」に条件として記載するに留めました
- **portfolio への `dependabot-auto-merge.yml` 追加** — 調査中に判明した別件です。`.github/workflows` ディレクトリ自体が存在せず、Dependabot PR 5 件が手動マージ待ちで滞留しています（ブロックはされていません）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
