### PR TITLE
ci(link-check): exclude sciencedirect.com from the lychee scan

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -63,6 +63,7 @@ jobs:
             --exclude 'educationendowmentfoundation\.org\.uk'
             --exclude 'nctm\.org'
             --exclude 'chikumashobo\.co\.jp'
+            --exclude 'sciencedirect\.com'
             --timeout 30
             --max-retries 2
             './dist/**/*.html'


### PR DESCRIPTION
`Fixes #381`

## 何が起きていたか

週次リンクチェックが 2026-07-20 から 5 件のエラーを報告していたが、**すべて ScienceDirect の記事ページで、リンク切れではない**。

| 検証 | 結果 |
|---|---|
| Crossref | 両論文とも実在。`alternative-id` が URL の PII と一致（`10.1016/j.ssaho.2025.102287` → `S2590291125010186` / `10.1016/j.pubecp.2022.100016` → `S2666551422000031`） |
| DOI 解決 | 両 DOI とも **200** で `linkinghub.elsevier.com/retrieve/pii/<同一 PII>` に着地 |
| ブラウザ実見 | ScienceDirect の "Are you a robot?" captcha 画面。人間には表示され、自動クライアントは遮断される |
| curl | 403（ボット遮断。404 ではない） |

## なぜすり抜けたか

workflow は「出版社はボットを弾くが人間には見える」という理由で既に **403 を許容**している。しかし **ScienceDirect が lychee に返すのは 400** で、許容リストに含まれていなかった。

`--accept` に 400 を足す案は採らない。400 は汎用の "Bad Request" で、全ドメインで URL の書式ミスを見逃すようになるため。代わりに **出版社単位の除外**とし、既存の EEF / Corwin / NCTM / 筑摩書房と同じ形に揃えた。

`scripts/links-known-issues.json` には既に ScienceDirect の URL が 2 本 403 で登録されており、linkinator 側は先に同じ結論に達していた。

## 副作用（明記）

**ScienceDirect のリンクは lychee / linkinator の双方で自動検出対象外になる。** PII の打ち間違いは自動では捕まらず、引用を書く時点で担保する必要がある（`CONTENT_GUIDELINES` の一次照合 / `edu-adversarial-verifier`）。

## 検証（実測）

本ブランチに対して `workflow_dispatch` で 2 回実行。

| 項目 | #381 の run | 本ブランチ 1 回目 | 本ブランチ 2 回目 |
|---|---|---|---|
| 🚫 Errors | **5** | **0** | **0** |
| ⏳ Timeouts | 0 | 3 | **0** |
| 👻 Excluded | 711 | 719 | 719 |
| run | [29711672776](https://github.com/Hayato-Isagawa/edu-evidence/actions/runs/29711672776) | [30411222053](https://github.com/Hayato-Isagawa/edu-evidence/actions/runs/30411222053) | [30411699569](https://github.com/Hayato-Isagawa/edu-evidence/actions/runs/30411699569) |

**ScienceDirect の 400 は解消（Errors 0）。**

1 回目に出た 3 件のタイムアウト（`https://doi.org/10.11151/eds.80.23` = J-STAGE / 教育社会学研究）は 2 回目で消えたため一時的なものと確認した。lychee は timeout も失敗扱いにするので、残っていれば次回の週次実行で新しい issue が起票されるところだった。