### PR TITLE
fix(strategies): label the methodology source as an evidence review

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -59,7 +59,7 @@ const strategies = defineCollection({
     // EEF 方式に倣い、戦略ページで「研究の詳細」セクションを表示
     methodology: z
       .object({
-        studies: z.number().optional(),           // メタ分析に含まれる研究数
+        studies: z.number().optional(),           // 主要レビューに含まれる研究数
         sampleSize: z.string().optional(),        // 総サンプルサイズ(例: "10,500人")
         effectSize: z.string().optional(),        // 効果量(例: "d=0.37, 95%CI [0.30, 0.44]")
         primaryMetaAnalysis: z

--- a/src/pages/changelog.astro
+++ b/src/pages/changelog.astro
@@ -21,6 +21,16 @@ interface ChangelogEntry {
 
 const entries: ChangelogEntry[] = [
   {
+    date: "2026-07-29",
+    items: [
+      {
+        type: "fix",
+        text: "指導法ページの「研究の詳細」で、出典を示す見出しを「主要メタ分析」から「主要エビデンスレビュー」に変更しました。ICT活用など一部のページは EEF のガイダンス報告書を出典としており、メタ分析ではないものを「メタ分析」と表示していたためです",
+        links: [{ label: "ICT活用", href: "/strategies/digital-technology" }],
+      },
+    ],
+  },
+  {
     date: "2026-07-28",
     items: [
       {

--- a/src/pages/strategies/[...slug].astro
+++ b/src/pages/strategies/[...slug].astro
@@ -318,7 +318,7 @@ const effectNote =
             </div>
             {d.methodology.primaryMetaAnalysis && (
               <div class="space-y-1 border-t border-[var(--color-line)] pt-3">
-                <div class="text-xs text-[var(--color-sub)]">主要メタ分析</div>
+                <div class="text-xs text-[var(--color-sub)]">主要エビデンスレビュー</div>
                 <div class="text-sm">
                   {d.methodology.primaryMetaAnalysis.authors} ({d.methodology.primaryMetaAnalysis.year}).{" "}
                   {d.methodology.primaryMetaAnalysis.url ? (


### PR DESCRIPTION
## 何が問題だったか

Technical Appendix の見出しが「主要メタ分析」だったが、`methodology.primaryMetaAnalysis` を持つ **67 ページのうち 6 本はメタ分析を指していない**。

| slug | `primaryMetaAnalysis.title` | 種別 |
|---|---|---|
| `digital-technology` | Using Digital Technology to Improve Learning: Guidance Report | ガイダンス報告書 |
| `feedback` | Teacher Feedback to Improve Pupil Learning: Guidance Report | ガイダンス報告書 |
| `early-numeracy-approaches` | Early numeracy approaches | Early Years Toolkit |
| `early-years-intervention` | Early Years Toolkit | Early Years Toolkit |
| `oral-language` | Oral language interventions — Technical Appendix | Toolkit の Technical Appendix |
| `reading-comprehension` | Reading comprehension strategies: Evidence Review | エビデンスレビュー |

これらのページでは直上に並ぶ「研究数」も **strand 集計値**（例: `digital-technology` は 32 メタ分析の統合）であり、「メタ分析に含まれる研究数」とは読めない。

## 対応

表示ラベルを **「主要エビデンスレビュー」** に変更し、`src/content.config.ts` のスキーマコメントも `// 主要レビューに含まれる研究数` に揃えた。メタ分析は「エビデンスレビュー」に包含されるため、残り 61 本の記述も破綻しない。

コンテンツ 74 本は無編集。6 本の出典を再取材せずに誤ラベルを解消する選択。

## 残る不整合（本 PR の範囲外）

フィールド名 `primaryMetaAnalysis` は変更していないため、**コードとラベルの乖離が残る**。改名すると 67 本のコンテンツ編集が必要になるため分離した。将来 `primaryReview` 等へ改名する場合は別 issue が適切。

## 検証

- `npm run check` 0 errors / `check:text` 0 件 / `check:consistency` 0 件 / `check:evidence-strength` 0 件 / `check:stale` 0 件
- `npm run build` 成功（OG 74 枚）。`dist/` で新ラベルが **67 戦略ページ + changelog** に出現、旧ラベルの残存は changelog の引用文のみ
- dev で `digital-technology` / `oral-language` / `phonics` の 3 パターンを目視確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)