### PR TITLE
refactor(design-system): replace arbitrary colour values with utilities

### DIFF
--- a/src/components/RelatedStrategyCard.astro
+++ b/src/components/RelatedStrategyCard.astro
@@ -44,10 +44,10 @@ const stars = "★".repeat(evidenceStrength) + "☆".repeat(5 - evidenceStrength
 const effectSign = monthsGained > 0 ? "+" : monthsGained === 0 ? "±" : "";
 const effectColor =
   monthsGained > 0
-    ? "text-[var(--color-accent)]"
+    ? "text-accent"
     : monthsGained === 0
-      ? "text-[var(--color-sub)]"
-      : "text-[var(--color-chart-red)]";
+      ? "text-sub"
+      : "text-chart-red";
 
 const effectBarMax = 9;
 const effectBarPct = Math.min(Math.abs(monthsGained), effectBarMax) / effectBarMax * 100;
@@ -57,12 +57,12 @@ const effectBarSign =
 
 <a
   href={href}
-  class="group block border border-[var(--color-line)] rounded-xl p-5 motion-safe:transition-colors motion-safe:duration-200 motion-safe:ease-out hover:border-[var(--color-accent)] hover:bg-[var(--color-card)] focus-visible:outline-none focus-visible:border-[var(--color-accent)] focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg)]"
+  class="group block border border-line rounded-xl p-5 motion-safe:transition-colors motion-safe:duration-200 motion-safe:ease-out hover:border-accent hover:bg-card focus-visible:outline-none focus-visible:border-accent focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
 >
   <div class="flex items-start justify-between gap-4">
     <div class="flex-1 min-w-0 space-y-2">
       <div class="flex flex-wrap items-center gap-2">
-        <h3 class="text-lg md:text-xl font-black tracking-tight leading-tight motion-safe:transition-colors motion-safe:duration-200 motion-safe:ease-out group-hover:text-[var(--color-accent)] group-focus-visible:text-[var(--color-accent)]">
+        <h3 class="text-lg md:text-xl font-black tracking-tight leading-tight motion-safe:transition-colors motion-safe:duration-200 motion-safe:ease-out group-hover:text-accent group-focus-visible:text-accent">
           {title}
         </h3>
         {badges.map((key) => (
@@ -73,7 +73,7 @@ const effectBarSign =
           </span>
         ))}
       </div>
-      <p class="text-sm text-[var(--color-sub)] leading-relaxed line-clamp-2">
+      <p class="text-sm text-sub leading-relaxed line-clamp-2">
         {summary}
       </p>
       <div class="font-mono text-[10px] uppercase tracking-widest text-amber-600" aria-label={`エビデンスの強さ ${evidenceStrength} / 5`}>
@@ -84,7 +84,7 @@ const effectBarSign =
       <div class="text-2xl md:text-3xl leading-none">
         {effectSign}{monthsGained}<span class="text-xs font-sans ml-0.5">ヶ月</span>
       </div>
-      <div class="mt-1 text-[var(--color-sub)] text-sm motion-safe:transition group-hover:translate-x-1 inline-block">→</div>
+      <div class="mt-1 text-sub text-sm motion-safe:transition group-hover:translate-x-1 inline-block">→</div>
     </div>
   </div>
 

--- a/src/components/StrategyRow.astro
+++ b/src/components/StrategyRow.astro
@@ -42,10 +42,10 @@ if (badges.length === 0) badges.push("eef");
 const effectSign = monthsGained > 0 ? "+" : monthsGained === 0 ? "±" : "";
 const effectColor =
   monthsGained > 0
-    ? "text-[var(--color-accent)]"
+    ? "text-accent"
     : monthsGained === 0
-      ? "text-[var(--color-sub)]"
-      : "text-[var(--color-chart-red)]";
+      ? "text-sub"
+      : "text-chart-red";
 
 const effectBarMax = 9;
 const effectBarPct = Math.min(Math.abs(monthsGained), effectBarMax) / effectBarMax * 100;
@@ -58,11 +58,11 @@ const effectBarSign =
   data-category={category ?? "指導法"}
   data-months={monthsGained}
   data-evidence={evidenceStrength}
-  class="strategy-row group block border-t border-[var(--color-line)] py-4 sm:py-8 md:py-10"
+  class="strategy-row group block border-t border-line py-4 sm:py-8 md:py-10"
 >
   <div class="grid grid-cols-12 gap-4 md:gap-6 items-center px-4 sm:px-2">
     <div
-      class="col-span-2 md:col-span-1 font-mono text-sm text-[var(--color-sub)]"
+      class="col-span-2 md:col-span-1 font-mono text-sm text-sub"
       data-num
     >
       {num}
@@ -71,7 +71,7 @@ const effectBarSign =
     <div class="col-span-10 md:col-span-7 space-y-2">
       <div class="flex flex-wrap items-center gap-2">
         <h2
-          class="text-2xl md:text-3xl font-black tracking-tight leading-tight group-hover:text-[var(--color-accent)] transition-colors"
+          class="text-2xl md:text-3xl font-black tracking-tight leading-tight group-hover:text-accent transition-colors"
         >
           {title}
         </h2>
@@ -84,7 +84,7 @@ const effectBarSign =
         ))}
       </div>
       <div
-        class="font-mono text-[11px] uppercase tracking-widest text-[var(--color-sub)] flex flex-wrap items-center gap-x-4 gap-y-1"
+        class="font-mono text-[11px] uppercase tracking-widest text-sub flex flex-wrap items-center gap-x-4 gap-y-1"
       >
         <span>{subjects.join(" · ")}</span>
         <span>{grades.join(" · ")}</span>
@@ -99,7 +99,7 @@ const effectBarSign =
     >
       {effectSign}{monthsGained}<span class="text-sm md:text-base font-sans ml-1">ヶ月</span>
       <span
-        class="inline-block ml-3 transition group-hover:translate-x-1 text-[var(--color-sub)] text-lg md:text-xl"
+        class="inline-block ml-3 transition group-hover:translate-x-1 text-sub text-lg md:text-xl"
         >→</span
       >
     </div>

--- a/src/components/TableOfContents.astro
+++ b/src/components/TableOfContents.astro
@@ -21,7 +21,7 @@ const items = headings.filter((h) => h.depth === 2 || h.depth === 3);
         data-toc
         data-toc-variant="sidebar"
       >
-        <p class="font-mono text-[10px] uppercase tracking-widest text-[var(--color-sub)] mb-3">
+        <p class="font-mono text-[10px] uppercase tracking-widest text-sub mb-3">
           目次
         </p>
         <ol class="space-y-1.5">
@@ -29,7 +29,7 @@ const items = headings.filter((h) => h.depth === 2 || h.depth === 3);
             <li class={h.depth === 3 ? "pl-3" : ""}>
               <a
                 href={`#${h.slug}`}
-                class="toc-link block text-sm leading-snug text-[var(--color-sub)] hover:text-[var(--color-ink)] transition-colors"
+                class="toc-link block text-sm leading-snug text-sub hover:text-ink transition-colors"
                 data-toc-link
               >
                 {h.text}
@@ -40,12 +40,12 @@ const items = headings.filter((h) => h.depth === 2 || h.depth === 3);
       </nav>
     ) : (
       <details
-        class="toc toc-mobile lg:hidden border border-[var(--color-line)] rounded-md mb-8"
+        class="toc toc-mobile lg:hidden border border-line rounded-md mb-8"
         data-toc
         data-toc-variant="mobile"
         data-state="closed"
       >
-        <summary class="cursor-pointer select-none flex items-center justify-between px-4 py-3 text-sm font-mono uppercase tracking-widest text-[var(--color-sub)]">
+        <summary class="cursor-pointer select-none flex items-center justify-between px-4 py-3 text-sm font-mono uppercase tracking-widest text-sub">
           <span>目次({items.length})</span>
           <svg
             class="toc-chevron w-4 h-4"
@@ -60,12 +60,12 @@ const items = headings.filter((h) => h.depth === 2 || h.depth === 3);
             <path d="m6 9 6 6 6-6" />
           </svg>
         </summary>
-        <ol class="space-y-1.5 px-4 pb-4 pt-1 border-t border-[var(--color-line)]">
+        <ol class="space-y-1.5 px-4 pb-4 pt-1 border-t border-line">
           {items.map((h) => (
             <li class={h.depth === 3 ? "pl-3" : ""}>
               <a
                 href={`#${h.slug}`}
-                class="toc-link inline-block py-1 text-sm leading-snug text-[var(--color-sub)] hover:text-[var(--color-ink)] transition-colors"
+                class="toc-link inline-block py-1 text-sm leading-snug text-sub hover:text-ink transition-colors"
                 data-toc-link
               >
                 {h.text}

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -109,32 +109,32 @@ const escapeLd = (obj: object): string => JSON.stringify(obj).replace(/</g, "\\u
       src="https://static.cloudflareinsights.com/beacon.min.js"
       data-cf-beacon='{"token": "14afdc722e86475ca003f42c859d679d"}'></script>
   </head>
-  <body class="bg-[var(--color-bg)] text-[var(--color-ink)]" data-menu="closed">
+  <body class="bg-bg text-ink" data-menu="closed">
     <a href="#main-content" class="skip-link">本文へスキップ</a>
     <header class="site-header">
       <div
         class="mx-auto max-w-6xl px-3 xs:px-4 sm:px-6 md:px-10 h-16 flex items-center justify-between gap-4"
       >
         <a href="/" class="font-black text-lg sm:text-xl tracking-tight flex items-center gap-2 whitespace-nowrap shrink-0">
-          <span class="text-[var(--color-accent)] inline-flex shrink-0">
+          <span class="text-accent inline-flex shrink-0">
             <Logo class="w-7 h-7" />
           </span>
-          EduEvidence <span class="text-[var(--color-accent)]">JP</span>
+          EduEvidence <span class="text-accent">JP</span>
         </a>
-        <nav class="hidden lg:flex items-center text-xs gap-4 lg:gap-6 text-[var(--color-sub)]" aria-label="メインナビゲーション">
+        <nav class="hidden lg:flex items-center text-xs gap-4 lg:gap-6 text-sub" aria-label="メインナビゲーション">
           <a href="/" class="link-underline">ホーム</a>
           <a href="/concerns" class="link-underline">悩みから探す</a>
           <a href="/#strategy-list" class="link-underline">指導法から探す</a>
           <a href="/columns" class="link-underline">コラム</a>
           <a href="/guide" class="link-underline">ガイド</a>
           <a href="/about" class="link-underline">サイトについて</a>
-          <a href="/search" class="hover:text-[var(--color-ink)] transition" aria-label="検索">
+          <a href="/search" class="hover:text-ink transition" aria-label="検索">
             <svg class="w-4 h-4 inline-block" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
           </a>
           <button
             id="theme-toggle"
             type="button"
-            class="theme-toggle relative flex items-center justify-center w-8 h-8 text-[var(--color-sub)] hover:text-[var(--color-ink)] transition-colors"
+            class="theme-toggle relative flex items-center justify-center w-8 h-8 text-sub hover:text-ink transition-colors"
             aria-label="ダークモードに切り替え"
             aria-pressed="false"
           >
@@ -162,9 +162,9 @@ const escapeLd = (obj: object): string => JSON.stringify(obj).replace(/</g, "\\u
           aria-expanded="false"
           aria-controls="mobile-menu"
         >
-          <span class="block w-6 h-[2px] bg-[var(--color-ink)] transition-transform duration-200 origin-center"></span>
-          <span class="block w-6 h-[2px] bg-[var(--color-ink)] transition-opacity duration-200"></span>
-          <span class="block w-6 h-[2px] bg-[var(--color-ink)] transition-transform duration-200 origin-center"></span>
+          <span class="block w-6 h-[2px] bg-ink transition-transform duration-200 origin-center"></span>
+          <span class="block w-6 h-[2px] bg-ink transition-opacity duration-200"></span>
+          <span class="block w-6 h-[2px] bg-ink transition-transform duration-200 origin-center"></span>
         </button>
       </div>
       <div
@@ -494,30 +494,30 @@ const escapeLd = (obj: object): string => JSON.stringify(obj).replace(/</g, "\\u
       })();
     </script>
 
-    <footer class="border-t border-[var(--color-line)]">
+    <footer class="border-t border-line">
       <div
-        class="mx-auto max-w-6xl px-3 xs:px-4 sm:px-6 md:px-10 py-6 xs:py-8 sm:py-12 grid md:grid-cols-4 gap-8 text-xs text-[var(--color-sub)] leading-relaxed"
+        class="mx-auto max-w-6xl px-3 xs:px-4 sm:px-6 md:px-10 py-6 xs:py-8 sm:py-12 grid md:grid-cols-4 gap-8 text-xs text-sub leading-relaxed"
       >
         <!-- Column 1: ブランド + コンタクト + 購読 -->
         <div class="space-y-4">
-          <div class="font-black text-base text-[var(--color-ink)] flex items-center gap-2">
-            <span class="text-[var(--color-accent)] inline-flex">
+          <div class="font-black text-base text-ink flex items-center gap-2">
+            <span class="text-accent inline-flex">
               <Logo class="w-5 h-5" />
             </span>
-            EduEvidence <span class="text-[var(--color-accent)]">JP</span>
+            EduEvidence <span class="text-accent">JP</span>
           </div>
           <p class="leading-relaxed">
             教員一人ひとりが「研究で確かめられた知見」にアクセスできるように。<br />
             英国 EEF Toolkit を起点に、73の指導法を「効果」「信頼性」「コスト」「出典」の4指標で整理し、日本の小学校現場に合わせて翻案・公開しています。
           </p>
           <div class="space-y-1.5 pt-2">
-            <div class="font-mono uppercase tracking-widest text-[10px] text-[var(--color-ink)]">お問い合わせ</div>
+            <div class="font-mono uppercase tracking-widest text-[10px] text-ink">お問い合わせ</div>
             <div>
               <a href="mailto:info@edu-evidence.org" class="link-underline">info@edu-evidence.org</a>
             </div>
           </div>
           <div class="space-y-1.5">
-            <div class="font-mono uppercase tracking-widest text-[10px] text-[var(--color-ink)]">購読</div>
+            <div class="font-mono uppercase tracking-widest text-[10px] text-ink">購読</div>
             <div>
               <a href="/rss.xml" class="link-underline">RSS フィード</a>
             </div>
@@ -528,7 +528,7 @@ const escapeLd = (obj: object): string => JSON.stringify(obj).replace(/</g, "\\u
         <section aria-labelledby="footer-explore" class="space-y-3">
           <h2
             id="footer-explore"
-            class="font-mono uppercase tracking-widest text-[var(--color-ink)] text-xs"
+            class="font-mono uppercase tracking-widest text-ink text-xs"
           >
             Explore — 探す
           </h2>
@@ -546,7 +546,7 @@ const escapeLd = (obj: object): string => JSON.stringify(obj).replace(/</g, "\\u
         <section aria-labelledby="footer-learn" class="space-y-3">
           <h2
             id="footer-learn"
-            class="font-mono uppercase tracking-widest text-[var(--color-ink)] text-xs"
+            class="font-mono uppercase tracking-widest text-ink text-xs"
           >
             Learn — 学ぶ・読む
           </h2>
@@ -565,7 +565,7 @@ const escapeLd = (obj: object): string => JSON.stringify(obj).replace(/</g, "\\u
           <section aria-labelledby="footer-about" class="space-y-3">
             <h2
               id="footer-about"
-              class="font-mono uppercase tracking-widest text-[var(--color-ink)] text-xs"
+              class="font-mono uppercase tracking-widest text-ink text-xs"
             >
               About — サイトについて
             </h2>
@@ -578,13 +578,13 @@ const escapeLd = (obj: object): string => JSON.stringify(obj).replace(/</g, "\\u
           <section aria-labelledby="footer-sister" class="space-y-3">
             <h2
               id="footer-sister"
-              class="font-mono uppercase tracking-widest text-[var(--color-ink)] text-xs"
+              class="font-mono uppercase tracking-widest text-ink text-xs"
             >
               Sister Sites — 姉妹サイト
             </h2>
             <ul class="space-y-1.5">
               <li>
-                <span aria-current="page" class="text-[var(--color-ink)]">EduEvidence JP(このサイト)</span>
+                <span aria-current="page" class="text-ink">EduEvidence JP(このサイト)</span>
               </li>
               <li>
                 <a href="https://news.edu-evidence.org" class="link-underline">EduWatch JP — 教育ニュース</a>
@@ -596,7 +596,7 @@ const escapeLd = (obj: object): string => JSON.stringify(obj).replace(/</g, "\\u
           </section>
         </div>
       </div>
-      <div class="mx-auto max-w-6xl px-3 xs:px-4 sm:px-6 md:px-10 pb-4 xs:pb-6 sm:pb-8 text-[10px] text-[var(--color-sub)] leading-relaxed">
+      <div class="mx-auto max-w-6xl px-3 xs:px-4 sm:px-6 md:px-10 pb-4 xs:pb-6 sm:pb-8 text-[10px] text-sub leading-relaxed">
         © 2026 EduEvidence JP. CC BY-SA 4.0. 英国 EEF
         <a
           class="link-underline"

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -5,20 +5,20 @@ import Layout from "../layouts/Layout.astro";
 <Layout title="ページが見つかりません — EduEvidence JP">
   <section class="py-20 sm:py-32 md:py-40 text-center space-y-8">
     <div class="space-y-2">
-      <p class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]">
+      <p class="font-mono text-xs uppercase tracking-widest text-accent">
         404 — Not Found
       </p>
-      <h1 class="font-black text-6xl md:text-8xl tracking-tight text-[var(--color-sub)]">
+      <h1 class="font-black text-6xl md:text-8xl tracking-tight text-sub">
         404
       </h1>
     </div>
-    <p class="text-[var(--color-sub)] text-base md:text-lg leading-relaxed max-w-md mx-auto">
+    <p class="text-sub text-base md:text-lg leading-relaxed max-w-md mx-auto">
       お探しのページは見つかりませんでした。<br />
       URLが変わったか、削除された可能性があります。
     </p>
     <a
       href="/"
-      class="group inline-flex items-center gap-2 border border-[var(--color-line)] text-[var(--color-sub)] rounded-full px-6 py-2.5 text-sm hover:border-[var(--color-accent)] hover:text-[var(--color-accent)] transition"
+      class="group inline-flex items-center gap-2 border border-line text-sub rounded-full px-6 py-2.5 text-sm hover:border-accent hover:text-accent transition"
     >
       トップページへ戻る
       <span class="inline-block transition-transform group-hover:translate-x-1">→</span>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -4,14 +4,14 @@ import Layout from "../layouts/Layout.astro";
 
 <Layout title="About — EduEvidence JP">
   <section class="pt-10 sm:pt-14 md:pt-20 lg:pt-28 pb-10 sm:pb-14 md:pb-20">
-    <p class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]">
+    <p class="font-mono text-xs uppercase tracking-widest text-accent">
       About
     </p>
-    <p class="mt-1 text-xs text-[var(--color-sub)]">サイトについて</p>
+    <p class="mt-1 text-xs text-sub">サイトについて</p>
     <h1
       class="mt-5 font-black text-4xl sm:text-5xl md:text-6xl lg:text-7xl leading-[1.15] tracking-tight"
     >
-      経験と勘に、<br /><span class="text-[var(--color-accent)]">エビデンス</span>を。
+      経験と勘に、<br /><span class="text-accent">エビデンス</span>を。
     </h1>
   </section>
 
@@ -36,36 +36,36 @@ import Layout from "../layouts/Layout.astro";
           <strong>EduEvidence JP</strong>・EduWatch JP・EduLaw JP は、教員の仕事を 1 本の木に見立てた姉妹サイトです。光を受けて学びを育てる「成熟した葉」、日々新しい情報が芽吹く「双葉」、足元から制度を支える「根」——それぞれが独立したサイトとして、1 本の木を形づくります。
         </p>
         <div class="grid sm:grid-cols-3 gap-5">
-          <div class="border border-[var(--color-line)] rounded-xl p-5 space-y-1.5">
-            <div class="font-mono text-[10px] uppercase tracking-widest text-[var(--color-sub)]">
+          <div class="border border-line rounded-xl p-5 space-y-1.5">
+            <div class="font-mono text-[10px] uppercase tracking-widest text-sub">
               成熟した葉
             </div>
             <div class="font-bold">
               <span aria-current="page">EduEvidence JP（このサイト）</span>
             </div>
-            <p class="text-sm text-[var(--color-sub)] leading-relaxed">
+            <p class="text-sm text-sub leading-relaxed">
               研究で確かめられた指導法・コラムを長期に蓄積するエビデンスポータル（ストック型）。
             </p>
           </div>
-          <div class="border border-[var(--color-line)] rounded-xl p-5 space-y-1.5">
-            <div class="font-mono text-[10px] uppercase tracking-widest text-[var(--color-sub)]">
+          <div class="border border-line rounded-xl p-5 space-y-1.5">
+            <div class="font-mono text-[10px] uppercase tracking-widest text-sub">
               双葉
             </div>
             <div class="font-bold">
-              <a href="https://news.edu-evidence.org" target="_blank" rel="noopener noreferrer" class="link-underline text-[var(--color-accent)]">EduWatch JP</a>
+              <a href="https://news.edu-evidence.org" target="_blank" rel="noopener noreferrer" class="link-underline text-accent">EduWatch JP</a>
             </div>
-            <p class="text-sm text-[var(--color-sub)] leading-relaxed">
+            <p class="text-sm text-sub leading-relaxed">
               教育の一次情報を日次収集し、週次ダイジェストで論点を整理（フロー型）。
             </p>
           </div>
-          <div class="border border-[var(--color-line)] rounded-xl p-5 space-y-1.5">
-            <div class="font-mono text-[10px] uppercase tracking-widest text-[var(--color-sub)]">
+          <div class="border border-line rounded-xl p-5 space-y-1.5">
+            <div class="font-mono text-[10px] uppercase tracking-widest text-sub">
               根
             </div>
             <div class="font-bold">
-              <a href="https://law.edu-evidence.org" target="_blank" rel="noopener noreferrer" class="link-underline text-[var(--color-accent)]">EduLaw JP</a>
+              <a href="https://law.edu-evidence.org" target="_blank" rel="noopener noreferrer" class="link-underline text-accent">EduLaw JP</a>
             </div>
-            <p class="text-sm text-[var(--color-sub)] leading-relaxed">
+            <p class="text-sm text-sub leading-relaxed">
               教育関連法と公式解説を法令別に整理する、制度の基盤。
             </p>
           </div>
@@ -76,42 +76,42 @@ import Layout from "../layouts/Layout.astro";
       <div class="space-y-6">
         <h2 class="text-2xl font-black tracking-tight">運営・執筆</h2>
         <div
-          class="border border-[var(--color-line)] rounded-xl p-6 md:p-8 space-y-4"
+          class="border border-line rounded-xl p-6 md:p-8 space-y-4"
         >
           <div class="space-y-1">
-            <div class="font-mono text-xs uppercase tracking-widest text-[var(--color-sub)]">
+            <div class="font-mono text-xs uppercase tracking-widest text-sub">
               企画・執筆
             </div>
             <div class="font-bold text-lg">
               Isagawa Hayato
             </div>
-            <p class="text-sm text-[var(--color-sub)] leading-relaxed">
+            <p class="text-sm text-sub leading-relaxed">
               元小学校教諭。現場経験約 10 年。学級担任の他、非常勤講師・理科専科・特別支援学級担任を経験。<br />
               小学校一種免許・中学校一種免許(理科)・高等学校一種免許(理科)保持。
             </p>
-            <p class="text-sm text-[var(--color-sub)] leading-relaxed pt-2">
-              教員時代に中室牧子氏の『<a href="https://d21.co.jp/book/9784799317327" target="_blank" rel="noopener noreferrer" class="link-underline text-[var(--color-accent)]">「学力」の経済学</a>』に出会い、エビデンスに基づく教育に興味を持つ。
+            <p class="text-sm text-sub leading-relaxed pt-2">
+              教員時代に中室牧子氏の『<a href="https://d21.co.jp/book/9784799317327" target="_blank" rel="noopener noreferrer" class="link-underline text-accent">「学力」の経済学</a>』に出会い、エビデンスに基づく教育に興味を持つ。
               現在は退職し、フリーランスのウェブエンジニアとして活動。
-              <a href="https://youtu.be/O1y8BTmGvDA" target="_blank" rel="noopener" class="link-underline text-[var(--color-accent)]">「フィンランド教育の失敗：日本の詰め込み教育はそこまで悪いのか？」</a>という動画をきっかけに、改めてエビデンスを伴った教育について学び始める（関連コラム: <a href="/columns/finland-education-myth" class="link-underline text-[var(--color-accent)]">フィンランド教育神話を冷静に見る</a>）。
-              その中で松岡亮二氏の『<a href="https://www.chikumashobo.co.jp/product/9784480072375/" target="_blank" rel="noopener noreferrer" class="link-underline text-[var(--color-accent)]">教育格差</a>』に出会い、データに基づく教育への学びを深めている。
+              <a href="https://youtu.be/O1y8BTmGvDA" target="_blank" rel="noopener" class="link-underline text-accent">「フィンランド教育の失敗：日本の詰め込み教育はそこまで悪いのか？」</a>という動画をきっかけに、改めてエビデンスを伴った教育について学び始める（関連コラム: <a href="/columns/finland-education-myth" class="link-underline text-accent">フィンランド教育神話を冷静に見る</a>）。
+              その中で松岡亮二氏の『<a href="https://www.chikumashobo.co.jp/product/9784480072375/" target="_blank" rel="noopener noreferrer" class="link-underline text-accent">教育格差</a>』に出会い、データに基づく教育への学びを深めている。
               本サイトは、現場で得た実感と研究の知見をつなぎたいという思いから立ち上げた。
             </p>
           </div>
           <div class="space-y-1">
-            <div class="font-mono text-xs uppercase tracking-widest text-[var(--color-sub)]">
+            <div class="font-mono text-xs uppercase tracking-widest text-sub">
               監修
             </div>
-            <div class="text-sm text-[var(--color-sub)]">
+            <div class="text-sm text-sub">
               （今後、教育研究の専門家による監修体制を構築予定です）
             </div>
           </div>
           <div class="space-y-1">
-            <div class="font-mono text-xs uppercase tracking-widest text-[var(--color-sub)]">
+            <div class="font-mono text-xs uppercase tracking-widest text-sub">
               協力
             </div>
-            <div class="text-sm text-[var(--color-sub)]">
+            <div class="text-sm text-sub">
               本サイトの改善にご協力いただける教員・研究者の方を募集しています。<br />
-              お問い合わせ: <a href="mailto:info@edu-evidence.org" class="link-underline text-[var(--color-accent)]">info@edu-evidence.org</a>
+              お問い合わせ: <a href="mailto:info@edu-evidence.org" class="link-underline text-accent">info@edu-evidence.org</a>
             </div>
           </div>
         </div>
@@ -209,7 +209,7 @@ import Layout from "../layouts/Layout.astro";
               </li>
             </ol>
             <p>
-              可能な限り、EEF・日本研究・Hattie の値を併記し、読者が比較できるようにしています。両者で値が異なる場合は「文化的注記」で補足しています。詳しくは <a href="/guide/cultural-context" class="link-underline text-[var(--color-accent)]">エビデンスと文化的文脈</a> を参照してください。
+              可能な限り、EEF・日本研究・Hattie の値を併記し、読者が比較できるようにしています。両者で値が異なる場合は「文化的注記」で補足しています。詳しくは <a href="/guide/cultural-context" class="link-underline text-accent">エビデンスと文化的文脈</a> を参照してください。
             </p>
           </div>
           <div class="space-y-2">
@@ -270,7 +270,7 @@ import Layout from "../layouts/Layout.astro";
         <p>
           本サイトは英国の Education Endowment Foundation (EEF) が公開する
           <a
-            class="link-underline text-[var(--color-accent)]"
+            class="link-underline text-accent"
             href="https://educationendowmentfoundation.org.uk/education-evidence/teaching-learning-toolkit"
             target="_blank"
             rel="noopener noreferrer">Teaching and Learning Toolkit</a
@@ -287,37 +287,37 @@ import Layout from "../layouts/Layout.astro";
             <h3 class="font-bold text-lg">日本の研究・書籍</h3>
             <ul class="space-y-3 text-sm leading-relaxed">
               <li>
-                『<a href="https://d21.co.jp/book/9784799317327" target="_blank" rel="noopener noreferrer" class="link-underline text-[var(--color-accent)]">「学力」の経済学</a>』 中室牧子 (2015), ディスカヴァー・トゥエンティワン. — 教育経済学の入門書。非認知能力・早期教育・インセンティブ設計など、本サイトでも繰り返し参照する知見を日本に紹介した代表作。
+                『<a href="https://d21.co.jp/book/9784799317327" target="_blank" rel="noopener noreferrer" class="link-underline text-accent">「学力」の経済学</a>』 中室牧子 (2015), ディスカヴァー・トゥエンティワン. — 教育経済学の入門書。非認知能力・早期教育・インセンティブ設計など、本サイトでも繰り返し参照する知見を日本に紹介した代表作。
               </li>
               <li>
-                『<a href="https://www.diamond.co.jp/book/9784478121092.html" target="_blank" rel="noopener noreferrer" class="link-underline text-[var(--color-accent)]">科学的根拠(エビデンス)で子育て — 教育経済学の最前線</a>』 中室牧子 (2024), ダイヤモンド社. — 近年の実証研究を保護者・教員向けに整理した最新の一冊。
+                『<a href="https://www.diamond.co.jp/book/9784478121092.html" target="_blank" rel="noopener noreferrer" class="link-underline text-accent">科学的根拠(エビデンス)で子育て — 教育経済学の最前線</a>』 中室牧子 (2024), ダイヤモンド社. — 近年の実証研究を保護者・教員向けに整理した最新の一冊。
               </li>
               <li>
-                『<a href="https://www.chikumashobo.co.jp/product/9784480072375/" target="_blank" rel="noopener noreferrer" class="link-underline text-[var(--color-accent)]">教育格差</a>』 松岡亮二 (2019), ちくま新書. — 家庭の SES・地域・性別が学力・進学率・学歴に与える影響を体系的に実証。教育格差の論点では本書を基盤に置いている。
+                『<a href="https://www.chikumashobo.co.jp/product/9784480072375/" target="_blank" rel="noopener noreferrer" class="link-underline text-accent">教育格差</a>』 松岡亮二 (2019), ちくま新書. — 家庭の SES・地域・性別が学力・進学率・学歴に与える影響を体系的に実証。教育格差の論点では本書を基盤に置いている。
               </li>
               <li>
-                『<a href="https://www.minervashobo.co.jp/book/b589599.html" target="_blank" rel="noopener noreferrer" class="link-underline text-[var(--color-accent)]">現場で使える教育社会学 — 教職のための「教育格差」入門</a>』 中村高康・松岡亮二 編著 (2021), ミネルヴァ書房. — 教育格差を教職課程向けに解説した教育社会学の入門テキスト。教員養成で十分に扱われてこなかった教育格差を全 15 章で扱い、各章に現場のための Q&A と演習を備える。松岡『教育格差』と問題意識を共有する一冊。
+                『<a href="https://www.minervashobo.co.jp/book/b589599.html" target="_blank" rel="noopener noreferrer" class="link-underline text-accent">現場で使える教育社会学 — 教職のための「教育格差」入門</a>』 中村高康・松岡亮二 編著 (2021), ミネルヴァ書房. — 教育格差を教職課程向けに解説した教育社会学の入門テキスト。教員養成で十分に扱われてこなかった教育格差を全 15 章で扱い、各章に現場のための Q&A と演習を備える。松岡『教育格差』と問題意識を共有する一冊。
               </li>
               <li>
-                『<a href="https://www.chuko.co.jp/laclef/2021/09/150740.html" target="_blank" rel="noopener noreferrer" class="link-underline text-[var(--color-accent)]">教育論の新常識 — 格差・学力・政策・未来</a>』 松岡亮二 編著 (2021), 中公新書ラクレ. — GIGA スクール・子どもの貧困・ジェンダー・九月入学など 20 のキーワードを、中室牧子ら計 22 名の専門家が解説する共著。
+                『<a href="https://www.chuko.co.jp/laclef/2021/09/150740.html" target="_blank" rel="noopener noreferrer" class="link-underline text-accent">教育論の新常識 — 格差・学力・政策・未来</a>』 松岡亮二 編著 (2021), 中公新書ラクレ. — GIGA スクール・子どもの貧困・ジェンダー・九月入学など 20 のキーワードを、中室牧子ら計 22 名の専門家が解説する共著。
               </li>
               <li>
-                『<a href="https://www.chikumashobo.co.jp/product/9784480073716/" target="_blank" rel="noopener noreferrer" class="link-underline text-[var(--color-accent)]">日本の教育はダメじゃない — 国際比較データで問いなおす</a>』 小松光・ジェルミー・ラプリー (2021), ちくま新書. — PISA など国際比較データから日本の教育を再評価する一冊。過度な自虐論への実証的な反証。
+                『<a href="https://www.chikumashobo.co.jp/product/9784480073716/" target="_blank" rel="noopener noreferrer" class="link-underline text-accent">日本の教育はダメじゃない — 国際比較データで問いなおす</a>』 小松光・ジェルミー・ラプリー (2021), ちくま新書. — PISA など国際比較データから日本の教育を再評価する一冊。過度な自虐論への実証的な反証。
               </li>
               <li>
-                『<a href="https://www.chuko.co.jp/ebook/2013/07/513962.html" target="_blank" rel="noopener noreferrer" class="link-underline text-[var(--color-accent)]">人間形成の日米比較 — かくれたカリキュラム</a>』 恒吉僚子 (1992), 中公新書. — 日本と米国の「個と集団」をめぐる意識の違いを、幼児教育・小学校の観察から浮かび上がらせた「かくれたカリキュラム」論の古典。
+                『<a href="https://www.chuko.co.jp/ebook/2013/07/513962.html" target="_blank" rel="noopener noreferrer" class="link-underline text-accent">人間形成の日米比較 — かくれたカリキュラム</a>』 恒吉僚子 (1992), 中公新書. — 日本と米国の「個と集団」をめぐる意識の違いを、幼児教育・小学校の観察から浮かび上がらせた「かくれたカリキュラム」論の古典。
               </li>
               <li>
-                『<a href="https://www.kadokawa.co.jp/product/322310000993/" target="_blank" rel="noopener noreferrer" class="link-underline text-[var(--color-accent)]">科学的根拠に基づく最高の勉強法</a>』 安川康介 (2024), KADOKAWA. — アクティブ・リコール(検索練習)、分散学習など、本サイトの戦略ページと重なる認知科学的学習法を平易にまとめた一冊。
+                『<a href="https://www.kadokawa.co.jp/product/322310000993/" target="_blank" rel="noopener noreferrer" class="link-underline text-accent">科学的根拠に基づく最高の勉強法</a>』 安川康介 (2024), KADOKAWA. — アクティブ・リコール(検索練習)、分散学習など、本サイトの戦略ページと重なる認知科学的学習法を平易にまとめた一冊。
               </li>
               <li>
-                『<a href="https://www.kobunsha.com/shelf/book/isbn/9784334046545" target="_blank" rel="noopener noreferrer" class="link-underline text-[var(--color-accent)]">東大生、教育格差を学ぶ</a>』 松岡亮二・髙橋史子・中村高康 編著 (2023), 光文社新書. — 東京大学のゼミで松岡『<a href="https://www.chikumashobo.co.jp/product/9784480072375/" target="_blank" rel="noopener noreferrer" class="link-underline text-[var(--color-accent)]">教育格差</a>』をテキストに議論した記録を編集した一冊。学生が自身の教育体験を格差論と突き合わせる構成が、教員研修の素材としても使える。
+                『<a href="https://www.kobunsha.com/shelf/book/isbn/9784334046545" target="_blank" rel="noopener noreferrer" class="link-underline text-accent">東大生、教育格差を学ぶ</a>』 松岡亮二・髙橋史子・中村高康 編著 (2023), 光文社新書. — 東京大学のゼミで松岡『<a href="https://www.chikumashobo.co.jp/product/9784480072375/" target="_blank" rel="noopener noreferrer" class="link-underline text-accent">教育格差</a>』をテキストに議論した記録を編集した一冊。学生が自身の教育体験を格差論と突き合わせる構成が、教員研修の素材としても使える。
               </li>
               <li>
-                『<a href="https://www.diamond.co.jp/book/9784478039472.html" target="_blank" rel="noopener noreferrer" class="link-underline text-[var(--color-accent)]">「原因と結果」の経済学 — データから真実を見抜く思考法</a>』 中室牧子・津川友介 (2017), ダイヤモンド社. — 因果推論の入門書。RCT・自然実験など本サイトで頻出する概念を、数式を使わず教育・健康・経済の具体例で解説。エビデンスを読むリテラシーの土台。
+                『<a href="https://www.diamond.co.jp/book/9784478039472.html" target="_blank" rel="noopener noreferrer" class="link-underline text-accent">「原因と結果」の経済学 — データから真実を見抜く思考法</a>』 中室牧子・津川友介 (2017), ダイヤモンド社. — 因果推論の入門書。RCT・自然実験など本サイトで頻出する概念を、数式を使わず教育・健康・経済の具体例で解説。エビデンスを読むリテラシーの土台。
               </li>
               <li>
-                『<a href="https://www.sbcr.jp/product/4815633417/" target="_blank" rel="noopener noreferrer" class="link-underline text-[var(--color-accent)]">ハーバード、スタンフォード、オックスフォード… 科学的に証明された すごい習慣大百科 — 人生が変わるテクニック112個集めました</a>』 堀田秀吾 (2025), SB クリエイティブ. — 心理学・行動科学・脳科学の研究に基づく習慣を 112 項目に整理。各項目に引用元研究が明記されており、一次ソースを辿る起点として使える。
+                『<a href="https://www.sbcr.jp/product/4815633417/" target="_blank" rel="noopener noreferrer" class="link-underline text-accent">ハーバード、スタンフォード、オックスフォード… 科学的に証明された すごい習慣大百科 — 人生が変わるテクニック112個集めました</a>』 堀田秀吾 (2025), SB クリエイティブ. — 心理学・行動科学・脳科学の研究に基づく習慣を 112 項目に整理。各項目に引用元研究が明記されており、一次ソースを辿る起点として使える。
               </li>
             </ul>
           </div>
@@ -326,10 +326,10 @@ import Layout from "../layouts/Layout.astro";
             <h3 class="font-bold text-lg">海外の研究者・書籍</h3>
             <ul class="space-y-3 text-sm leading-relaxed">
               <li>
-                『<a href="https://bookstore.sunmark.co.jp/products/9784763138439" target="_blank" rel="noopener noreferrer" class="link-underline text-[var(--color-accent)]">米国最強経済学者にして 2 児の母が読み解く 子どもの育て方ベスト</a>』 エミリー・オスター 著 / 堀内久美子 訳 (2022), サンマーク出版. — ブラウン大学経済学部教授。中室牧子と同様にデータ・統計を経済学の手法で読み解き、就学前期の子育てをめぐる通説を実証研究に照らして再検討する。
+                『<a href="https://bookstore.sunmark.co.jp/products/9784763138439" target="_blank" rel="noopener noreferrer" class="link-underline text-accent">米国最強経済学者にして 2 児の母が読み解く 子どもの育て方ベスト</a>』 エミリー・オスター 著 / 堀内久美子 訳 (2022), サンマーク出版. — ブラウン大学経済学部教授。中室牧子と同様にデータ・統計を経済学の手法で読み解き、就学前期の子育てをめぐる通説を実証研究に照らして再検討する。
               </li>
               <li>
-                『<a href="https://www.hayakawa-online.co.jp/shopdetail/000000013682/" target="_blank" rel="noopener noreferrer" class="link-underline text-[var(--color-accent)]">日本の15歳はなぜ学力が高いのか? — 5つの教育大国に学ぶ成功の秘密</a>』 ルーシー・クレハン 著 / 橋川史 訳 (2017), 早川書房. — 英国の教育研究者が日本・フィンランド・上海・シンガポール・カナダの 5 教育大国を実地調査したフィールドレポート。
+                『<a href="https://www.hayakawa-online.co.jp/shopdetail/000000013682/" target="_blank" rel="noopener noreferrer" class="link-underline text-accent">日本の15歳はなぜ学力が高いのか? — 5つの教育大国に学ぶ成功の秘密</a>』 ルーシー・クレハン 著 / 橋川史 訳 (2017), 早川書房. — 英国の教育研究者が日本・フィンランド・上海・シンガポール・カナダの 5 教育大国を実地調査したフィールドレポート。
               </li>
             </ul>
           </div>
@@ -338,13 +338,13 @@ import Layout from "../layouts/Layout.astro";
             <h3 class="font-bold text-lg">国際的な枠組み・研究データベース</h3>
             <ul class="space-y-3 text-sm leading-relaxed">
               <li>
-                <a href="https://educationendowmentfoundation.org.uk/education-evidence/teaching-learning-toolkit" target="_blank" rel="noopener noreferrer" class="link-underline text-[var(--color-accent)]">Education Endowment Foundation — Teaching and Learning Toolkit</a>. — 英国の教育研究財団が 30 以上の指導法をメタ分析で評価。本サイトの効果量(+◯ヶ月)の主要な参照元。
+                <a href="https://educationendowmentfoundation.org.uk/education-evidence/teaching-learning-toolkit" target="_blank" rel="noopener noreferrer" class="link-underline text-accent">Education Endowment Foundation — Teaching and Learning Toolkit</a>. — 英国の教育研究財団が 30 以上の指導法をメタ分析で評価。本サイトの効果量(+◯ヶ月)の主要な参照元。
               </li>
               <li>
-                <a href="https://www.oecd.org/pisa/" target="_blank" rel="noopener noreferrer" class="link-underline text-[var(--color-accent)]">OECD — PISA (Programme for International Student Assessment)</a>. — 3 年ごとの国際学力調査。読解・数学・科学の国際比較データの出典。
+                <a href="https://www.oecd.org/pisa/" target="_blank" rel="noopener noreferrer" class="link-underline text-accent">OECD — PISA (Programme for International Student Assessment)</a>. — 3 年ごとの国際学力調査。読解・数学・科学の国際比較データの出典。
               </li>
               <li>
-                Hattie, J. <a href="https://www.visiblelearningmetax.com/" target="_blank" rel="noopener noreferrer" class="link-underline text-[var(--color-accent)]">Visible Learning MetaX</a>. — 800 以上のメタ分析を統合した教育要因のデータベース。効果量が楽観的に出やすい点を注記した上で参考値として併記している。
+                Hattie, J. <a href="https://www.visiblelearningmetax.com/" target="_blank" rel="noopener noreferrer" class="link-underline text-accent">Visible Learning MetaX</a>. — 800 以上のメタ分析を統合した教育要因のデータベース。効果量が楽観的に出やすい点を注記した上で参考値として併記している。
               </li>
             </ul>
           </div>
@@ -353,16 +353,16 @@ import Layout from "../layouts/Layout.astro";
             <h3 class="font-bold text-lg">日本の公式資料</h3>
             <ul class="space-y-3 text-sm leading-relaxed">
               <li>
-                <a href="https://www.mext.go.jp/a_menu/shotou/gakuryoku-chousa/" target="_blank" rel="noopener noreferrer" class="link-underline text-[var(--color-accent)]">文部科学省 — 全国学力・学習状況調査</a>. — 毎年実施の小 6・中 3 対象学力調査。学力・家庭環境・学習習慣のデータ源。
+                <a href="https://www.mext.go.jp/a_menu/shotou/gakuryoku-chousa/" target="_blank" rel="noopener noreferrer" class="link-underline text-accent">文部科学省 — 全国学力・学習状況調査</a>. — 毎年実施の小 6・中 3 対象学力調査。学力・家庭環境・学習習慣のデータ源。
               </li>
               <li>
-                <a href="https://www.mext.go.jp/content/20230220-mxt_jidou01-000024699-201-1.pdf" target="_blank" rel="noopener noreferrer" class="link-underline text-[var(--color-accent)]">文部科学省 — 生徒指導提要(2022 年改訂)</a>. — 生徒指導の 4 層構造(発達支持的・課題予防的 2 層・困難課題対応的)を定義した公式ガイドライン。
+                <a href="https://www.mext.go.jp/content/20230220-mxt_jidou01-000024699-201-1.pdf" target="_blank" rel="noopener noreferrer" class="link-underline text-accent">文部科学省 — 生徒指導提要(2022 年改訂)</a>. — 生徒指導の 4 層構造(発達支持的・課題予防的 2 層・困難課題対応的)を定義した公式ガイドライン。
               </li>
               <li>
-                <a href="https://www.mext.go.jp/a_menu/other/mext_02412.html" target="_blank" rel="noopener noreferrer" class="link-underline text-[var(--color-accent)]">文部科学省 — 初等中等教育段階における生成 AI の利活用に関するガイドライン(Ver.2.0)</a>. — 2024 年 12 月公表。生成 AI の学校現場での扱い方に関する公式指針。
+                <a href="https://www.mext.go.jp/a_menu/other/mext_02412.html" target="_blank" rel="noopener noreferrer" class="link-underline text-accent">文部科学省 — 初等中等教育段階における生成 AI の利活用に関するガイドライン(Ver.2.0)</a>. — 2024 年 12 月公表。生成 AI の学校現場での扱い方に関する公式指針。
               </li>
               <li>
-                <a href="https://www.j-sla.or.jp/material/research/dokusyotyousa.html" target="_blank" rel="noopener noreferrer" class="link-underline text-[var(--color-accent)]">全国学校図書館協議会 — 学校読書調査</a>. — 毎年実施される読書冊数調査。小中高の読書習慣データ源。
+                <a href="https://www.j-sla.or.jp/material/research/dokusyotyousa.html" target="_blank" rel="noopener noreferrer" class="link-underline text-accent">全国学校図書館協議会 — 学校読書調査</a>. — 毎年実施される読書冊数調査。小中高の読書習慣データ源。
               </li>
             </ul>
           </div>

--- a/src/pages/changelog.astro
+++ b/src/pages/changelog.astro
@@ -974,13 +974,13 @@ const typeLabel: Record<string, { label: string; color: string }> = {
   add: { label: "追加", color: "text-emerald-700 dark:text-emerald-300" },
   update: { label: "更新", color: "text-amber-800 dark:text-amber-200" },
   fix: { label: "修正", color: "text-rose-700 dark:text-rose-200" },
-  remove: { label: "削除", color: "text-[var(--color-sub)]" },
+  remove: { label: "削除", color: "text-sub" },
 };
 ---
 
 <Layout title="更新履歴 — EduEvidence JP">
   <section class="pt-10 sm:pt-14 md:pt-20 lg:pt-28 pb-10 sm:pb-14 md:pb-20">
-    <p class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]">
+    <p class="font-mono text-xs uppercase tracking-widest text-accent">
       Changelog
     </p>
     <h1
@@ -988,7 +988,7 @@ const typeLabel: Record<string, { label: string; color: string }> = {
     >
       更新履歴
     </h1>
-    <div class="mt-6 max-w-2xl text-[var(--color-sub)] leading-loose text-sm sm:text-base">
+    <div class="mt-6 max-w-2xl text-sub leading-loose text-sm sm:text-base">
       <p>
         記事の追加・修正・改訂を時系列で記録しています。
       </p>
@@ -998,8 +998,8 @@ const typeLabel: Record<string, { label: string; color: string }> = {
   <section class="pb-24">
     {
       entries.map((entry) => (
-        <div class="border-t border-[var(--color-line)] py-10 space-y-4">
-          <div class="font-mono text-sm text-[var(--color-accent)]">
+        <div class="border-t border-line py-10 space-y-4">
+          <div class="font-mono text-sm text-accent">
             {entry.date}
           </div>
           <ul class="space-y-3">
@@ -1031,6 +1031,6 @@ const typeLabel: Record<string, { label: string; color: string }> = {
         </div>
       ))
     }
-    <div class="border-t border-[var(--color-line)]"></div>
+    <div class="border-t border-line"></div>
   </section>
 </Layout>

--- a/src/pages/columns/[...slug].astro
+++ b/src/pages/columns/[...slug].astro
@@ -84,8 +84,8 @@ const breadcrumbJsonLd = {
   breadcrumbJsonLd={breadcrumbJsonLd}
   longForm
 >
-  <header class="pt-10 sm:pt-14 md:pt-20 lg:pt-28 pb-12 border-b border-[var(--color-line)]">
-    <p class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]">
+  <header class="pt-10 sm:pt-14 md:pt-20 lg:pt-28 pb-12 border-b border-line">
+    <p class="font-mono text-xs uppercase tracking-widest text-accent">
       Column
     </p>
     <h1
@@ -93,7 +93,7 @@ const breadcrumbJsonLd = {
     >
       {d.title}
     </h1>
-    <p class="mt-3 text-sm text-[var(--color-sub)] font-mono tracking-wide">
+    <p class="mt-3 text-sm text-sub font-mono tracking-wide">
       <time datetime={d.date}>公開: {formatDay(d.date)}</time>
       {d.lastVerified && d.lastVerified !== d.date && (
         <span class="ml-3">
@@ -102,7 +102,7 @@ const breadcrumbJsonLd = {
       )}
     </p>
     <p
-      class="mt-6 text-[var(--color-sub)] text-base md:text-lg leading-loose max-w-2xl"
+      class="mt-6 text-sub text-base md:text-lg leading-loose max-w-2xl"
     >
       {d.summary}
     </p>
@@ -112,7 +112,7 @@ const breadcrumbJsonLd = {
           {d.tags.map((tag) => (
             <a
               href={`/tags/${encodeURIComponent(tag)}`}
-              class="font-mono text-[11px] uppercase tracking-widest text-[var(--color-sub)] border border-[var(--color-line)] rounded-full px-3 py-1 hover:border-[var(--color-accent)] hover:text-[var(--color-accent)] transition"
+              class="font-mono text-[11px] uppercase tracking-widest text-sub border border-line rounded-full px-3 py-1 hover:border-accent hover:text-accent transition"
             >
               {tag}
             </a>
@@ -120,7 +120,7 @@ const breadcrumbJsonLd = {
         </div>
       )
     }
-    <p class="mt-6 text-[var(--color-sub)] text-sm leading-relaxed">
+    <p class="mt-6 text-sub text-sm leading-relaxed">
       <a href="/columns" class="link-underline">← コラム一覧</a>
       <span class="ml-3"><a href="/" class="link-underline">トップ</a></span>
     </p>
@@ -140,13 +140,13 @@ const breadcrumbJsonLd = {
 
   {
     seriesItems.length >= 2 && (
-      <section class="pt-10 border-t border-[var(--color-line)] max-w-2xl space-y-6">
+      <section class="pt-10 border-t border-line max-w-2xl space-y-6">
         <div class="space-y-1">
-          <div class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]">
+          <div class="font-mono text-xs uppercase tracking-widest text-accent">
             Series
           </div>
           <h2 class="text-2xl font-black tracking-tight">シリーズ: {seriesTitle}</h2>
-          <p class="text-sm text-[var(--color-sub)]">
+          <p class="text-sm text-sub">
             全{seriesItems.length}回シリーズの第{currentIndex + 1}回です。
           </p>
         </div>
@@ -154,15 +154,15 @@ const breadcrumbJsonLd = {
           {seriesItems.map((c, i) =>
             c.id === entry.id ? (
               <li>
-                <div class="block border border-[var(--color-accent)] rounded-xl p-4 bg-[var(--color-card)]">
+                <div class="block border border-accent rounded-xl p-4 bg-card">
                   <div class="space-y-1">
-                    <div class="font-mono text-[10px] uppercase tracking-widest text-[var(--color-accent)]">
+                    <div class="font-mono text-[10px] uppercase tracking-widest text-accent">
                       第{i + 1}回 ・ この記事
                     </div>
                     <h3 class="text-base md:text-lg font-black tracking-tight leading-snug">
                       {c.data.title}
                     </h3>
-                    <p class="text-sm text-[var(--color-sub)] leading-relaxed line-clamp-2">
+                    <p class="text-sm text-sub leading-relaxed line-clamp-2">
                       {c.data.summary}
                     </p>
                   </div>
@@ -172,21 +172,21 @@ const breadcrumbJsonLd = {
               <li>
                 <a
                   href={`/columns/${c.id}`}
-                  class="group block border border-[var(--color-line)] rounded-xl p-4 transition hover:border-[var(--color-accent)] hover:bg-[var(--color-card)]"
+                  class="group block border border-line rounded-xl p-4 transition hover:border-accent hover:bg-card"
                 >
                   <div class="flex items-start justify-between gap-4">
                     <div class="flex-1 min-w-0 space-y-1">
-                      <div class="font-mono text-[10px] uppercase tracking-widest text-[var(--color-sub)]">
+                      <div class="font-mono text-[10px] uppercase tracking-widest text-sub">
                         第{i + 1}回
                       </div>
-                      <h3 class="text-base md:text-lg font-black tracking-tight leading-snug group-hover:text-[var(--color-accent)] transition">
+                      <h3 class="text-base md:text-lg font-black tracking-tight leading-snug group-hover:text-accent transition">
                         {c.data.title}
                       </h3>
-                      <p class="text-sm text-[var(--color-sub)] leading-relaxed line-clamp-2">
+                      <p class="text-sm text-sub leading-relaxed line-clamp-2">
                         {c.data.summary}
                       </p>
                     </div>
-                    <span class="shrink-0 text-[var(--color-sub)] transition group-hover:translate-x-1">
+                    <span class="shrink-0 text-sub transition group-hover:translate-x-1">
                       →
                     </span>
                   </div>
@@ -201,13 +201,13 @@ const breadcrumbJsonLd = {
 
   {
     related.length > 0 && (
-      <section class="pt-10 border-t border-[var(--color-line)] max-w-2xl space-y-6">
+      <section class="pt-10 border-t border-line max-w-2xl space-y-6">
         <div class="space-y-1">
-          <div class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]">
+          <div class="font-mono text-xs uppercase tracking-widest text-accent">
             Related Strategies
           </div>
           <h2 class="text-2xl font-black tracking-tight">関連する指導法</h2>
-          <p class="text-sm text-[var(--color-sub)]">
+          <p class="text-sm text-sub">
             本コラムで言及した指導法の詳細ページ。エビデンスの強さと効果量を確認できます。
           </p>
         </div>
@@ -227,10 +227,10 @@ const breadcrumbJsonLd = {
     )
   }
 
-  <div class="pt-10 mt-10 border-t border-[var(--color-line)] max-w-2xl">
+  <div class="pt-10 mt-10 border-t border-line max-w-2xl">
     <a
       href="/columns"
-      class="link-underline font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]"
+      class="link-underline font-mono text-xs uppercase tracking-widest text-accent"
     >
       ← コラム一覧へ戻る
     </a>

--- a/src/pages/columns/index.astro
+++ b/src/pages/columns/index.astro
@@ -32,15 +32,15 @@ function formatListDay(iso: string): string {
 
 <Layout title="エビデンスで考える — EduEvidence JP">
   <section class="pt-10 sm:pt-14 md:pt-20 lg:pt-28 pb-10 sm:pb-14 md:pb-20">
-    <p class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]">
+    <p class="font-mono text-xs uppercase tracking-widest text-accent">
       Columns — Think with evidence
     </p>
     <h1
       class="mt-5 font-black text-4xl sm:text-5xl md:text-6xl lg:text-7xl leading-[1.15] tracking-tight"
     >
-      <span class="text-[var(--color-accent)]">エビデンス</span>で考える
+      <span class="text-accent">エビデンス</span>で考える
     </h1>
-    <div class="mt-6 max-w-2xl text-[var(--color-sub)] leading-loose text-sm sm:text-base">
+    <div class="mt-6 max-w-2xl text-sub leading-loose text-sm sm:text-base">
       <p>
         教育界で話題のテーマを、研究のエビデンスに照らして考えるコラムシリーズです。
       </p>
@@ -54,8 +54,8 @@ function formatListDay(iso: string): string {
         data-filter="all"
         class={`tag-chip font-mono text-[11px] uppercase tracking-widest border rounded-full px-3 py-1 transition cursor-pointer ${
           initialTag === ""
-            ? "border-[var(--color-accent)] bg-[var(--color-accent)] text-white dark:text-[var(--color-bg)]"
-            : "border-[var(--color-line)] text-[var(--color-sub)] hover:border-[var(--color-accent)] hover:text-[var(--color-accent)]"
+            ? "border-accent bg-accent text-white dark:text-bg"
+            : "border-line text-sub hover:border-accent hover:text-accent"
         }`}
       >
         すべて <span class="ml-1">{columns.length}</span>
@@ -67,8 +67,8 @@ function formatListDay(iso: string): string {
             data-filter={tag}
             class={`tag-chip font-mono text-[11px] uppercase tracking-widest border rounded-full px-3 py-1 transition cursor-pointer ${
               initialTag === tag
-                ? "border-[var(--color-accent)] bg-[var(--color-accent)] text-white dark:text-[var(--color-bg)]"
-                : "border-[var(--color-line)] text-[var(--color-sub)] hover:border-[var(--color-accent)] hover:text-[var(--color-accent)]"
+                ? "border-accent bg-accent text-white dark:text-bg"
+                : "border-line text-sub hover:border-accent hover:text-accent"
             }`}
           >
             {tag} <span class="ml-1">{count}</span>
@@ -76,14 +76,14 @@ function formatListDay(iso: string): string {
         ))
       }
     </div>
-    <p class="mt-3 text-xs text-[var(--color-sub)]" data-result-count>
+    <p class="mt-3 text-xs text-sub" data-result-count>
       {initialTag ? `「${initialTag}」に一致: ` : "全 "}
       <span data-result-num>{initialTag ? tagCounts.get(initialTag) ?? 0 : columns.length}</span> 件
     </p>
   </section>
 
   <section class="pb-24">
-    <div class="border-b border-[var(--color-line)]" data-column-list>
+    <div class="border-b border-line" data-column-list>
       {
         columns.map((c, i) => {
           const matches = initialTag === "" || c.data.tags.includes(initialTag);
@@ -92,31 +92,31 @@ function formatListDay(iso: string): string {
               href={`/columns/${c.id}`}
               data-tags={JSON.stringify(c.data.tags)}
               data-hidden={matches ? undefined : "true"}
-              class="group block border-t border-[var(--color-line)] py-10 transition hover:bg-[var(--color-card)] data-[hidden=true]:hidden"
+              class="group block border-t border-line py-10 transition hover:bg-card data-[hidden=true]:hidden"
             >
               <div class="grid grid-cols-12 gap-4 items-baseline px-2">
-                <div class="col-span-2 md:col-span-1 font-mono text-sm text-[var(--color-sub)]">
+                <div class="col-span-2 md:col-span-1 font-mono text-sm text-sub">
                   {String(i + 1).padStart(2, "0")}
                 </div>
                 <div class="col-span-10 md:col-span-8 space-y-2">
-                  <h3 class="text-2xl md:text-3xl font-black tracking-tight leading-tight group-hover:text-[var(--color-accent)] transition">
+                  <h3 class="text-2xl md:text-3xl font-black tracking-tight leading-tight group-hover:text-accent transition">
                     {c.data.title}
                   </h3>
-                  <p class="text-sm text-[var(--color-sub)] leading-relaxed line-clamp-2">
+                  <p class="text-sm text-sub leading-relaxed line-clamp-2">
                     {c.data.summary}
                   </p>
                 </div>
                 <div class="col-span-12 md:col-span-3 md:text-right">
                   <time
-                    class="font-mono text-xs text-[var(--color-sub)]"
+                    class="font-mono text-xs text-sub"
                     datetime={c.data.lastVerified ?? c.data.date}
                   >
                     {formatListDay(c.data.lastVerified ?? c.data.date)}
                     {c.data.lastVerified && c.data.lastVerified !== c.data.date && (
-                      <span class="ml-1 text-[var(--color-accent)]">(更新)</span>
+                      <span class="ml-1 text-accent">(更新)</span>
                     )}
                   </time>
-                  <span class="inline-block ml-3 transition group-hover:translate-x-1 text-[var(--color-sub)]">
+                  <span class="inline-block ml-3 transition group-hover:translate-x-1 text-sub">
                     →
                   </span>
                 </div>
@@ -138,16 +138,16 @@ function formatListDay(iso: string): string {
     if (!filterRoot || !list || !resultNum || !resultLabel) return;
 
     const activeClasses = [
-      "border-[var(--color-accent)]",
-      "bg-[var(--color-accent)]",
+      "border-accent",
+      "bg-accent",
       "text-white",
-      "dark:text-[var(--color-bg)]",
+      "dark:text-bg",
     ];
     const inactiveClasses = [
-      "border-[var(--color-line)]",
-      "text-[var(--color-sub)]",
-      "hover:border-[var(--color-accent)]",
-      "hover:text-[var(--color-accent)]",
+      "border-line",
+      "text-sub",
+      "hover:border-accent",
+      "hover:text-accent",
     ];
 
     function setActive(buttonEl) {

--- a/src/pages/concerns/index.astro
+++ b/src/pages/concerns/index.astro
@@ -28,13 +28,13 @@ function formatMonths(m: number): string {
 
 <Layout title="悩みから探す — EduEvidence JP">
   <section class="pt-10 sm:pt-14 md:pt-20 lg:pt-28 pb-10 sm:pb-14 md:pb-20">
-    <p class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]">
+    <p class="font-mono text-xs uppercase tracking-widest text-accent">
       Find by your concern
     </p>
     <h1 class="mt-5 font-black text-4xl sm:text-5xl md:text-6xl lg:text-7xl leading-[1.15] tracking-tight">
-      <span class="text-[var(--color-accent)]">悩み</span>から探す
+      <span class="text-accent">悩み</span>から探す
     </h1>
-    <div class="mt-6 max-w-2xl text-[var(--color-sub)] leading-loose text-sm sm:text-base space-y-2">
+    <div class="mt-6 max-w-2xl text-sub leading-loose text-sm sm:text-base space-y-2">
       <p>
         現場でよくある悩みから、エビデンスに裏付けられた指導法・コラムに進めます。
       </p>
@@ -48,10 +48,10 @@ function formatMonths(m: number): string {
     {
       concernCategories.map((cat) => (
         <div class="space-y-6">
-          <div class="border-b border-[var(--color-line)] pb-3 flex items-baseline gap-4 flex-wrap relative pl-4">
+          <div class="border-b border-line pb-3 flex items-baseline gap-4 flex-wrap relative pl-4">
             <span
               aria-hidden="true"
-              class="absolute left-0 top-1 w-[3px] h-[calc(100%-1rem)] rounded-full bg-[var(--color-accent)]"
+              class="absolute left-0 top-1 w-[3px] h-[calc(100%-1rem)] rounded-full bg-accent"
             />
             <h2
               id={cat.id}
@@ -59,7 +59,7 @@ function formatMonths(m: number): string {
             >
               {cat.title}
             </h2>
-            <p class="text-sm text-[var(--color-sub)]">{cat.description}</p>
+            <p class="text-sm text-sub">{cat.description}</p>
           </div>
 
           <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -69,19 +69,19 @@ function formatMonths(m: number): string {
               return (
                 <article
                   id={concern.slug}
-                  class="border border-[var(--color-line)] rounded-xl p-5 md:p-6 bg-[var(--color-card)] space-y-4 motion-safe:transition-colors motion-safe:duration-200 motion-safe:ease-out focus-within:border-[var(--color-accent)]"
+                  class="border border-line rounded-xl p-5 md:p-6 bg-card space-y-4 motion-safe:transition-colors motion-safe:duration-200 motion-safe:ease-out focus-within:border-accent"
                 >
                   <h3 class="font-black text-lg md:text-xl leading-snug">
                     {concern.title}
                   </h3>
-                  <p class="text-sm text-[var(--color-sub)] leading-relaxed">
+                  <p class="text-sm text-sub leading-relaxed">
                     {concern.diagnosis}
                   </p>
 
                   <div class="space-y-2">
                     <p
                       id={strategiesLabelId}
-                      class="font-mono text-[10px] uppercase tracking-widest text-[var(--color-sub)]"
+                      class="font-mono text-[10px] uppercase tracking-widest text-sub"
                     >
                       関連する指導法
                     </p>
@@ -95,17 +95,17 @@ function formatMonths(m: number): string {
                         const monthsLabel = formatMonths(s.monthsGained);
                         const monthsClass =
                           s.monthsGained > 0
-                            ? "text-[var(--color-accent)]"
+                            ? "text-accent"
                             : s.monthsGained < 0
-                              ? "text-[var(--color-chart-red)]"
-                              : "text-[var(--color-sub)]";
+                              ? "text-chart-red"
+                              : "text-sub";
                         return (
                           <li>
                             <a
                               href={`/strategies/${slug}`}
-                              class="group inline-flex items-baseline gap-1.5 border border-[var(--color-line)] rounded-full px-3 min-h-[1.5rem] py-1 text-xs bg-[var(--color-bg)] motion-safe:transition-colors motion-safe:duration-200 motion-safe:ease-out hover:border-[var(--color-accent)] hover:bg-[var(--color-card)] focus-visible:outline-none focus-visible:border-[var(--color-accent)] focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg)]"
+                              class="group inline-flex items-baseline gap-1.5 border border-line rounded-full px-3 min-h-[1.5rem] py-1 text-xs bg-bg motion-safe:transition-colors motion-safe:duration-200 motion-safe:ease-out hover:border-accent hover:bg-card focus-visible:outline-none focus-visible:border-accent focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
                             >
-                              <span class="font-bold motion-safe:transition-colors motion-safe:duration-200 motion-safe:ease-out group-hover:text-[var(--color-accent)] group-focus-visible:text-[var(--color-accent)]">
+                              <span class="font-bold motion-safe:transition-colors motion-safe:duration-200 motion-safe:ease-out group-hover:text-accent group-focus-visible:text-accent">
                                 {s.title}
                               </span>
                               <span class={`font-mono text-[10px] font-bold ${monthsClass}`}>
@@ -122,7 +122,7 @@ function formatMonths(m: number): string {
                     <div class="space-y-2">
                       <p
                         id={columnsLabelId}
-                        class="font-mono text-[10px] uppercase tracking-widest text-[var(--color-sub)]"
+                        class="font-mono text-[10px] uppercase tracking-widest text-sub"
                       >
                         関連コラム
                       </p>
@@ -137,15 +137,15 @@ function formatMonths(m: number): string {
                             <li>
                               <a
                                 href={`/columns/${slug}`}
-                                class="group inline-flex items-center gap-1.5 border border-[var(--color-line)] rounded-full px-3 min-h-[1.5rem] py-1 text-xs bg-[var(--color-bg)] motion-safe:transition-colors motion-safe:duration-200 motion-safe:ease-out hover:border-[var(--color-accent)] hover:bg-[var(--color-card)] focus-visible:outline-none focus-visible:border-[var(--color-accent)] focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg)]"
+                                class="group inline-flex items-center gap-1.5 border border-line rounded-full px-3 min-h-[1.5rem] py-1 text-xs bg-bg motion-safe:transition-colors motion-safe:duration-200 motion-safe:ease-out hover:border-accent hover:bg-card focus-visible:outline-none focus-visible:border-accent focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
                               >
                                 <span
                                   aria-hidden="true"
-                                  class="font-mono text-[9px] uppercase tracking-widest text-[var(--color-sub)] motion-safe:transition-colors motion-safe:duration-200 motion-safe:ease-out group-hover:text-[var(--color-accent)] group-focus-visible:text-[var(--color-accent)]"
+                                  class="font-mono text-[9px] uppercase tracking-widest text-sub motion-safe:transition-colors motion-safe:duration-200 motion-safe:ease-out group-hover:text-accent group-focus-visible:text-accent"
                                 >
                                   Column
                                 </span>
-                                <span class="motion-safe:transition-colors motion-safe:duration-200 motion-safe:ease-out group-hover:text-[var(--color-accent)] group-focus-visible:text-[var(--color-accent)]">
+                                <span class="motion-safe:transition-colors motion-safe:duration-200 motion-safe:ease-out group-hover:text-accent group-focus-visible:text-accent">
                                   {title}
                                 </span>
                               </a>

--- a/src/pages/cost/index.astro
+++ b/src/pages/cost/index.astro
@@ -41,13 +41,13 @@ const costGroups = [
 
 <Layout title="コストから探す — EduEvidence JP">
   <section class="pt-10 sm:pt-14 md:pt-20 lg:pt-28 pb-10 sm:pb-14 md:pb-20">
-    <p class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]">
+    <p class="font-mono text-xs uppercase tracking-widest text-accent">
       Browse by cost
     </p>
     <h1 class="mt-5 font-black text-4xl sm:text-5xl md:text-6xl lg:text-7xl leading-[1.15] tracking-tight">
       コストから探す
     </h1>
-    <div class="mt-6 max-w-2xl text-[var(--color-sub)] leading-loose text-sm sm:text-base">
+    <div class="mt-6 max-w-2xl text-sub leading-loose text-sm sm:text-base">
       <p>「お金をかけずに明日から」始められるものから探せます。</p>
     </div>
   </section>
@@ -65,11 +65,11 @@ const costGroups = [
               <div class="flex items-baseline gap-4 px-2">
                 <span class="text-xl font-black text-emerald-700 dark:text-emerald-300 tracking-widest">{group.yen}</span>
                 <h2 class="text-xl font-black tracking-tight">{group.label}</h2>
-                <span class="text-xs text-[var(--color-sub)]">{strategies.length}件</span>
+                <span class="text-xs text-sub">{strategies.length}件</span>
               </div>
-              <p class="text-sm text-[var(--color-sub)] px-2">{group.desc}</p>
+              <p class="text-sm text-sub px-2">{group.desc}</p>
             </div>
-            <div class="border-b border-[var(--color-line)]">
+            <div class="border-b border-line">
               {strategies.map((s, i) => (
                 <StrategyRow
                   index={i + 1}

--- a/src/pages/faq.astro
+++ b/src/pages/faq.astro
@@ -21,19 +21,19 @@ const faqSections = [
     items: [
 {
     q: "「+◯ヶ月」とは何を意味しますか?",
-    a: `その指導法を1年間取り入れた学級の子どもが、取り入れなかった場合より約◯ヶ月先の学力水準に到達した、という意味です。例えば「+5ヶ月」なら、1年間で約1年半分の成長が得られたことになります。ただし集団の平均値であり、すべての子どもに同じ効果が出ることを保証するものではありません。計算の詳細は <a href="/guide/indicators" class="link-underline text-[var(--color-accent)]">指標の読み方</a> を参照してください。`,
+    a: `その指導法を1年間取り入れた学級の子どもが、取り入れなかった場合より約◯ヶ月先の学力水準に到達した、という意味です。例えば「+5ヶ月」なら、1年間で約1年半分の成長が得られたことになります。ただし集団の平均値であり、すべての子どもに同じ効果が出ることを保証するものではありません。計算の詳細は <a href="/guide/indicators" class="link-underline text-accent">指標の読み方</a> を参照してください。`,
   },
   {
     q: "コスト(¥)には何が含まれていますか?",
-    a: `導入に必要な金銭的コスト(児童1人あたり年間)の概算です。EEF の £ 基準を日本円に換算しています(2026年4月時点、1£ ≒ 215円)。¥1つは「0〜17,000円/年/人」、¥5つは「258,000円以上」です。具体例は <a href="/guide/indicators" class="link-underline text-[var(--color-accent)]">指標の読み方</a> を参照してください。`,
+    a: `導入に必要な金銭的コスト(児童1人あたり年間)の概算です。EEF の £ 基準を日本円に換算しています(2026年4月時点、1£ ≒ 215円)。¥1つは「0〜17,000円/年/人」、¥5つは「258,000円以上」です。具体例は <a href="/guide/indicators" class="link-underline text-accent">指標の読み方</a> を参照してください。`,
   },
   {
     q: "エビデンスの強さ(★)はどう決まっていますか?",
-    a: `EEF が用いている基準(研究の数、研究デザインの質、対象者の規模、結果の一貫性など)を参考に、<strong>本サイトが各指導法を総合的に評価したもの</strong>です。★が多いほど「多くの質の高い研究で繰り返し確かめられている」ことを意味します。日本の研究や Hattie を主な出典とする指導法にも同じ尺度で付けています。判定は本サイトのルーブリックによるため、<strong>EEF を出典とする指導法でも、EEF 自身の確実性評価とは一致しないことがあります</strong>。EEF を出典に含むページでは、EEF 自身の評価を「出典別のエビデンス」に EEF の値として別に表示しています。詳しくは <a href="/guide/indicators" class="link-underline text-[var(--color-accent)]">指標の読み方</a> の「エビデンスの強さ」セクションをご覧ください。`,
+    a: `EEF が用いている基準(研究の数、研究デザインの質、対象者の規模、結果の一貫性など)を参考に、<strong>本サイトが各指導法を総合的に評価したもの</strong>です。★が多いほど「多くの質の高い研究で繰り返し確かめられている」ことを意味します。日本の研究や Hattie を主な出典とする指導法にも同じ尺度で付けています。判定は本サイトのルーブリックによるため、<strong>EEF を出典とする指導法でも、EEF 自身の確実性評価とは一致しないことがあります</strong>。EEF を出典に含むページでは、EEF 自身の評価を「出典別のエビデンス」に EEF の値として別に表示しています。詳しくは <a href="/guide/indicators" class="link-underline text-accent">指標の読み方</a> の「エビデンスの強さ」セクションをご覧ください。`,
   },
   {
     q: "出典バッジ(EEF・日本・Hattie)は何を意味していますか?",
-    a: `各指導法の効果量がどの研究ソースに基づいているかを示します。該当するものが複数あれば複数のバッジが表示されます。<strong>EEF</strong> は英国 Education Endowment Foundation の Teaching and Learning Toolkit、<strong>日本</strong> は中室牧子・松岡亮二・赤林英夫氏ら国内研究者の知見、<strong>Hattie</strong> は Visible Learning(参考値、上限寄りの傾向あり)を示します。詳細は <a href="/guide/indicators" class="link-underline text-[var(--color-accent)]">指標の読み方</a> の第4指標を参照してください。`,
+    a: `各指導法の効果量がどの研究ソースに基づいているかを示します。該当するものが複数あれば複数のバッジが表示されます。<strong>EEF</strong> は英国 Education Endowment Foundation の Teaching and Learning Toolkit、<strong>日本</strong> は中室牧子・松岡亮二・赤林英夫氏ら国内研究者の知見、<strong>Hattie</strong> は Visible Learning(参考値、上限寄りの傾向あり)を示します。詳細は <a href="/guide/indicators" class="link-underline text-accent">指標の読み方</a> の第4指標を参照してください。`,
   },
 
     ],
@@ -48,7 +48,7 @@ const faqSections = [
   },
   {
     q: "海外の研究結果は、日本の教室にも当てはまりますか?",
-    a: `注意が必要です。EEF の数値は主に英語圏のランダム化比較試験やメタ分析に基づいています。教育制度・文化・学級規模が異なる日本で、効果の大きさがそのまま再現されるとは限りません。ただし、フィードバックやメタ認知のように「学習のメカニズム」に働きかける指導法は、文化を超えて効果が確認される傾向があります。各戦略ページに「日本の文脈で考慮したいこと」を記載しています。詳しくは <a href="/guide/cultural-context" class="link-underline text-[var(--color-accent)]">エビデンスと文化的文脈</a> を参照してください。`,
+    a: `注意が必要です。EEF の数値は主に英語圏のランダム化比較試験やメタ分析に基づいています。教育制度・文化・学級規模が異なる日本で、効果の大きさがそのまま再現されるとは限りません。ただし、フィードバックやメタ認知のように「学習のメカニズム」に働きかける指導法は、文化を超えて効果が確認される傾向があります。各戦略ページに「日本の文脈で考慮したいこと」を記載しています。詳しくは <a href="/guide/cultural-context" class="link-underline text-accent">エビデンスと文化的文脈</a> を参照してください。`,
   },
   {
     q: "+◯ヶ月が大きい指導法をやれば、それでいいのですか?",
@@ -63,15 +63,15 @@ const faqSections = [
     items: [
   {
     q: "どこから読み始めるのがおすすめですか?",
-    a: `まず <a href="/guide/indicators" class="link-underline text-[var(--color-accent)]">指標の読み方</a> で数値の意味を把握し、<a href="/guide/evidence" class="link-underline text-[var(--color-accent)]">エビデンス入門</a> でエビデンスの考え方を押さえるとスムーズです。その後、気になる指導法を効果量順または費用対効果で探してみてください。高効果・低コストの代表例は <a href="/strategies/feedback" class="link-underline text-[var(--color-accent)]">フィードバック(${months("feedback")})</a> と <a href="/strategies/metacognition" class="link-underline text-[var(--color-accent)]">メタ認知の指導(${months("metacognition")})</a> です。`,
+    a: `まず <a href="/guide/indicators" class="link-underline text-accent">指標の読み方</a> で数値の意味を把握し、<a href="/guide/evidence" class="link-underline text-accent">エビデンス入門</a> でエビデンスの考え方を押さえるとスムーズです。その後、気になる指導法を効果量順または費用対効果で探してみてください。高効果・低コストの代表例は <a href="/strategies/feedback" class="link-underline text-accent">フィードバック(${months("feedback")})</a> と <a href="/strategies/metacognition" class="link-underline text-accent">メタ認知の指導(${months("metacognition")})</a> です。`,
   },
   {
     q: "効果がマイナスの指導法はあるのですか?",
-    a: `あります。本サイトにも掲載しており、例えば <a href="/strategies/repeating-a-year" class="link-underline text-[var(--color-accent)]">留年(${months("repeating-a-year")})</a>、<a href="/strategies/corporal-punishment" class="link-underline text-[var(--color-accent)]">体罰(${months("corporal-punishment")})</a>、<a href="/strategies/suspension" class="link-underline text-[var(--color-accent)]">停学・出席停止(${months("suspension")})</a>、<a href="/strategies/learning-styles" class="link-underline text-[var(--color-accent)]">学習スタイルに合わせた指導(${months("learning-styles")})</a> などは、研究で負の効果または効果が確認されていないことが報告されています。エビデンスは「やるべきこと」だけでなく「避けるべきこと」も教えてくれます。`,
+    a: `あります。本サイトにも掲載しており、例えば <a href="/strategies/repeating-a-year" class="link-underline text-accent">留年(${months("repeating-a-year")})</a>、<a href="/strategies/corporal-punishment" class="link-underline text-accent">体罰(${months("corporal-punishment")})</a>、<a href="/strategies/suspension" class="link-underline text-accent">停学・出席停止(${months("suspension")})</a>、<a href="/strategies/learning-styles" class="link-underline text-accent">学習スタイルに合わせた指導(${months("learning-styles")})</a> などは、研究で負の効果または効果が確認されていないことが報告されています。エビデンスは「やるべきこと」だけでなく「避けるべきこと」も教えてくれます。`,
   },
   {
     q: "特別支援教育にも当てはまりますか?",
-    a: `通常学級での指導を主に想定していますが、特別支援教育でも多くが参照できます。例えば <a href="/strategies/scaffolding" class="link-underline text-[var(--color-accent)]">足場かけ(${months("scaffolding")})</a>、<a href="/strategies/feedback" class="link-underline text-[var(--color-accent)]">フィードバック(${months("feedback")})</a>、<a href="/strategies/one-to-one-tuition" class="link-underline text-[var(--color-accent)]">個別指導(${months("one-to-one-tuition")})</a>、<a href="/strategies/universal-design-learning" class="link-underline text-[var(--color-accent)]">授業のユニバーサルデザイン(${months("universal-design-learning")})</a> は、通常学級の 8.8% とされる特別なニーズを持つ子どもにも有効と EEF の SEND ガイダンスで位置づけられています。`,
+    a: `通常学級での指導を主に想定していますが、特別支援教育でも多くが参照できます。例えば <a href="/strategies/scaffolding" class="link-underline text-accent">足場かけ(${months("scaffolding")})</a>、<a href="/strategies/feedback" class="link-underline text-accent">フィードバック(${months("feedback")})</a>、<a href="/strategies/one-to-one-tuition" class="link-underline text-accent">個別指導(${months("one-to-one-tuition")})</a>、<a href="/strategies/universal-design-learning" class="link-underline text-accent">授業のユニバーサルデザイン(${months("universal-design-learning")})</a> は、通常学級の 8.8% とされる特別なニーズを持つ子どもにも有効と EEF の SEND ガイダンスで位置づけられています。`,
   },
   {
     q: "カテゴリ(指導法 / 認知科学 / 制度・環境 等)はどう違うのですか?",
@@ -86,7 +86,7 @@ const faqSections = [
     items: [
   {
     q: "記事の内容はどのくらいの頻度で更新されますか?",
-    a: `EEF が原典を更新した場合や、国内で重要な研究が公表された場合に、随時見直します。明らかな誤りが見つかった場合は速やかに修正します。更新の履歴は <a href="/changelog" class="link-underline text-[var(--color-accent)]">更新履歴</a> で公開しています。各指導法ページには「最終検証日」も記載しています。`,
+    a: `EEF が原典を更新した場合や、国内で重要な研究が公表された場合に、随時見直します。明らかな誤りが見つかった場合は速やかに修正します。更新の履歴は <a href="/changelog" class="link-underline text-accent">更新履歴</a> で公開しています。各指導法ページには「最終検証日」も記載しています。`,
   },
   {
     q: "このサイトの内容を授業研究や校内研修で使ってもいいですか?",
@@ -94,7 +94,7 @@ const faqSections = [
   },
   {
     q: "自分の学校で実践した事例を共有したいのですが?",
-    a: `ぜひお寄せください。<a href="/voices" class="link-underline text-[var(--color-accent)]">現場の声</a> ページで実践事例を共有しています。匿名での掲載も可能です。<a href="mailto:info@edu-evidence.org" class="link-underline text-[var(--color-accent)]">info@edu-evidence.org</a> までご連絡ください。`,
+    a: `ぜひお寄せください。<a href="/voices" class="link-underline text-accent">現場の声</a> ページで実践事例を共有しています。匿名での掲載も可能です。<a href="mailto:info@edu-evidence.org" class="link-underline text-accent">info@edu-evidence.org</a> までご連絡ください。`,
   },
     ],
   },
@@ -103,7 +103,7 @@ const faqSections = [
 
 <Layout title="よくある質問 — EduEvidence JP">
   <section class="pt-10 sm:pt-14 md:pt-20 lg:pt-28 pb-10 sm:pb-14 md:pb-20">
-    <p class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]">
+    <p class="font-mono text-xs uppercase tracking-widest text-accent">
       Frequently asked questions
     </p>
     <h1
@@ -121,30 +121,30 @@ const faqSections = [
         return (
           <div class="space-y-4">
             <div class="space-y-1">
-              <p class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]">
+              <p class="font-mono text-xs uppercase tracking-widest text-accent">
                 Section {String(sIdx + 1).padStart(2, "0")}
               </p>
               <h2 class="font-black text-2xl md:text-3xl tracking-tight">{section.heading}</h2>
-              <p class="text-sm text-[var(--color-sub)]">{section.description}</p>
+              <p class="text-sm text-sub">{section.description}</p>
             </div>
             <div>
               {section.items.map((faq, i) => (
-                <div class="border-t border-[var(--color-line)] py-8 md:py-10">
+                <div class="border-t border-line py-8 md:py-10">
                   <div class="grid grid-cols-12 gap-4">
-                    <div class="col-span-2 md:col-span-1 font-mono text-sm text-[var(--color-sub)]">
+                    <div class="col-span-2 md:col-span-1 font-mono text-sm text-sub">
                       Q{String(qOffset + i + 1).padStart(2, "0")}
                     </div>
                     <div class="col-span-10 md:col-span-11 space-y-3">
                       <h3 class="font-bold text-lg">{faq.q}</h3>
                       <p
-                        class="prose-article text-[var(--color-sub)] leading-loose text-sm md:text-base"
+                        class="prose-article text-sub leading-loose text-sm md:text-base"
                         set:html={annotateGlossaryTerms(faq.a)}
                       />
                     </div>
                   </div>
                 </div>
               ))}
-              <div class="border-t border-[var(--color-line)]" />
+              <div class="border-t border-line" />
             </div>
           </div>
         );

--- a/src/pages/grades/[grade].astro
+++ b/src/pages/grades/[grade].astro
@@ -24,21 +24,21 @@ const strategies = allStrategies
 
 <Layout title={`${grade} — EduEvidence JP`}>
   <section class="pt-10 sm:pt-14 md:pt-20 lg:pt-28 pb-10 sm:pb-14 md:pb-20">
-    <p class="font-mono text-xs uppercase tracking-widest text-[var(--color-sub)]">
-      <a href="/grades" class="hover:text-[var(--color-ink)]">Grades</a> /
+    <p class="font-mono text-xs uppercase tracking-widest text-sub">
+      <a href="/grades" class="hover:text-ink">Grades</a> /
     </p>
-    <p class="mt-1 text-xs text-[var(--color-sub)]">学年で絞り込み</p>
+    <p class="mt-1 text-xs text-sub">学年で絞り込み</p>
     <h1 class="mt-5 font-black text-4xl sm:text-5xl md:text-6xl lg:text-7xl leading-[1.15] tracking-tight">
-      <span class="text-[var(--color-accent)]">{grade}</span>
+      <span class="text-accent">{grade}</span>
     </h1>
-    <div class="mt-6 max-w-2xl text-[var(--color-sub)] leading-loose text-sm sm:text-base space-y-1">
+    <div class="mt-6 max-w-2xl text-sub leading-loose text-sm sm:text-base space-y-1">
       <p>「{grade}」で活用できる指導法</p>
       <p class="text-xs">{strategies.length}件</p>
     </div>
   </section>
 
   <section class="pb-24 space-y-8">
-    <div class="border-b border-[var(--color-line)]">
+    <div class="border-b border-line">
       {strategies.map((s, i) => (
         <StrategyRow
           index={i + 1}
@@ -53,7 +53,7 @@ const strategies = allStrategies
       ))}
     </div>
     <div>
-      <a href="/grades" class="link-underline font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]">← 学年一覧へ戻る</a>
+      <a href="/grades" class="link-underline font-mono text-xs uppercase tracking-widest text-accent">← 学年一覧へ戻る</a>
     </div>
   </section>
 </Layout>

--- a/src/pages/grades/index.astro
+++ b/src/pages/grades/index.astro
@@ -19,13 +19,13 @@ const grades = [...gradeMap.entries()].sort(
 
 <Layout title="学年から探す — EduEvidence JP">
   <section class="pt-10 sm:pt-14 md:pt-20 lg:pt-28 pb-10 sm:pb-14 md:pb-20">
-    <p class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]">
+    <p class="font-mono text-xs uppercase tracking-widest text-accent">
       Browse by grade
     </p>
     <h1 class="mt-5 font-black text-4xl sm:text-5xl md:text-6xl lg:text-7xl leading-[1.15] tracking-tight">
       学年から探す
     </h1>
-    <div class="mt-6 max-w-2xl text-[var(--color-sub)] leading-loose text-sm sm:text-base">
+    <div class="mt-6 max-w-2xl text-sub leading-loose text-sm sm:text-base">
       <p>担当する学年で使える指導法を見つけられます。</p>
     </div>
   </section>
@@ -36,12 +36,12 @@ const grades = [...gradeMap.entries()].sort(
         grades.map(([grade, count]) => (
           <a
             href={`/grades/${encodeURIComponent(grade)}`}
-            class="group block border border-[var(--color-line)] rounded-xl p-6 hover:border-[var(--color-accent)] hover:bg-[var(--color-card)] transition text-center space-y-2"
+            class="group block border border-line rounded-xl p-6 hover:border-accent hover:bg-card transition text-center space-y-2"
           >
-            <div class="text-3xl font-black group-hover:text-[var(--color-accent)] transition">
+            <div class="text-3xl font-black group-hover:text-accent transition">
               {grade}
             </div>
-            <div class="text-xs text-[var(--color-sub)]">
+            <div class="text-xs text-sub">
               {count}件の指導法 →
             </div>
           </a>

--- a/src/pages/guide/cultural-context.astro
+++ b/src/pages/guide/cultural-context.astro
@@ -4,15 +4,15 @@ import Layout from "../../layouts/Layout.astro";
 
 <Layout title="エビデンスと文化的文脈 — EduEvidence JP">
   <section class="pt-10 sm:pt-14 md:pt-20 lg:pt-28 pb-10 sm:pb-14 md:pb-20">
-    <p class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]">
+    <p class="font-mono text-xs uppercase tracking-widest text-accent">
       Guide — Evidence in cultural context
     </p>
     <h1
       class="mt-5 font-black text-4xl sm:text-5xl md:text-6xl lg:text-7xl leading-[1.15] tracking-tight"
     >
-      エビデンスと<br /><span class="text-[var(--color-accent)]">文化的文脈</span>
+      エビデンスと<br /><span class="text-accent">文化的文脈</span>
     </h1>
-    <div class="mt-6 max-w-2xl text-[var(--color-sub)] leading-loose text-sm sm:text-base">
+    <div class="mt-6 max-w-2xl text-sub leading-loose text-sm sm:text-base">
       <p>
         海外の教育研究は、そのまま日本に当てはまりません。本サイトがどう「出典と文化」を扱うかを説明します。
       </p>
@@ -22,12 +22,12 @@ import Layout from "../../layouts/Layout.astro";
   <section class="pb-24 space-y-20">
 
     <!-- 1. 前提 -->
-    <div class="border-t border-[var(--color-line)] pt-10 space-y-6">
+    <div class="border-t border-line pt-10 space-y-6">
       <div class="flex items-center gap-6">
-        <span class="font-mono text-xs uppercase tracking-widest text-[var(--color-sub)]">01</span>
+        <span class="font-mono text-xs uppercase tracking-widest text-sub">01</span>
         <h2 class="text-3xl font-black tracking-tight">エビデンスは文化依存である</h2>
       </div>
-      <div class="leading-loose text-[var(--color-ink)]/90 space-y-4">
+      <div class="leading-loose text-ink/90 space-y-4">
         <p>
           教育研究の多くは、英語圏(米国・英国・豪州・ニュージーランドなど)で行われています。これらの研究を <strong>日本の小学校にそのまま当てはめても、同じ効果が出るとは限りません</strong>。
         </p>
@@ -38,35 +38,35 @@ import Layout from "../../layouts/Layout.astro";
     </div>
 
     <!-- 2. 具体例 -->
-    <div class="border-t border-[var(--color-line)] pt-10 space-y-6">
+    <div class="border-t border-line pt-10 space-y-6">
       <div class="flex items-center gap-6">
-        <span class="font-mono text-xs uppercase tracking-widest text-[var(--color-sub)]">02</span>
+        <span class="font-mono text-xs uppercase tracking-widest text-sub">02</span>
         <h2 class="text-3xl font-black tracking-tight">文化で効果が変わる例</h2>
       </div>
-      <div class="leading-loose text-[var(--color-ink)]/90 space-y-6">
+      <div class="leading-loose text-ink/90 space-y-6">
         <p>
           海外で大きな効果が報告されていても、日本では効果が小さくなる(あるいはその逆の)代表例:
         </p>
         <div class="space-y-4">
-          <div class="border border-[var(--color-line)] rounded-xl p-5 space-y-2">
+          <div class="border border-line rounded-xl p-5 space-y-2">
             <h3 class="font-bold">宿題</h3>
             <p class="text-sm leading-relaxed">
               EEF では宿題に +5ヶ月の効果が報告されていますが、日本は既に家庭学習の時間が長い国です。宿題を <strong>さらに増やす</strong> ことで同じ効果が得られるとは限りません。量より質(授業との連動・フィードバック)が鍵。
             </p>
           </div>
-          <div class="border border-[var(--color-line)] rounded-xl p-5 space-y-2">
+          <div class="border border-line rounded-xl p-5 space-y-2">
             <h3 class="font-bold">協同学習・ペア学習</h3>
             <p class="text-sm leading-relaxed">
               日本の小学校では班活動・グループ学習が既に広く行われており、海外の「新しい介入」としての効果はそのまま出ない可能性があります。逆に、日本式の <strong>Lesson Study(研究授業)</strong> は海外に輸出されて高い評価を得ています。
             </p>
           </div>
-          <div class="border border-[var(--color-line)] rounded-xl p-5 space-y-2">
+          <div class="border border-line rounded-xl p-5 space-y-2">
             <h3 class="font-bold">学級規模の縮小</h3>
             <p class="text-sm leading-relaxed">
               欧米の研究で学級規模縮小の効果は限定的(+2ヶ月程度)ですが、日本の学級はもともと規模が大きく、縮小の効果は文化的期待とも絡んで異なる結果になる可能性があります。田中隆一氏らの日本の研究が参考になります。
             </p>
           </div>
-          <div class="border border-[var(--color-line)] rounded-xl p-5 space-y-2">
+          <div class="border border-line rounded-xl p-5 space-y-2">
             <h3 class="font-bold">教師への公の褒め・フィードバック</h3>
             <p class="text-sm leading-relaxed">
               「みんなの前で個別に褒める」方式は、集団主義的な日本の教室では必ずしも有効でないことがあります。フィードバックの形式は文化に合わせて調整が必要です。
@@ -77,12 +77,12 @@ import Layout from "../../layouts/Layout.astro";
     </div>
 
     <!-- 3. 本サイトの出典階層 -->
-    <div class="border-t border-[var(--color-line)] pt-10 space-y-6">
+    <div class="border-t border-line pt-10 space-y-6">
       <div class="flex items-center gap-6">
-        <span class="font-mono text-xs uppercase tracking-widest text-[var(--color-sub)]">03</span>
+        <span class="font-mono text-xs uppercase tracking-widest text-sub">03</span>
         <h2 class="text-3xl font-black tracking-tight">本サイトの出典階層</h2>
       </div>
-      <div class="leading-loose text-[var(--color-ink)]/90 space-y-6">
+      <div class="leading-loose text-ink/90 space-y-6">
         <p>
           本サイトでは、各指導法のページに「代表値(月数)」を表示しています。この値は次の優先順位で決めています。
         </p>
@@ -107,49 +107,49 @@ import Layout from "../../layouts/Layout.astro";
     </div>
 
     <!-- 4. なぜ日本の教育研究が限定的か -->
-    <div class="border-t border-[var(--color-line)] pt-10 space-y-6">
+    <div class="border-t border-line pt-10 space-y-6">
       <div class="flex items-center gap-6">
-        <span class="font-mono text-xs uppercase tracking-widest text-[var(--color-sub)]">04</span>
+        <span class="font-mono text-xs uppercase tracking-widest text-sub">04</span>
         <h2 class="text-3xl font-black tracking-tight">日本の教育研究が限定的な理由</h2>
       </div>
-      <div class="leading-loose text-[var(--color-ink)]/90 space-y-4">
+      <div class="leading-loose text-ink/90 space-y-4">
         <p>
           「日本では効果を検証した研究があるはずだ」と思うかもしれませんが、実は日本発の大規模 RCT やメタ分析は非常に限られています。その理由は構造的なものです。
         </p>
         <div class="space-y-3 pt-2">
           <div class="space-y-1">
             <h3 class="font-bold">① 倫理的制約</h3>
-            <p class="text-sm text-[var(--color-sub)] leading-relaxed">
+            <p class="text-sm text-sub leading-relaxed">
               「一部の学級にだけ効果のある指導を与え、別の学級には与えない」という RCT の基本設計が、日本の公教育では「不公平」と捉えられ実施が難しい。
             </p>
           </div>
           <div class="space-y-1">
             <h3 class="font-bold">② 制度的制約</h3>
-            <p class="text-sm text-[var(--color-sub)] leading-relaxed">
+            <p class="text-sm text-sub leading-relaxed">
               学校制度が均質で、学級編成・教科書・時数が全国で似通っているため、十分に異なる対照群を作りにくい。公立学校の比率が高く、介入の自由度も限定的。
             </p>
           </div>
           <div class="space-y-1">
             <h3 class="font-bold">③ 研究文化の違い</h3>
-            <p class="text-sm text-[var(--color-sub)] leading-relaxed">
+            <p class="text-sm text-sub leading-relaxed">
               日本の教育学は質的研究・実践報告が中心で、量的 RCT の基盤が弱い。「研究紀要」による実践報告が多く、因果推論を前提とした設計は少数派。
             </p>
           </div>
           <div class="space-y-1">
             <h3 class="font-bold">④ 研究資金</h3>
-            <p class="text-sm text-[var(--color-sub)] leading-relaxed">
+            <p class="text-sm text-sub leading-relaxed">
               教育研究への公的投資は、臨床医学・経済学に比べて規模が小さい。大規模な介入研究を実施するための継続的な資金源が限定的。
             </p>
           </div>
           <div class="space-y-1">
             <h3 class="font-bold">⑤ 言語の壁</h3>
-            <p class="text-sm text-[var(--color-sub)] leading-relaxed">
+            <p class="text-sm text-sub leading-relaxed">
               日本発の研究の多くは日本語で発表されるため、国際的な英語査読誌に載る数が限定的。結果として海外メタ分析に含まれにくい。
             </p>
           </div>
           <div class="space-y-1">
             <h3 class="font-bold">⑥ 倫理審査の仕組み</h3>
-            <p class="text-sm text-[var(--color-sub)] leading-relaxed">
+            <p class="text-sm text-sub leading-relaxed">
               医学研究の IRB に相当する倫理審査の仕組みが、教育研究では発達途上。大規模 RCT の実施ハードルになっている。
             </p>
           </div>
@@ -161,12 +161,12 @@ import Layout from "../../layouts/Layout.astro";
     </div>
 
     <!-- 5. 近年の前進 -->
-    <div class="border-t border-[var(--color-line)] pt-10 space-y-6">
+    <div class="border-t border-line pt-10 space-y-6">
       <div class="flex items-center gap-6">
-        <span class="font-mono text-xs uppercase tracking-widest text-[var(--color-sub)]">05</span>
+        <span class="font-mono text-xs uppercase tracking-widest text-sub">05</span>
         <h2 class="text-3xl font-black tracking-tight">それでも前進している</h2>
       </div>
-      <div class="leading-loose text-[var(--color-ink)]/90 space-y-4">
+      <div class="leading-loose text-ink/90 space-y-4">
         <p>
           近年、日本発のエビデンスベース教育研究は着実に増えています。代表的な研究者と研究領域:
         </p>
@@ -200,12 +200,12 @@ import Layout from "../../layouts/Layout.astro";
     </div>
 
     <!-- 6. 読者へのお願い -->
-    <div class="border-t border-[var(--color-line)] pt-10 space-y-6">
+    <div class="border-t border-line pt-10 space-y-6">
       <div class="flex items-center gap-6">
-        <span class="font-mono text-xs uppercase tracking-widest text-[var(--color-sub)]">06</span>
+        <span class="font-mono text-xs uppercase tracking-widest text-sub">06</span>
         <h2 class="text-3xl font-black tracking-tight">読者の先生方へ</h2>
       </div>
-      <div class="leading-loose text-[var(--color-ink)]/90 space-y-4">
+      <div class="leading-loose text-ink/90 space-y-4">
         <p>
           本サイトの数値は、**目の前の子どもたちに対する保証ではありません**。研究で確かめられた「平均的な傾向」と「日本の文脈で想定される注意点」を提示しているに過ぎません。
         </p>
@@ -213,19 +213,19 @@ import Layout from "../../layouts/Layout.astro";
           最終的には、<strong>(1) 研究のエビデンス</strong>、<strong>(2) 先生自身の専門的判断</strong>、<strong>(3) 学校・地域の文脈</strong>の3つを組み合わせて、「うちの教室では、今、何が最も良い選択か」を考える材料として使ってください。
         </p>
         <p>
-          また、日本の文脈で実践された経験がありましたら、ぜひ <a href="/voices" class="link-underline text-[var(--color-accent)]">現場の声</a> からお寄せください。読者の実践が、次の世代のエビデンスベースを作ります。
+          また、日本の文脈で実践された経験がありましたら、ぜひ <a href="/voices" class="link-underline text-accent">現場の声</a> からお寄せください。読者の実践が、次の世代のエビデンスベースを作ります。
         </p>
       </div>
     </div>
 
     <!-- 導線 -->
-    <div class="border-t border-[var(--color-line)] pt-10 text-center space-y-6">
-      <p class="text-[var(--color-sub)] leading-loose">
+    <div class="border-t border-line pt-10 text-center space-y-6">
+      <p class="text-sub leading-loose">
         エビデンスの限界を知った上で、具体的な指導法を見てみましょう。
       </p>
       <a
         href="/"
-        class="link-underline inline-block font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]"
+        class="link-underline inline-block font-mono text-xs uppercase tracking-widest text-accent"
       >
         ← 指導法一覧へ戻る
       </a>

--- a/src/pages/guide/evidence.astro
+++ b/src/pages/guide/evidence.astro
@@ -4,15 +4,15 @@ import Layout from "../../layouts/Layout.astro";
 
 <Layout title="エビデンス入門 — EduEvidence JP">
   <section class="pt-10 sm:pt-14 md:pt-20 lg:pt-28 pb-10 sm:pb-14 md:pb-20">
-    <p class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]">
+    <p class="font-mono text-xs uppercase tracking-widest text-accent">
       Guide — What is evidence?
     </p>
     <h1
       class="mt-5 font-black text-4xl sm:text-5xl md:text-6xl lg:text-7xl leading-[1.15] tracking-tight"
     >
-      <span class="text-[var(--color-accent)]">エビデンス</span>入門
+      <span class="text-accent">エビデンス</span>入門
     </h1>
-    <div class="mt-6 max-w-2xl text-[var(--color-sub)] leading-loose text-sm sm:text-base">
+    <div class="mt-6 max-w-2xl text-sub leading-loose text-sm sm:text-base">
       <p>
         「エビデンスに基づく教育」の基本を、研究の読み方が分からなくても理解できるように解説します。
       </p>
@@ -22,12 +22,12 @@ import Layout from "../../layouts/Layout.astro";
   <section class="pb-24 space-y-20">
 
     <!-- 1. エビデンスとは -->
-    <div class="border-t border-[var(--color-line)] pt-10 space-y-6">
+    <div class="border-t border-line pt-10 space-y-6">
       <div class="flex items-center gap-6">
-        <span class="font-mono text-xs uppercase tracking-widest text-[var(--color-sub)]">01</span>
+        <span class="font-mono text-xs uppercase tracking-widest text-sub">01</span>
         <h2 class="text-3xl font-black tracking-tight">エビデンスとは何か</h2>
       </div>
-      <div class="space-y-4 leading-loose text-[var(--color-ink)]/90">
+      <div class="space-y-4 leading-loose text-ink/90">
         <p>
           教育における「エビデンス」とは、<strong>研究で確かめられた知見</strong>のことです。
         </p>
@@ -45,73 +45,73 @@ import Layout from "../../layouts/Layout.astro";
     </div>
 
     <!-- 2. 研究の種類 -->
-    <div class="border-t border-[var(--color-line)] pt-10 space-y-6">
+    <div class="border-t border-line pt-10 space-y-6">
       <div class="flex items-center gap-6">
-        <span class="font-mono text-xs uppercase tracking-widest text-[var(--color-sub)]">02</span>
+        <span class="font-mono text-xs uppercase tracking-widest text-sub">02</span>
         <h2 class="text-3xl font-black tracking-tight">研究にはレベルがある</h2>
       </div>
-      <div class="leading-loose text-[var(--color-ink)]/90 space-y-6">
+      <div class="leading-loose text-ink/90 space-y-6">
         <p>
           「研究で確かめた」と一口に言っても、研究の質はさまざまです。
           以下のように、エビデンスの信頼性には段階があります。
         </p>
         <div class="space-y-1">
-          <div class="grid grid-cols-12 gap-4 border border-[var(--color-line)] rounded-xl p-5">
+          <div class="grid grid-cols-12 gap-4 border border-line rounded-xl p-5">
             <div class="col-span-3 md:col-span-2">
-              <div class="font-mono text-xs text-[var(--color-sub)] uppercase">最も強い</div>
-              <div class="font-black text-lg text-[var(--color-accent)]">Level 5</div>
+              <div class="font-mono text-xs text-sub uppercase">最も強い</div>
+              <div class="font-black text-lg text-accent">Level 5</div>
             </div>
             <div class="col-span-9 md:col-span-10 space-y-1">
               <div class="font-bold">メタ分析・システマティックレビュー</div>
-              <div class="text-sm text-[var(--color-sub)]">
+              <div class="text-sm text-sub">
                 複数の研究を統合し、全体的な傾向を分析したもの。本サイトのデータは主にここから来ています。
               </div>
             </div>
           </div>
-          <div class="grid grid-cols-12 gap-4 border border-[var(--color-line)] rounded-lg p-5">
+          <div class="grid grid-cols-12 gap-4 border border-line rounded-lg p-5">
             <div class="col-span-3 md:col-span-2">
-              <div class="font-mono text-xs text-[var(--color-sub)] uppercase">強い</div>
+              <div class="font-mono text-xs text-sub uppercase">強い</div>
               <div class="font-black text-lg">Level 4</div>
             </div>
             <div class="col-span-9 md:col-span-10 space-y-1">
               <div class="font-bold">ランダム化比較試験(RCT)</div>
-              <div class="text-sm text-[var(--color-sub)]">
+              <div class="text-sm text-sub">
                 対象者をランダムに2グループに分け、介入あり・なしの結果を比較する研究。因果関係を最も厳密に示せる。
               </div>
             </div>
           </div>
-          <div class="grid grid-cols-12 gap-4 border border-[var(--color-line)] rounded-lg p-5">
+          <div class="grid grid-cols-12 gap-4 border border-line rounded-lg p-5">
             <div class="col-span-3 md:col-span-2">
-              <div class="font-mono text-xs text-[var(--color-sub)] uppercase">中程度</div>
+              <div class="font-mono text-xs text-sub uppercase">中程度</div>
               <div class="font-black text-lg">Level 3</div>
             </div>
             <div class="col-span-9 md:col-span-10 space-y-1">
               <div class="font-bold">準実験研究</div>
-              <div class="text-sm text-[var(--color-sub)]">
+              <div class="text-sm text-sub">
                 RCTほど厳密ではないが、介入群と比較群を設けた研究。現実的な制約の中で行われることが多い。
               </div>
             </div>
           </div>
-          <div class="grid grid-cols-12 gap-4 border border-[var(--color-line)] rounded-lg p-5">
+          <div class="grid grid-cols-12 gap-4 border border-line rounded-lg p-5">
             <div class="col-span-3 md:col-span-2">
-              <div class="font-mono text-xs text-[var(--color-sub)] uppercase">弱い</div>
+              <div class="font-mono text-xs text-sub uppercase">弱い</div>
               <div class="font-black text-lg">Level 2</div>
             </div>
             <div class="col-span-9 md:col-span-10 space-y-1">
               <div class="font-bold">観察研究・相関研究</div>
-              <div class="text-sm text-[var(--color-sub)]">
+              <div class="text-sm text-sub">
                 介入は行わず、既存のデータの関連を分析する。因果関係の主張は難しい。
               </div>
             </div>
           </div>
-          <div class="grid grid-cols-12 gap-4 border border-[var(--color-line)] rounded-lg p-5">
+          <div class="grid grid-cols-12 gap-4 border border-line rounded-lg p-5">
             <div class="col-span-3 md:col-span-2">
-              <div class="font-mono text-xs text-[var(--color-sub)] uppercase">最も弱い</div>
+              <div class="font-mono text-xs text-sub uppercase">最も弱い</div>
               <div class="font-black text-lg">Level 1</div>
             </div>
             <div class="col-span-9 md:col-span-10 space-y-1">
               <div class="font-bold">個人の経験・事例報告・専門家の意見</div>
-              <div class="text-sm text-[var(--color-sub)]">
+              <div class="text-sm text-sub">
                 参考にはなるが、一般化はできない。多くの「教育実践報告」はここに位置する。
               </div>
             </div>
@@ -121,12 +121,12 @@ import Layout from "../../layouts/Layout.astro";
     </div>
 
     <!-- 2.5 研究の質を決めるもの -->
-    <div class="border-t border-[var(--color-line)] pt-10 space-y-6">
+    <div class="border-t border-line pt-10 space-y-6">
       <div class="flex items-center gap-6">
-        <span class="font-mono text-xs uppercase tracking-widest text-[var(--color-sub)]">02-b</span>
+        <span class="font-mono text-xs uppercase tracking-widest text-sub">02-b</span>
         <h2 class="text-3xl font-black tracking-tight">研究の質を決める3つの要素</h2>
       </div>
-      <div class="leading-loose text-[var(--color-ink)]/90 space-y-6">
+      <div class="leading-loose text-ink/90 space-y-6">
         <p>
           では、上のレベルを分けているのは何でしょうか。研究の質を決めるのは、主に以下の3つです。
         </p>
@@ -134,18 +134,18 @@ import Layout from "../../layouts/Layout.astro";
         <div class="space-y-2">
           <h3 class="font-bold">① 比較対象があるか</h3>
           <div class="grid md:grid-cols-2 gap-4 text-sm">
-            <div class="border border-[var(--color-line)] rounded-lg p-4 space-y-1">
-              <div class="text-[var(--color-chart-red)] font-bold">質が低い</div>
+            <div class="border border-line rounded-lg p-4 space-y-1">
+              <div class="text-chart-red font-bold">質が低い</div>
               <div>
                 「フィードバックをやったら成績が上がった」<br />
-                <span class="text-[var(--color-sub)]">→ 他の要因(季節・成長・別の指導)かもしれない</span>
+                <span class="text-sub">→ 他の要因(季節・成長・別の指導)かもしれない</span>
               </div>
             </div>
-            <div class="border border-[var(--color-accent)]/30 rounded-lg p-4 space-y-1">
-              <div class="text-[var(--color-accent)] font-bold">質が高い</div>
+            <div class="border border-accent/30 rounded-lg p-4 space-y-1">
+              <div class="text-accent font-bold">質が高い</div>
               <div>
                 「やった学級と、やらなかった学級を比べた」<br />
-                <span class="text-[var(--color-sub)]">→ 差があれば、介入が原因だと言いやすい</span>
+                <span class="text-sub">→ 差があれば、介入が原因だと言いやすい</span>
               </div>
             </div>
           </div>
@@ -154,22 +154,22 @@ import Layout from "../../layouts/Layout.astro";
         <div class="space-y-2">
           <h3 class="font-bold">② グループの分け方が公平か</h3>
           <div class="grid md:grid-cols-2 gap-4 text-sm">
-            <div class="border border-[var(--color-line)] rounded-lg p-4 space-y-1">
-              <div class="text-[var(--color-chart-red)] font-bold">質が低い</div>
+            <div class="border border-line rounded-lg p-4 space-y-1">
+              <div class="text-chart-red font-bold">質が低い</div>
               <div>
                 教師が「やりたい学級」を選んで介入<br />
-                <span class="text-[var(--color-sub)]">→ やる気のある学級だけが選ばれ、結果が歪む</span>
+                <span class="text-sub">→ やる気のある学級だけが選ばれ、結果が歪む</span>
               </div>
             </div>
-            <div class="border border-[var(--color-accent)]/30 rounded-lg p-4 space-y-1">
-              <div class="text-[var(--color-accent)] font-bold">質が高い(RCT)</div>
+            <div class="border border-accent/30 rounded-lg p-4 space-y-1">
+              <div class="text-accent font-bold">質が高い(RCT)</div>
               <div>
                 コイン投げやくじ引きでランダムに分ける<br />
-                <span class="text-[var(--color-sub)]">→ 両グループの条件がほぼ同じになる</span>
+                <span class="text-sub">→ 両グループの条件がほぼ同じになる</span>
               </div>
             </div>
           </div>
-          <p class="text-sm text-[var(--color-sub)]">
+          <p class="text-sm text-sub">
             これがRCTが「最も強い研究デザイン」とされる理由です。
           </p>
         </div>
@@ -178,15 +178,15 @@ import Layout from "../../layouts/Layout.astro";
           <h3 class="font-bold">③ 結果が繰り返されているか</h3>
           <div class="space-y-2 text-sm">
             <div class="flex gap-3 items-start">
-              <span class="text-[var(--color-sub)] shrink-0">1本の研究</span>
+              <span class="text-sub shrink-0">1本の研究</span>
               <span>「効果あり」→ まだ分からない。たまたまかもしれない</span>
             </div>
             <div class="flex gap-3 items-start">
-              <span class="text-[var(--color-sub)] shrink-0">10本の研究</span>
+              <span class="text-sub shrink-0">10本の研究</span>
               <span>全て「効果あり」→ かなり確からしい</span>
             </div>
             <div class="flex gap-3 items-start">
-              <span class="text-[var(--color-accent)] shrink-0 font-bold">メタ分析(50本統合)</span>
+              <span class="text-accent shrink-0 font-bold">メタ分析(50本統合)</span>
               <span>「効果あり」→ 強い確信が持てる</span>
             </div>
           </div>
@@ -212,12 +212,12 @@ import Layout from "../../layouts/Layout.astro";
     </div>
 
     <!-- 3. 効果量 -->
-    <div class="border-t border-[var(--color-line)] pt-10 space-y-6">
+    <div class="border-t border-line pt-10 space-y-6">
       <div class="flex items-center gap-6">
-        <span class="font-mono text-xs uppercase tracking-widest text-[var(--color-sub)]">03</span>
+        <span class="font-mono text-xs uppercase tracking-widest text-sub">03</span>
         <h2 class="text-3xl font-black tracking-tight">効果量とは</h2>
       </div>
-      <div class="leading-loose text-[var(--color-ink)]/90 space-y-4">
+      <div class="leading-loose text-ink/90 space-y-4">
         <p>
           「効果があった」だけでは、どのくらい効いたのかが分かりません。
           <strong>効果量（effect size）</strong>は、その「どのくらい」を数値化した指標です。
@@ -226,17 +226,17 @@ import Layout from "../../layouts/Layout.astro";
           研究の世界では「コーエンのd」という指標がよく使われ、おおよそ以下のように解釈されます。
         </p>
         <div class="grid grid-cols-3 gap-4 text-sm text-center pt-2">
-          <div class="border border-[var(--color-line)] rounded-lg p-4 space-y-1">
+          <div class="border border-line rounded-lg p-4 space-y-1">
             <div class="font-mono font-bold text-lg">d = 0.2</div>
-            <div class="text-[var(--color-sub)]">小さい効果</div>
+            <div class="text-sub">小さい効果</div>
           </div>
-          <div class="border border-[var(--color-line)] rounded-lg p-4 space-y-1">
+          <div class="border border-line rounded-lg p-4 space-y-1">
             <div class="font-mono font-bold text-lg">d = 0.5</div>
-            <div class="text-[var(--color-sub)]">中程度の効果</div>
+            <div class="text-sub">中程度の効果</div>
           </div>
-          <div class="border border-[var(--color-line)] rounded-lg p-4 space-y-1">
+          <div class="border border-line rounded-lg p-4 space-y-1">
             <div class="font-mono font-bold text-lg">d = 0.8</div>
-            <div class="text-[var(--color-sub)]">大きい効果</div>
+            <div class="text-sub">大きい効果</div>
           </div>
         </div>
         <p>
@@ -247,12 +247,12 @@ import Layout from "../../layouts/Layout.astro";
     </div>
 
     <!-- 4. メタ分析 -->
-    <div class="border-t border-[var(--color-line)] pt-10 space-y-6">
+    <div class="border-t border-line pt-10 space-y-6">
       <div class="flex items-center gap-6">
-        <span class="font-mono text-xs uppercase tracking-widest text-[var(--color-sub)]">04</span>
+        <span class="font-mono text-xs uppercase tracking-widest text-sub">04</span>
         <h2 class="text-3xl font-black tracking-tight">メタ分析とは</h2>
       </div>
-      <div class="space-y-4 leading-loose text-[var(--color-ink)]/90">
+      <div class="space-y-4 leading-loose text-ink/90">
         <p>
           本サイトの数値の多くは「メタ分析」と呼ばれる研究手法から得られています。
         </p>
@@ -274,12 +274,12 @@ import Layout from "../../layouts/Layout.astro";
     </div>
 
     <!-- 5. エビデンスの限界 -->
-    <div class="border-t border-[var(--color-line)] pt-10 space-y-6">
+    <div class="border-t border-line pt-10 space-y-6">
       <div class="flex items-center gap-6">
-        <span class="font-mono text-xs uppercase tracking-widest text-[var(--color-sub)]">05</span>
+        <span class="font-mono text-xs uppercase tracking-widest text-sub">05</span>
         <h2 class="text-3xl font-black tracking-tight">エビデンスの限界</h2>
       </div>
-      <div class="leading-loose text-[var(--color-ink)]/90 space-y-4">
+      <div class="leading-loose text-ink/90 space-y-4">
         <p>
           エビデンスは万能ではありません。以下の限界を知った上で活用することが大切です。
         </p>
@@ -309,12 +309,12 @@ import Layout from "../../layouts/Layout.astro";
     </div>
 
     <!-- 6. エビデンスとの付き合い方 -->
-    <div class="border-t border-[var(--color-line)] pt-10 space-y-6">
+    <div class="border-t border-line pt-10 space-y-6">
       <div class="flex items-center gap-6">
-        <span class="font-mono text-xs uppercase tracking-widest text-[var(--color-sub)]">06</span>
+        <span class="font-mono text-xs uppercase tracking-widest text-sub">06</span>
         <h2 class="text-3xl font-black tracking-tight">エビデンスとの付き合い方</h2>
       </div>
-      <div class="leading-loose text-[var(--color-ink)]/90 space-y-6">
+      <div class="leading-loose text-ink/90 space-y-6">
         <p>
           エビデンスに基づく教育は「数字に従え」ということではありません。
         </p>
@@ -322,21 +322,21 @@ import Layout from "../../layouts/Layout.astro";
           より正確には、<strong>3つの要素を組み合わせて判断する</strong>という考え方です。
         </p>
         <div class="grid md:grid-cols-3 gap-4">
-          <div class="border border-[var(--color-line)] rounded-xl p-5 space-y-2">
+          <div class="border border-line rounded-xl p-5 space-y-2">
             <div class="font-bold">① 研究のエビデンス</div>
-            <p class="text-sm text-[var(--color-sub)]">
+            <p class="text-sm text-sub">
               このサイトが提供する「研究ではこう言われている」という情報
             </p>
           </div>
-          <div class="border border-[var(--color-line)] rounded-xl p-5 space-y-2">
+          <div class="border border-line rounded-xl p-5 space-y-2">
             <div class="font-bold">② 教師の専門的判断</div>
-            <p class="text-sm text-[var(--color-sub)]">
+            <p class="text-sm text-sub">
               目の前の子ども・教室の状況を踏まえた、教師としての経験と直感
             </p>
           </div>
-          <div class="border border-[var(--color-line)] rounded-xl p-5 space-y-2">
+          <div class="border border-line rounded-xl p-5 space-y-2">
             <div class="font-bold">③ 学校・地域の文脈</div>
-            <p class="text-sm text-[var(--color-sub)]">
+            <p class="text-sm text-sub">
               自校の子どもの特性、地域の教育課題、学校の方針やリソース
             </p>
           </div>
@@ -352,46 +352,46 @@ import Layout from "../../layouts/Layout.astro";
     </div>
 
     <!-- 7. もっと深く知るための参考図書 -->
-    <div class="border-t border-[var(--color-line)] pt-10 space-y-6">
+    <div class="border-t border-line pt-10 space-y-6">
       <div class="flex items-center gap-6">
-        <span class="font-mono text-xs uppercase tracking-widest text-[var(--color-sub)]">07</span>
+        <span class="font-mono text-xs uppercase tracking-widest text-sub">07</span>
         <h2 class="text-3xl font-black tracking-tight">もっと深く知るための参考図書</h2>
       </div>
-      <div class="leading-loose text-[var(--color-ink)]/90 space-y-4">
+      <div class="leading-loose text-ink/90 space-y-4">
         <p>
           エビデンスの読み方や、教育経済学の考え方をもう一歩踏み込んで学びたいときに参考になる書籍を紹介します。本サイトでも繰り返し引用しています。
         </p>
         <ul class="space-y-4 leading-loose">
           <li>
-            <strong>『<a href="https://d21.co.jp/book/detail/978-4-7993-1685-6" target="_blank" rel="noopener noreferrer" class="link-underline text-[var(--color-accent)]">「学力」の経済学</a>』</strong> — 中室牧子(2015)、ディスカヴァー・トゥエンティワン. 教育経済学の入門書として 30 万部超のベストセラー。非認知能力・少人数学級の費用対効果・行動への報酬など、「何に予算を使うべきか」を実証研究をもとに解説。
+            <strong>『<a href="https://d21.co.jp/book/detail/978-4-7993-1685-6" target="_blank" rel="noopener noreferrer" class="link-underline text-accent">「学力」の経済学</a>』</strong> — 中室牧子(2015)、ディスカヴァー・トゥエンティワン. 教育経済学の入門書として 30 万部超のベストセラー。非認知能力・少人数学級の費用対効果・行動への報酬など、「何に予算を使うべきか」を実証研究をもとに解説。
           </li>
           <li>
-            <strong>『<a href="https://www.diamond.co.jp/book/9784478039472.html" target="_blank" rel="noopener noreferrer" class="link-underline text-[var(--color-accent)]">「原因と結果」の経済学 — データから真実を見抜く思考法</a>』</strong> — 中室牧子・津川友介(2017)、ダイヤモンド社. 因果関係と相関関係の違い、ランダム化比較試験(RCT)・差の差分析・操作変数法などの因果推論の考え方を、医療・教育・経済の例を通して平易に解説。エビデンスを読むときの基本姿勢を学べる。
+            <strong>『<a href="https://www.diamond.co.jp/book/9784478039472.html" target="_blank" rel="noopener noreferrer" class="link-underline text-accent">「原因と結果」の経済学 — データから真実を見抜く思考法</a>』</strong> — 中室牧子・津川友介(2017)、ダイヤモンド社. 因果関係と相関関係の違い、ランダム化比較試験(RCT)・差の差分析・操作変数法などの因果推論の考え方を、医療・教育・経済の例を通して平易に解説。エビデンスを読むときの基本姿勢を学べる。
           </li>
           <li>
-            <strong>『<a href="https://www.diamond.co.jp/book/9784478121092.html" target="_blank" rel="noopener noreferrer" class="link-underline text-[var(--color-accent)]">科学的根拠(エビデンス)で子育て — 教育経済学の最前線</a>』</strong> — 中室牧子(2024)、ダイヤモンド社. 『「学力」の経済学』から 9 年ぶりの単著。最新のエビデンスを厳選して紹介し、保護者・教育関係者向けに「研究で確かめられている知見」を整理。
+            <strong>『<a href="https://www.diamond.co.jp/book/9784478121092.html" target="_blank" rel="noopener noreferrer" class="link-underline text-accent">科学的根拠(エビデンス)で子育て — 教育経済学の最前線</a>』</strong> — 中室牧子(2024)、ダイヤモンド社. 『「学力」の経済学』から 9 年ぶりの単著。最新のエビデンスを厳選して紹介し、保護者・教育関係者向けに「研究で確かめられている知見」を整理。
           </li>
           <li>
-            <strong>『<a href="https://www.ohmsha.co.jp/book/9784274065705/" target="_blank" rel="noopener noreferrer" class="link-underline text-[var(--color-accent)]">マンガでわかる 統計学</a>』</strong> — 高橋信 著、トレンド・プロ 漫画制作 (2004)、オーム社. 統計学の基礎(平均・分散・検定・回帰など)をマンガ形式で導入する入門書。エビデンスを読むときに登場する用語を物語の中で掴める。
+            <strong>『<a href="https://www.ohmsha.co.jp/book/9784274065705/" target="_blank" rel="noopener noreferrer" class="link-underline text-accent">マンガでわかる 統計学</a>』</strong> — 高橋信 著、トレンド・プロ 漫画制作 (2004)、オーム社. 統計学の基礎(平均・分散・検定・回帰など)をマンガ形式で導入する入門書。エビデンスを読むときに登場する用語を物語の中で掴める。
           </li>
           <li>
-            <strong>『<a href="https://bookstore.sunmark.co.jp/products/9784763138439" target="_blank" rel="noopener noreferrer" class="link-underline text-[var(--color-accent)]">米国最強経済学者にして 2 児の母が読み解く 子どもの育て方ベスト</a>』</strong> — エミリー・オスター 著、堀内久美子 訳 (2022)、サンマーク出版. ブラウン大学経済学部教授で 2 児の母である著者が、就学前期の子育てをめぐる通説を経済学・統計の手法でデータに基づき再検討した一般書。エビデンスを家庭の意思決定にどう生かすかの実例として読みやすい。
+            <strong>『<a href="https://bookstore.sunmark.co.jp/products/9784763138439" target="_blank" rel="noopener noreferrer" class="link-underline text-accent">米国最強経済学者にして 2 児の母が読み解く 子どもの育て方ベスト</a>』</strong> — エミリー・オスター 著、堀内久美子 訳 (2022)、サンマーク出版. ブラウン大学経済学部教授で 2 児の母である著者が、就学前期の子育てをめぐる通説を経済学・統計の手法でデータに基づき再検討した一般書。エビデンスを家庭の意思決定にどう生かすかの実例として読みやすい。
           </li>
           <li>
-            <strong>『<a href="https://www.keisoshobo.co.jp/book/b636200.html" target="_blank" rel="noopener noreferrer" class="link-underline text-[var(--color-accent)]">教育政策をめぐるエビデンス — 学力格差・学級規模・教師多忙とデータサイエンス</a>』</strong> — 中西啓喜(2023)、勁草書房. なぜエビデンスに基づく教育政策の議論は難しいのかを、少人数学級などを補助線に検討した教育社会学の一冊。エビデンスを「教育政策」と「教育実践」の 2 つの領域に整理し、階層の高いエビデンスに限らず、学校現場の意見を政策目的の発見に活かす方向を提起する。
+            <strong>『<a href="https://www.keisoshobo.co.jp/book/b636200.html" target="_blank" rel="noopener noreferrer" class="link-underline text-accent">教育政策をめぐるエビデンス — 学力格差・学級規模・教師多忙とデータサイエンス</a>』</strong> — 中西啓喜(2023)、勁草書房. なぜエビデンスに基づく教育政策の議論は難しいのかを、少人数学級などを補助線に検討した教育社会学の一冊。エビデンスを「教育政策」と「教育実践」の 2 つの領域に整理し、階層の高いエビデンスに限らず、学校現場の意見を政策目的の発見に活かす方向を提起する。
           </li>
         </ul>
       </div>
     </div>
 
     <!-- 導線 -->
-    <div class="border-t border-[var(--color-line)] pt-10 text-center space-y-6">
-      <p class="text-[var(--color-sub)] leading-loose">
+    <div class="border-t border-line pt-10 text-center space-y-6">
+      <p class="text-sub leading-loose">
         準備ができたら、具体的な指導法を見てみましょう。
       </p>
       <a
         href="/"
-        class="link-underline inline-block font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]"
+        class="link-underline inline-block font-mono text-xs uppercase tracking-widest text-accent"
       >
         ← 指導法一覧へ戻る
       </a>

--- a/src/pages/guide/glossary.astro
+++ b/src/pages/guide/glossary.astro
@@ -33,7 +33,7 @@ function anchorFor(term: string): string {
 
 <Layout title="用語集 — EduEvidence JP">
   <section class="pt-10 sm:pt-14 md:pt-20 lg:pt-28 pb-10 sm:pb-14 md:pb-20">
-    <p class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]">
+    <p class="font-mono text-xs uppercase tracking-widest text-accent">
       Guide — Glossary
     </p>
     <h1
@@ -41,7 +41,7 @@ function anchorFor(term: string): string {
     >
       用語集
     </h1>
-    <div class="mt-6 max-w-2xl text-[var(--color-sub)] leading-loose text-sm sm:text-base space-y-2">
+    <div class="mt-6 max-w-2xl text-sub leading-loose text-sm sm:text-base space-y-2">
       <p>
         本サイトで使われている専門用語を一行で解説します。カテゴリごとにまとめています。
       </p>
@@ -54,27 +54,27 @@ function anchorFor(term: string): string {
       <section class="pb-10" aria-labelledby={`cat-${group.category}`}>
         <h2
           id={`cat-${group.category}`}
-          class="font-black text-2xl sm:text-3xl tracking-tight mb-4 mt-2 text-[var(--color-accent)] scroll-mt-20"
+          class="font-black text-2xl sm:text-3xl tracking-tight mb-4 mt-2 text-accent scroll-mt-20"
         >
           {group.label}
         </h2>
         {group.terms.map((t) => (
           <div
             id={anchorFor(t.term)}
-            class="border-t border-[var(--color-line)] py-5 grid grid-cols-12 gap-4 scroll-mt-20"
+            class="border-t border-line py-5 grid grid-cols-12 gap-4 scroll-mt-20"
           >
             <div class="col-span-12 md:col-span-4">
               <div class="font-bold">{t.term}</div>
-              <div class="font-mono text-[11px] text-[var(--color-sub)]">
+              <div class="font-mono text-[11px] text-sub">
                 {t.en}
               </div>
             </div>
-            <div class="col-span-12 md:col-span-8 text-sm text-[var(--color-sub)] leading-relaxed">
+            <div class="col-span-12 md:col-span-8 text-sm text-sub leading-relaxed">
               {t.def}
             </div>
           </div>
         ))}
-        <div class="border-t border-[var(--color-line)]"></div>
+        <div class="border-t border-line"></div>
       </section>
     ))
   }

--- a/src/pages/guide/index.astro
+++ b/src/pages/guide/index.astro
@@ -31,7 +31,7 @@ const guides = [
 
 <Layout title="Guide — EduEvidence JP">
   <section class="pt-10 sm:pt-14 md:pt-20 lg:pt-28 pb-10 sm:pb-14 md:pb-20">
-    <p class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]">
+    <p class="font-mono text-xs uppercase tracking-widest text-accent">
       Guide
     </p>
     <h1
@@ -39,7 +39,7 @@ const guides = [
     >
       読み方ガイド
     </h1>
-    <div class="mt-6 max-w-2xl text-[var(--color-sub)] leading-loose text-sm sm:text-base">
+    <div class="mt-6 max-w-2xl text-sub leading-loose text-sm sm:text-base">
       <p>
         指導法の記事をより深く理解するための補助資料を揃えています。
       </p>
@@ -47,26 +47,26 @@ const guides = [
   </section>
 
   <section class="pb-24">
-    <div class="border-b border-[var(--color-line)]">
+    <div class="border-b border-line">
       {
         guides.map((g) => (
           <a
             href={g.href}
-            class="group block border-t border-[var(--color-line)] py-10 transition hover:bg-[var(--color-card)]"
+            class="group block border-t border-line py-10 transition hover:bg-card"
           >
             <div class="grid grid-cols-12 gap-4 items-baseline px-2">
-              <div class="col-span-2 md:col-span-1 font-mono text-sm text-[var(--color-sub)]">
+              <div class="col-span-2 md:col-span-1 font-mono text-sm text-sub">
                 {g.num}
               </div>
               <div class="col-span-10 md:col-span-8 space-y-2">
-                <h3 class="text-2xl md:text-3xl font-black tracking-tight leading-tight group-hover:text-[var(--color-accent)] transition">
+                <h3 class="text-2xl md:text-3xl font-black tracking-tight leading-tight group-hover:text-accent transition">
                   {g.title}
                 </h3>
-                <p class="text-sm text-[var(--color-sub)] leading-relaxed">
+                <p class="text-sm text-sub leading-relaxed">
                   {g.desc}
                 </p>
               </div>
-              <div class="hidden md:block md:col-span-3 text-right text-[var(--color-sub)] text-xl transition group-hover:translate-x-1">
+              <div class="hidden md:block md:col-span-3 text-right text-sub text-xl transition group-hover:translate-x-1">
                 →
               </div>
             </div>

--- a/src/pages/guide/indicators.astro
+++ b/src/pages/guide/indicators.astro
@@ -4,15 +4,15 @@ import Layout from "../../layouts/Layout.astro";
 
 <Layout title="指標の読み方 — EduEvidence JP">
   <section class="pt-10 sm:pt-14 md:pt-20 lg:pt-28 pb-10 sm:pb-14 md:pb-20">
-    <p class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]">
+    <p class="font-mono text-xs uppercase tracking-widest text-accent">
       Guide — How to read
     </p>
     <h1
       class="mt-5 font-black text-4xl sm:text-5xl md:text-6xl lg:text-7xl leading-[1.15] tracking-tight"
     >
-      4つの指標の<br /><span class="text-[var(--color-accent)]">読み方</span>
+      4つの指標の<br /><span class="text-accent">読み方</span>
     </h1>
-    <div class="mt-6 max-w-2xl text-[var(--color-sub)] leading-loose text-sm sm:text-base">
+    <div class="mt-6 max-w-2xl text-sub leading-loose text-sm sm:text-base">
       <p>
         本サイトの各指導法には4つの指標が付いています。ここでは、それぞれの意味と読み取り方を解説します。
       </p>
@@ -22,15 +22,15 @@ import Layout from "../../layouts/Layout.astro";
   <section class="pb-24 space-y-20">
 
     <!-- 学習効果 -->
-    <div class="border-t border-[var(--color-line)] pt-10 space-y-6">
+    <div class="border-t border-line pt-10 space-y-6">
       <div class="flex items-center gap-6">
-        <span class="font-mono text-xs uppercase tracking-widest text-[var(--color-sub)]">01</span>
+        <span class="font-mono text-xs uppercase tracking-widest text-sub">01</span>
         <h2 class="text-3xl font-black tracking-tight">学習効果（+◯ヶ月）</h2>
       </div>
-      <div class="text-5xl font-black text-[var(--color-accent)]">
+      <div class="text-5xl font-black text-accent">
         +6<span class="text-lg ml-1">ヶ月</span>
       </div>
-      <div class="leading-loose text-[var(--color-ink)]/90 space-y-6">
+      <div class="leading-loose text-ink/90 space-y-6">
         <p>
           その指導法を1年間取り入れた学級の子どもが、4月スタートで3月に測定した時、
           <strong>取り入れなかった場合と比べて、約◯ヶ月先の学力水準に到達した</strong>ことを示します。
@@ -60,7 +60,7 @@ import Layout from "../../layouts/Layout.astro";
             <li>・月数が小さい指導法が「意味がない」のではなく、効果が小さめだということです</li>
           </ul>
         </div>
-        <div class="border-l-4 border-[var(--color-accent)] pl-5 py-1 space-y-2 bg-[var(--color-accent)]/5 -mx-5 pr-5">
+        <div class="border-l-4 border-accent pl-5 py-1 space-y-2 bg-accent/5 -mx-5 pr-5">
           <h3 class="font-bold">【重要】この数値は「学力」への効果のみです</h3>
           <p class="text-sm">
             「+◯ヶ月」は主に<strong>テストで測定可能な学力(読解・算数等)</strong>への効果を示しています。
@@ -73,14 +73,14 @@ import Layout from "../../layouts/Layout.astro";
             <li>・<strong>ウェルビーイング</strong> — 学校が楽しい、安心できる場所である感覚</li>
           </ul>
           <p class="text-sm">
-            たとえば<a href="/strategies/social-emotional-learning" class="link-underline text-[var(--color-accent)]">SEL(+4ヶ月)</a>、
-            <a href="/strategies/arts-participation" class="link-underline text-[var(--color-accent)]">芸術活動(+3ヶ月)</a>、
-            <a href="/strategies/outdoor-learning" class="link-underline text-[var(--color-accent)]">屋外学習(+3ヶ月)</a>、
-            <a href="/strategies/mentoring" class="link-underline text-[var(--color-accent)]">メンタリング(+2ヶ月)</a>などは、
+            たとえば<a href="/strategies/social-emotional-learning" class="link-underline text-accent">SEL(+4ヶ月)</a>、
+            <a href="/strategies/arts-participation" class="link-underline text-accent">芸術活動(+3ヶ月)</a>、
+            <a href="/strategies/outdoor-learning" class="link-underline text-accent">屋外学習(+3ヶ月)</a>、
+            <a href="/strategies/mentoring" class="link-underline text-accent">メンタリング(+2ヶ月)</a>などは、
             <strong>学力効果は小さくても、非認知的な側面で大きな価値</strong>を持つことが多くの研究で示されています。
             月数だけで判断せず、<strong>「この指導で何を育てたいのか」</strong>と合わせて検討してください。
           </p>
-          <p class="text-xs text-[var(--color-sub)]">
+          <p class="text-xs text-sub">
             EEF も公式の使い方ガイド(<a href="https://educationendowmentfoundation.org.uk/education-evidence/using-the-toolkits" target="_blank" rel="noopener" class="link-underline">Using the Toolkits</a>)で「Toolkit は教育的達成度(attainment)を主要な指標としており、意欲・出席・行動など他の成果はこの月数に体系的に反映されていない」と明記しています。
           </p>
         </div>
@@ -88,20 +88,20 @@ import Layout from "../../layouts/Layout.astro";
           <h3 class="font-bold">目安としての読み方</h3>
           <div class="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm text-center">
             <div class="border border-red-600/30 dark:border-red-400/30 rounded-lg p-4 space-y-1 bg-red-50/30 dark:bg-red-400/10">
-              <div class="text-2xl font-black text-[var(--color-chart-red)]">-1 以下</div>
-              <div class="text-[var(--color-sub)]">やらない方が<br />よかった領域</div>
+              <div class="text-2xl font-black text-chart-red">-1 以下</div>
+              <div class="text-sub">やらない方が<br />よかった領域</div>
             </div>
-            <div class="border border-[var(--color-line)] rounded-lg p-4 space-y-1">
-              <div class="text-2xl font-black text-[var(--color-accent)]">+1〜3</div>
-              <div class="text-[var(--color-sub)]">小さいが<br />確認できる効果</div>
+            <div class="border border-line rounded-lg p-4 space-y-1">
+              <div class="text-2xl font-black text-accent">+1〜3</div>
+              <div class="text-sub">小さいが<br />確認できる効果</div>
             </div>
-            <div class="border border-[var(--color-line)] rounded-lg p-4 space-y-1">
-              <div class="text-2xl font-black text-[var(--color-accent)]">+4〜6</div>
-              <div class="text-[var(--color-sub)]">中程度〜<br />大きな効果</div>
+            <div class="border border-line rounded-lg p-4 space-y-1">
+              <div class="text-2xl font-black text-accent">+4〜6</div>
+              <div class="text-sub">中程度〜<br />大きな効果</div>
             </div>
-            <div class="border border-[var(--color-line)] rounded-lg p-4 space-y-1">
-              <div class="text-2xl font-black text-[var(--color-accent)]">+7 以上</div>
-              <div class="text-[var(--color-sub)]">非常に<br />大きな効果</div>
+            <div class="border border-line rounded-lg p-4 space-y-1">
+              <div class="text-2xl font-black text-accent">+7 以上</div>
+              <div class="text-sub">非常に<br />大きな効果</div>
             </div>
           </div>
         </div>
@@ -110,9 +110,9 @@ import Layout from "../../layouts/Layout.astro";
           <p>
             「-◯ヶ月」は、その取り組みを行った学級が、<strong>行わなかった場合より◯ヶ月分遅れた</strong>ことを意味します。
             本サイトでは直感に反してでも効果のない・逆効果の研究知見も掲載しており、例えば
-            <a href="/strategies/repeating-a-year" class="link-underline text-[var(--color-accent)]">留年(-4ヶ月)</a>、
-            <a href="/strategies/corporal-punishment" class="link-underline text-[var(--color-accent)]">体罰(-3ヶ月)</a>、
-            <a href="/strategies/suspension" class="link-underline text-[var(--color-accent)]">停学・出席停止(-2ヶ月)</a> など、
+            <a href="/strategies/repeating-a-year" class="link-underline text-accent">留年(-4ヶ月)</a>、
+            <a href="/strategies/corporal-punishment" class="link-underline text-accent">体罰(-3ヶ月)</a>、
+            <a href="/strategies/suspension" class="link-underline text-accent">停学・出席停止(-2ヶ月)</a> など、
             <strong>「やってはいけない」ことをエビデンスで確認する</strong>ためにも使えます。
           </p>
         </div>
@@ -120,13 +120,13 @@ import Layout from "../../layouts/Layout.astro";
     </div>
 
     <!-- エビデンスの強さ -->
-    <div class="border-t border-[var(--color-line)] pt-10 space-y-6">
+    <div class="border-t border-line pt-10 space-y-6">
       <div class="flex items-center gap-6">
-        <span class="font-mono text-xs uppercase tracking-widest text-[var(--color-sub)]">02</span>
+        <span class="font-mono text-xs uppercase tracking-widest text-sub">02</span>
         <h2 class="text-3xl font-black tracking-tight">エビデンスの強さ（★）</h2>
       </div>
       <div class="text-4xl text-amber-500">★★★★☆</div>
-      <div class="leading-loose text-[var(--color-ink)]/90 space-y-6">
+      <div class="leading-loose text-ink/90 space-y-6">
         <p>
           その効果が<strong>どれだけ信頼できる研究で確かめられているか</strong>を示します。
           「効果が大きい」ことと「証拠が確か」であることは別の話です。
@@ -169,18 +169,18 @@ import Layout from "../../layouts/Layout.astro";
     </div>
 
     <!-- 導入コスト -->
-    <div class="border-t border-[var(--color-line)] pt-10 space-y-6">
+    <div class="border-t border-line pt-10 space-y-6">
       <div class="flex items-center gap-6">
-        <span class="font-mono text-xs uppercase tracking-widest text-[var(--color-sub)]">03</span>
+        <span class="font-mono text-xs uppercase tracking-widest text-sub">03</span>
         <h2 class="text-3xl font-black tracking-tight">導入コスト（¥）</h2>
       </div>
       <div class="text-4xl text-emerald-700 dark:text-emerald-300 tracking-widest">¥¥···</div>
-      <div class="leading-loose text-[var(--color-ink)]/90 space-y-6">
+      <div class="leading-loose text-ink/90 space-y-6">
         <p>
           その指導法を導入するのに、児童1人あたり年間どのくらいの<strong>金銭的コスト</strong>がかかるかの概算です。
           EEF Toolkit の基準(英ポンド £)を日本円に換算し、日本の小学校の文脈に合わせた目安としています。
         </p>
-        <p class="text-xs text-[var(--color-sub)]">
+        <p class="text-xs text-sub">
           ※ 下記の日本円換算は <strong>2026年4月時点(1£ ≒ 215円)</strong> の為替レートに基づく概算です。為替変動により数値は変わります。
         </p>
         <div class="space-y-3">
@@ -190,35 +190,35 @@ import Layout from "../../layouts/Layout.astro";
               <span class="text-emerald-700 dark:text-emerald-300 shrink-0 font-mono">¥····</span>
               <div>
                 <div><strong>0円〜約17,000円</strong>（EEF: £0–£80）</div>
-                <div class="text-[var(--color-sub)] text-sm">教師の工夫で始められる。特別な予算不要。例: フィードバック、メタ認知の指導、検索練習</div>
+                <div class="text-sub text-sm">教師の工夫で始められる。特別な予算不要。例: フィードバック、メタ認知の指導、検索練習</div>
               </div>
             </div>
             <div class="flex gap-4 items-start">
               <span class="text-emerald-700 dark:text-emerald-300 shrink-0 font-mono">¥¥···</span>
               <div>
                 <div><strong>約17,000〜43,000円</strong>（EEF: £80–£200）</div>
-                <div class="text-[var(--color-sub)] text-sm">少額の教材費や短時間の研修。例: 協同学習、SEL、マスタリーラーニング</div>
+                <div class="text-sub text-sm">少額の教材費や短時間の研修。例: 協同学習、SEL、マスタリーラーニング</div>
               </div>
             </div>
             <div class="flex gap-4 items-start">
               <span class="text-emerald-700 dark:text-emerald-300 shrink-0 font-mono">¥¥¥··</span>
               <div>
                 <div><strong>約43,000〜150,000円</strong>（EEF: £200–£700）</div>
-                <div class="text-[var(--color-sub)] text-sm">まとまった教材費、定期的な研修、一部人員の確保。例: 少人数指導、保護者との連携プログラム</div>
+                <div class="text-sub text-sm">まとまった教材費、定期的な研修、一部人員の確保。例: 少人数指導、保護者との連携プログラム</div>
               </div>
             </div>
             <div class="flex gap-4 items-start">
               <span class="text-emerald-700 dark:text-emerald-300 shrink-0 font-mono">¥¥¥¥·</span>
               <div>
                 <div><strong>約150,000〜258,000円</strong>（EEF: £700–£1,200）</div>
-                <div class="text-[var(--color-sub)] text-sm">専門スタッフの配置、大規模な研修、ICT環境整備。例: 個別指導、補助スタッフの活用</div>
+                <div class="text-sub text-sm">専門スタッフの配置、大規模な研修、ICT環境整備。例: 個別指導、補助スタッフの活用</div>
               </div>
             </div>
             <div class="flex gap-4 items-start">
               <span class="text-emerald-700 dark:text-emerald-300 shrink-0 font-mono">¥¥¥¥¥</span>
               <div>
                 <div><strong>約258,000円以上</strong>（EEF: £1,200以上）</div>
-                <div class="text-[var(--color-sub)] text-sm">学級編成の変更、教員増員など、組織的・制度的投資。例: 学級規模の縮小、教科担任制</div>
+                <div class="text-sub text-sm">学級編成の変更、教員増員など、組織的・制度的投資。例: 学級規模の縮小、教科担任制</div>
               </div>
             </div>
           </div>
@@ -236,9 +236,9 @@ import Layout from "../../layouts/Layout.astro";
     </div>
 
     <!-- 出典(ソース) -->
-    <div class="border-t border-[var(--color-line)] pt-10 space-y-6">
+    <div class="border-t border-line pt-10 space-y-6">
       <div class="flex items-center gap-6">
-        <span class="font-mono text-xs uppercase tracking-widest text-[var(--color-sub)]">04</span>
+        <span class="font-mono text-xs uppercase tracking-widest text-sub">04</span>
         <h2 class="text-3xl font-black tracking-tight">出典バッジ</h2>
       </div>
       <div class="flex flex-wrap gap-2">
@@ -246,7 +246,7 @@ import Layout from "../../layouts/Layout.astro";
         <span class="font-mono text-[10px] tracking-widest uppercase border rounded-full px-2 py-0.5 leading-none inline-flex items-center h-5 text-rose-700 border-rose-700/40 bg-rose-50 dark:text-rose-200 dark:border-rose-200/40 dark:bg-rose-200/10">日本</span>
         <span class="font-mono text-[10px] tracking-widest uppercase border rounded-full px-2 py-0.5 leading-none inline-flex items-center h-5 text-amber-800 border-amber-800/40 bg-amber-50 dark:text-amber-200 dark:border-amber-200/40 dark:bg-amber-200/10">Hattie</span>
       </div>
-      <div class="leading-loose text-[var(--color-ink)]/90 space-y-6">
+      <div class="leading-loose text-ink/90 space-y-6">
         <p>
           各指導法に付いているバッジは、その効果量が<strong>どの研究ソースに基づいているか</strong>を示します。
           複数のソースに該当する場合は、複数のバッジが表示されます。
@@ -258,21 +258,21 @@ import Layout from "../../layouts/Layout.astro";
               <span class="font-mono text-[10px] tracking-widest uppercase border rounded-full px-2 py-0.5 leading-none inline-flex items-center h-5 text-sky-800 border-sky-800/40 bg-sky-50 dark:text-sky-200 dark:border-sky-200/40 dark:bg-sky-200/10 shrink-0 mt-1">EEF</span>
               <div>
                 <div><strong>英国 Education Endowment Foundation</strong></div>
-                <div class="text-[var(--color-sub)] text-sm">Teaching and Learning Toolkit に基づく。数百〜数千本のメタ分析を統合。本サイトの主要参照元。</div>
+                <div class="text-sub text-sm">Teaching and Learning Toolkit に基づく。数百〜数千本のメタ分析を統合。本サイトの主要参照元。</div>
               </div>
             </div>
             <div class="flex gap-4 items-start">
               <span class="font-mono text-[10px] tracking-widest uppercase border rounded-full px-2 py-0.5 leading-none inline-flex items-center h-5 text-rose-700 border-rose-700/40 bg-rose-50 dark:text-rose-200 dark:border-rose-200/40 dark:bg-rose-200/10 shrink-0 mt-1">日本</span>
               <div>
                 <div><strong>日本国内の研究</strong></div>
-                <div class="text-[var(--color-sub)] text-sm">中室牧子・松岡亮二・赤林英夫・耳塚寛明 等による実証研究。日本の文脈に最も近い知見。</div>
+                <div class="text-sub text-sm">中室牧子・松岡亮二・赤林英夫・耳塚寛明 等による実証研究。日本の文脈に最も近い知見。</div>
               </div>
             </div>
             <div class="flex gap-4 items-start">
               <span class="font-mono text-[10px] tracking-widest uppercase border rounded-full px-2 py-0.5 leading-none inline-flex items-center h-5 text-amber-800 border-amber-800/40 bg-amber-50 dark:text-amber-200 dark:border-amber-200/40 dark:bg-amber-200/10 shrink-0 mt-1">Hattie</span>
               <div>
                 <div><strong>Hattie の Visible Learning</strong></div>
-                <div class="text-[var(--color-sub)] text-sm">800以上のメタ分析を統合。影響力は大きいが、効果量が楽観的に出やすい傾向があり、参考値として扱う。</div>
+                <div class="text-sub text-sm">800以上のメタ分析を統合。影響力は大きいが、効果量が楽観的に出やすい傾向があり、参考値として扱う。</div>
               </div>
             </div>
           </div>
@@ -282,22 +282,22 @@ import Layout from "../../layouts/Layout.astro";
           <p>
             複数のソースで値が異なる場合、本サイトは以下の順で代表値を選んでいます:
             <strong>日本研究(★3以上) &gt; EEF &gt; Hattie(保守的に調整) &gt; 推測値(0として扱う)</strong>。
-            詳しくは <a href="/guide/cultural-context" class="link-underline text-[var(--color-accent)]">エビデンスと文化的文脈</a> を参照。
+            詳しくは <a href="/guide/cultural-context" class="link-underline text-accent">エビデンスと文化的文脈</a> を参照。
           </p>
         </div>
       </div>
     </div>
 
     <!-- まとめ -->
-    <div class="border-t border-[var(--color-line)] pt-10 text-center space-y-8">
-      <p class="text-[var(--color-sub)] leading-loose">
+    <div class="border-t border-line pt-10 text-center space-y-8">
+      <p class="text-sub leading-loose">
         4つの指標は、いずれも「絶対的な答え」ではありません。<br />
         目の前の子どもと教室の状況を踏まえて、<br />
-        <strong class="text-[var(--color-ink)]">判断の参考</strong>としてお使いください。
+        <strong class="text-ink">判断の参考</strong>としてお使いください。
       </p>
       <a
         href="/"
-        class="link-underline inline-block font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]"
+        class="link-underline inline-block font-mono text-xs uppercase tracking-widest text-accent"
       >
         ← 指導法一覧へ戻る
       </a>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -40,22 +40,22 @@ const featuredConcerns = featuredConcernSlugs.map((slug) => {
 
 <Layout>
   <section class="pt-10 sm:pt-14 md:pt-20 lg:pt-28 pb-10 sm:pb-14 md:pb-20">
-    <p class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]">
+    <p class="font-mono text-xs uppercase tracking-widest text-accent">
       Evidence-based teaching for elementary schools
     </p>
-    <p class="mt-1 text-xs text-[var(--color-sub)]">
+    <p class="mt-1 text-xs text-sub">
       小学校教員のための教育エビデンス・ポータル
     </p>
     <h1
       class="mt-5 font-black text-4xl sm:text-5xl md:text-6xl lg:text-7xl leading-[1.15] tracking-tight"
     >
-      <span class="text-[var(--color-accent)]">エビデンス</span>を、<br />
+      <span class="text-accent">エビデンス</span>を、<br />
       現場の指導へ。
     </h1>
     <div
-      class="mt-6 max-w-2xl text-[var(--color-sub)] leading-loose text-sm sm:text-base space-y-4"
+      class="mt-6 max-w-2xl text-sub leading-loose text-sm sm:text-base space-y-4"
     >
-      <p class="text-[var(--color-ink)] font-bold text-base sm:text-lg leading-snug">
+      <p class="text-ink font-bold text-base sm:text-lg leading-snug">
         経験と勘に、もうひとつの視点を。
       </p>
       <p>
@@ -69,12 +69,12 @@ const featuredConcerns = featuredConcernSlugs.map((slug) => {
 
   <section
     aria-labelledby="concerns-cta-heading"
-    class="border-t border-[var(--color-line)] py-8 xs:py-10 sm:py-14"
+    class="border-t border-line py-8 xs:py-10 sm:py-14"
   >
     <div class="grid grid-cols-12 gap-6 mb-6">
       <div class="col-span-12 min-[900px]:col-span-8 space-y-2">
         <p
-          class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]"
+          class="font-mono text-xs uppercase tracking-widest text-accent"
         >
           Find by your concern
         </p>
@@ -82,9 +82,9 @@ const featuredConcerns = featuredConcernSlugs.map((slug) => {
           id="concerns-cta-heading"
           class="font-black text-3xl md:text-4xl tracking-tight leading-[1.2]"
         >
-          現場の<span class="text-[var(--color-accent)]">悩み</span>から、エビデンスを探す。
+          現場の<span class="text-accent">悩み</span>から、エビデンスを探す。
         </h2>
-        <p class="text-sm text-[var(--color-sub)] leading-relaxed pt-1">
+        <p class="text-sm text-sub leading-relaxed pt-1">
           指導法の一覧から入る前に、まず日々の悩みから関連するエビデンスをたどれます。
         </p>
       </div>
@@ -93,10 +93,10 @@ const featuredConcerns = featuredConcernSlugs.map((slug) => {
       >
         <a
           href="/concerns"
-          class="group inline-flex items-center justify-between gap-3 rounded-full border border-[var(--color-accent)] bg-[var(--color-accent)] px-5 py-3 text-sm font-bold text-white dark:text-[var(--color-bg)] motion-safe:transition motion-safe:duration-200 motion-safe:ease-out hover:bg-[var(--color-accent-hover)] hover:border-[var(--color-accent-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg)]"
+          class="group inline-flex items-center justify-between gap-3 rounded-full border border-accent bg-accent px-5 py-3 text-sm font-bold text-white dark:text-bg motion-safe:transition motion-safe:duration-200 motion-safe:ease-out hover:bg-accent-hover hover:border-accent-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
         >
-          <span class="text-white dark:text-[var(--color-bg)]">全{totalConcerns}件の悩みを見る</span>
-          <span class="text-white dark:text-[var(--color-bg)] motion-safe:transition group-hover:translate-x-0.5" aria-hidden="true">→</span>
+          <span class="text-white dark:text-bg">全{totalConcerns}件の悩みを見る</span>
+          <span class="text-white dark:text-bg motion-safe:transition group-hover:translate-x-0.5" aria-hidden="true">→</span>
         </a>
       </div>
     </div>
@@ -113,30 +113,30 @@ const featuredConcerns = featuredConcernSlugs.map((slug) => {
                 href={`/concerns#${concern.slug}`}
                 aria-labelledby={titleId}
                 data-concern-card
-                class="group block h-full rounded-xl border border-[var(--color-line)] bg-[var(--color-card)] p-5 space-y-3 motion-safe:transition motion-safe:duration-200 motion-safe:ease-out hover:border-[var(--color-accent)] focus-visible:border-[var(--color-accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg)]"
+                class="group block h-full rounded-xl border border-line bg-card p-5 space-y-3 motion-safe:transition motion-safe:duration-200 motion-safe:ease-out hover:border-accent focus-visible:border-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
               >
-                <div class="font-mono text-[10px] tracking-widest uppercase text-[var(--color-sub)]">
+                <div class="font-mono text-[10px] tracking-widest uppercase text-sub">
                   {categoryTitle}
                 </div>
                 <h3
                   id={titleId}
-                  class="font-black text-base leading-snug motion-safe:transition group-hover:text-[var(--color-accent)] group-focus-visible:text-[var(--color-accent)]"
+                  class="font-black text-base leading-snug motion-safe:transition group-hover:text-accent group-focus-visible:text-accent"
                 >
                   {concern.title}
                 </h3>
-                <p class="text-xs text-[var(--color-sub)] leading-relaxed line-clamp-3">
+                <p class="text-xs text-sub leading-relaxed line-clamp-3">
                   {concern.diagnosis}
                 </p>
-                <div class="flex items-center gap-3 pt-1 text-[11px] text-[var(--color-sub)]">
+                <div class="flex items-center gap-3 pt-1 text-[11px] text-sub">
                   <span>
-                    <span class="font-bold text-[var(--color-ink)]">
+                    <span class="font-bold text-ink">
                       {strategyCount}
                     </span>
                     件の指導法
                   </span>
                   {columnCount > 0 && (
                     <span>
-                      <span class="font-bold text-[var(--color-ink)]">
+                      <span class="font-bold text-ink">
                         {columnCount}
                       </span>
                       件のコラム
@@ -151,70 +151,70 @@ const featuredConcerns = featuredConcernSlugs.map((slug) => {
     </ul>
   </section>
 
-  <section class="border-t border-[var(--color-line)] py-5 xs:py-7 sm:py-10">
+  <section class="border-t border-line py-5 xs:py-7 sm:py-10">
     <div class="grid grid-cols-12 gap-6">
       <div class="col-span-12 min-[900px]:col-span-3 space-y-3">
         <div class="space-y-1">
           <div
-            class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]"
+            class="font-mono text-xs uppercase tracking-widest text-accent"
           >
             How to read
           </div>
-          <div class="text-xs text-[var(--color-sub)]">指標の読み方</div>
+          <div class="text-xs text-sub">指標の読み方</div>
         </div>
         <div class="flex items-baseline gap-4">
-          <span class="text-3xl font-black text-[var(--color-accent)]">+5<span class="text-base ml-1">ヶ月</span></span>
-          <span class="text-3xl font-black text-[var(--color-chart-red)]">(<span class="text-base mr-0.5">-</span>5<span class="text-base ml-1">ヶ月</span>)</span>
+          <span class="text-3xl font-black text-accent">+5<span class="text-base ml-1">ヶ月</span></span>
+          <span class="text-3xl font-black text-chart-red">(<span class="text-base mr-0.5">-</span>5<span class="text-base ml-1">ヶ月</span>)</span>
         </div>
         <div class="text-xl text-amber-500">★★★★☆</div>
       </div>
       <div
-        class="col-span-12 min-[900px]:col-span-9 text-sm md:text-base text-[var(--color-sub)] leading-loose space-y-3"
+        class="col-span-12 min-[900px]:col-span-9 text-sm md:text-base text-sub leading-loose space-y-3"
       >
         <p>
-          <strong class="text-[var(--color-accent)]">+◯ヶ月(緑)</strong> =
-          この指導法を取り入れた学級は、1年後に<strong class="text-[var(--color-ink)]">通常より◯ヶ月分先</strong>に進んだ。取り入れる価値のある指導法。<br />
-          <strong class="text-[var(--color-chart-red)]">(-◯ヶ月)(赤)</strong> =
-          逆に、<strong class="text-[var(--color-ink)]">◯ヶ月分遅れた</strong>。やらない方がよかった指導法。
+          <strong class="text-accent">+◯ヶ月(緑)</strong> =
+          この指導法を取り入れた学級は、1年後に<strong class="text-ink">通常より◯ヶ月分先</strong>に進んだ。取り入れる価値のある指導法。<br />
+          <strong class="text-chart-red">(-◯ヶ月)(赤)</strong> =
+          逆に、<strong class="text-ink">◯ヶ月分遅れた</strong>。やらない方がよかった指導法。
         </p>
         <p>
-          <span class="text-amber-500">★</span> は<strong class="text-[var(--color-ink)]">「その数字をどこまで信じていいか」</strong>を表します。<br />
+          <span class="text-amber-500">★</span> は<strong class="text-ink">「その数字をどこまで信じていいか」</strong>を表します。<br />
           ★が多い = 多くの質の高い研究で繰り返し確かめられている。<br />
           ★が少ない = 研究がまだ少なく、数字が変わる可能性がある。
         </p>
-        <p class="text-[var(--color-ink)] font-bold">
+        <p class="text-ink font-bold">
           月数と★をセットで見ることで、より確かな判断ができます。
         </p>
         <div class="grid grid-cols-2 gap-3 text-sm">
-          <div class="border border-[var(--color-line)] rounded-lg p-3">
-            <div class="font-bold text-[var(--color-ink)]">+5ヶ月 ★★☆☆☆</div>
-            <div class="text-[var(--color-sub)]">効果は大きいが研究が少ない。<br />過大評価の可能性あり</div>
+          <div class="border border-line rounded-lg p-3">
+            <div class="font-bold text-ink">+5ヶ月 ★★☆☆☆</div>
+            <div class="text-sub">効果は大きいが研究が少ない。<br />過大評価の可能性あり</div>
           </div>
-          <div class="border border-[var(--color-accent)]/30 rounded-lg p-3">
-            <div class="font-bold text-[var(--color-ink)]">+5ヶ月 ★★★★★</div>
-            <div class="text-[var(--color-sub)]">同じ+5でも<br /><strong class="text-[var(--color-ink)]">★が多い方が信頼できる</strong></div>
+          <div class="border border-accent/30 rounded-lg p-3">
+            <div class="font-bold text-ink">+5ヶ月 ★★★★★</div>
+            <div class="text-sub">同じ+5でも<br /><strong class="text-ink">★が多い方が信頼できる</strong></div>
           </div>
         </div>
         <p class="text-xs">
           ※ 月数は集団の平均値であり、個々の教室への効果を保証しません。
-          <a href="/guide/indicators" class="link-underline text-[var(--color-accent)]">指標の読み方 →</a>
+          <a href="/guide/indicators" class="link-underline text-accent">指標の読み方 →</a>
         </p>
-        <p class="text-xs text-[var(--color-sub)] bg-[var(--color-accent)]/5 border-l-2 border-[var(--color-accent)] pl-3 py-2">
-          <strong class="text-[var(--color-ink)]">【重要】</strong> この月数は<strong class="text-[var(--color-ink)]">テストで測れる学力</strong>への効果を示したものです。
+        <p class="text-xs text-sub bg-accent/5 border-l-2 border-accent pl-3 py-2">
+          <strong class="text-ink">【重要】</strong> この月数は<strong class="text-ink">テストで測れる学力</strong>への効果を示したものです。
           非認知能力・社会性・ウェルビーイングなど、学力以外の側面も教育では同じく大切です。月数が小さくても、そうした面で大きな価値を持つ指導法があります。
         </p>
       </div>
     </div>
   </section>
 
-  <section class="border-t border-[var(--color-line)] py-5 xs:py-7 sm:py-10">
+  <section class="border-t border-line py-5 xs:py-7 sm:py-10">
     <div class="grid grid-cols-12 gap-6">
       <div class="col-span-12 min-[900px]:col-span-3 space-y-3">
         <div class="space-y-1">
-          <div class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]">
+          <div class="font-mono text-xs uppercase tracking-widest text-accent">
             Data source
           </div>
-          <div class="text-xs text-[var(--color-sub)]">データの出典</div>
+          <div class="text-xs text-sub">データの出典</div>
         </div>
         <div class="flex items-center gap-2">
           <span class="font-mono text-[10px] tracking-widest uppercase border rounded-full px-2 py-0.5 leading-none inline-flex items-center h-5 text-sky-800 border-sky-800/40 bg-sky-50 dark:text-sky-200 dark:border-sky-200/40 dark:bg-sky-200/10">EEF</span>
@@ -222,21 +222,21 @@ const featuredConcerns = featuredConcernSlugs.map((slug) => {
           <span class="font-mono text-[10px] tracking-widest uppercase border rounded-full px-2 py-0.5 leading-none inline-flex items-center h-5 text-amber-800 border-amber-800/40 bg-amber-50 dark:text-amber-200 dark:border-amber-200/40 dark:bg-amber-200/10">Hattie</span>
         </div>
       </div>
-      <div class="col-span-12 min-[900px]:col-span-9 text-sm md:text-base text-[var(--color-sub)] leading-loose space-y-3">
+      <div class="col-span-12 min-[900px]:col-span-9 text-sm md:text-base text-sub leading-loose space-y-3">
         <p>
           このサイトの「+◯ヶ月」は主に
-          <strong class="text-[var(--color-ink)]">英国 Education Endowment Foundation（EEF）</strong>
-          の <a href="https://educationendowmentfoundation.org.uk/education-evidence/teaching-learning-toolkit" target="_blank" rel="noopener" class="link-underline text-[var(--color-accent)]">Teaching and Learning Toolkit</a> に基づいています。
+          <strong class="text-ink">英国 Education Endowment Foundation（EEF）</strong>
+          の <a href="https://educationendowmentfoundation.org.uk/education-evidence/teaching-learning-toolkit" target="_blank" rel="noopener" class="link-underline text-accent">Teaching and Learning Toolkit</a> に基づいています。
         </p>
         <p>
-          EEF は英国政府が設立した教育研究財団で、<strong class="text-[var(--color-ink)]">数百〜数千本の研究を統合したメタ分析</strong>をもとに、30以上の指導法を「効果」「信頼性」「コスト」の3指標で評価・公開しています。世界中の教育政策で参照される、最も体系的な教育エビデンスの一つです。
+          EEF は英国政府が設立した教育研究財団で、<strong class="text-ink">数百〜数千本の研究を統合したメタ分析</strong>をもとに、30以上の指導法を「効果」「信頼性」「コスト」の3指標で評価・公開しています。世界中の教育政策で参照される、最も体系的な教育エビデンスの一つです。
         </p>
         <p>
-          本サイトでは EEF のデータに加え、<strong class="text-[var(--color-ink)]">日本の研究者によるエビデンス</strong>（中室牧子・松岡亮二・赤林英夫 他）と、
-          <strong class="text-[var(--color-ink)]">Hattie の Visible Learning</strong> のデータを併記しています。
+          本サイトでは EEF のデータに加え、<strong class="text-ink">日本の研究者によるエビデンス</strong>（中室牧子・松岡亮二・赤林英夫 他）と、
+          <strong class="text-ink">Hattie の Visible Learning</strong> のデータを併記しています。
         </p>
         <p>
-          Visible Learning は、ジョン・ハッティが<strong class="text-[var(--color-ink)]">800以上のメタ分析を統合</strong>し、250以上の教育要因を効果量で順位づけした研究プロジェクトです。影響力は非常に大きいですが、<strong class="text-[var(--color-ink)]">効果量が楽観的に出やすい傾向</strong>があり、独立した研究で再現されない値もあります。本サイトでは EEF を主とし、Hattie は参考値として扱っています。
+          Visible Learning は、ジョン・ハッティが<strong class="text-ink">800以上のメタ分析を統合</strong>し、250以上の教育要因を効果量で順位づけした研究プロジェクトです。影響力は非常に大きいですが、<strong class="text-ink">効果量が楽観的に出やすい傾向</strong>があり、独立した研究で再現されない値もあります。本サイトでは EEF を主とし、Hattie は参考値として扱っています。
         </p>
         <p>
           各指導法に <span class="font-mono text-[10px] tracking-widest uppercase border rounded-full px-1.5 py-0.5 text-sky-800 border-sky-800/40 bg-sky-50 dark:text-sky-200 dark:border-sky-200/40 dark:bg-sky-200/10">EEF</span>
@@ -246,23 +246,23 @@ const featuredConcerns = featuredConcernSlugs.map((slug) => {
         </p>
         <p class="text-xs">
           ※ EEF の数値は英国の学校を対象としたものです。日本の教室にそのまま当てはまるとは限りません。各指導法ページに「日本の文脈で考慮したいこと」を記載しています。
-          <a href="/guide/cultural-context" class="link-underline text-[var(--color-accent)]">エビデンスと文化的文脈 →</a>
+          <a href="/guide/cultural-context" class="link-underline text-accent">エビデンスと文化的文脈 →</a>
         </p>
       </div>
     </div>
   </section>
 
-  <section class="border-t border-[var(--color-line)] py-8 xs:py-10 sm:py-14">
+  <section class="border-t border-line py-8 xs:py-10 sm:py-14">
     <div class="flex items-baseline justify-between mb-6 flex-wrap gap-3">
       <div class="space-y-1">
-        <p class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]">
+        <p class="font-mono text-xs uppercase tracking-widest text-accent">
           Latest
         </p>
         <h2 class="font-black text-2xl md:text-3xl tracking-tight">最新の更新</h2>
       </div>
       <div class="flex items-center gap-4 text-xs">
-        <a href="/columns" class="link-underline text-[var(--color-sub)] hover:text-[var(--color-ink)] transition">コラム一覧 →</a>
-        <a href="/rss.xml" class="link-underline text-[var(--color-sub)] hover:text-[var(--color-ink)] transition">RSS 購読</a>
+        <a href="/columns" class="link-underline text-sub hover:text-ink transition">コラム一覧 →</a>
+        <a href="/rss.xml" class="link-underline text-sub hover:text-ink transition">RSS 購読</a>
       </div>
     </div>
     <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
@@ -270,18 +270,18 @@ const featuredConcerns = featuredConcernSlugs.map((slug) => {
         latestColumns.map((c) => (
           <a
             href={`/columns/${c.id}`}
-            class="group block border border-[var(--color-line)] rounded-xl p-5 bg-[var(--color-card)] hover:border-[var(--color-accent)] transition space-y-3"
+            class="group block border border-line rounded-xl p-5 bg-card hover:border-accent transition space-y-3"
           >
-            <div class="font-mono text-[10px] tracking-widest text-[var(--color-sub)]">
+            <div class="font-mono text-[10px] tracking-widest text-sub">
               {c.data.lastVerified ?? c.data.date}
               {c.data.lastVerified && c.data.lastVerified !== c.data.date && (
-                <span class="ml-1 text-[var(--color-accent)]">(更新)</span>
+                <span class="ml-1 text-accent">(更新)</span>
               )}
             </div>
-            <h3 class="font-black text-base md:text-lg leading-snug group-hover:text-[var(--color-accent)] transition">
+            <h3 class="font-black text-base md:text-lg leading-snug group-hover:text-accent transition">
               {c.data.title}
             </h3>
-            <p class="text-xs text-[var(--color-sub)] leading-relaxed line-clamp-3">
+            <p class="text-xs text-sub leading-relaxed line-clamp-3">
               {c.data.summary}
             </p>
           </a>
@@ -294,84 +294,84 @@ const featuredConcerns = featuredConcernSlugs.map((slug) => {
     <div class="flex flex-wrap gap-3">
       <a
         href="/subjects"
-        class="border border-[var(--color-line)] rounded-full px-4 py-2 text-sm hover:border-[var(--color-accent)] hover:bg-[var(--color-card)] transition"
+        class="border border-line rounded-full px-4 py-2 text-sm hover:border-accent hover:bg-card transition"
       >
-        <span class="font-bold">教科</span><span class="text-[var(--color-sub)] ml-1">から探す</span>
+        <span class="font-bold">教科</span><span class="text-sub ml-1">から探す</span>
       </a>
       <a
         href="/grades"
-        class="border border-[var(--color-line)] rounded-full px-4 py-2 text-sm hover:border-[var(--color-accent)] hover:bg-[var(--color-card)] transition"
+        class="border border-line rounded-full px-4 py-2 text-sm hover:border-accent hover:bg-card transition"
       >
-        <span class="font-bold">学年</span><span class="text-[var(--color-sub)] ml-1">から探す</span>
+        <span class="font-bold">学年</span><span class="text-sub ml-1">から探す</span>
       </a>
       <a
         href="/cost"
-        class="border border-[var(--color-line)] rounded-full px-4 py-2 text-sm hover:border-[var(--color-accent)] hover:bg-[var(--color-card)] transition"
+        class="border border-line rounded-full px-4 py-2 text-sm hover:border-accent hover:bg-card transition"
       >
-        <span class="font-bold">コスト</span><span class="text-[var(--color-sub)] ml-1">から探す</span>
+        <span class="font-bold">コスト</span><span class="text-sub ml-1">から探す</span>
       </a>
       <a
         href="/tags"
-        class="border border-[var(--color-line)] rounded-full px-4 py-2 text-sm hover:border-[var(--color-accent)] hover:bg-[var(--color-card)] transition"
+        class="border border-line rounded-full px-4 py-2 text-sm hover:border-accent hover:bg-card transition"
       >
-        <span class="font-bold">タグ</span><span class="text-[var(--color-sub)] ml-1">から探す</span>
+        <span class="font-bold">タグ</span><span class="text-sub ml-1">から探す</span>
       </a>
       <a
         href="/seasonal/july"
-        class="border border-[var(--color-line)] rounded-full px-4 py-2 text-sm hover:border-[var(--color-accent)] hover:bg-[var(--color-card)] transition"
+        class="border border-line rounded-full px-4 py-2 text-sm hover:border-accent hover:bg-card transition"
       >
-        <span class="font-bold">7月・学期末</span><span class="text-[var(--color-sub)] ml-1">から探す</span>
+        <span class="font-bold">7月・学期末</span><span class="text-sub ml-1">から探す</span>
       </a>
     </div>
 
     <div class="space-y-4">
       <div
-        class="flex items-baseline justify-between px-2 text-xs text-[var(--color-sub)]"
+        class="flex items-baseline justify-between px-2 text-xs text-sub"
       >
-        <span class="font-bold text-sm text-[var(--color-ink)]">エビデンス一覧</span>
+        <span class="font-bold text-sm text-ink">エビデンス一覧</span>
         <span id="count-display">{strategies.length}件</span>
       </div>
 
       <div class="flex flex-wrap items-center gap-2 px-2">
-        <span class="text-xs text-[var(--color-sub)]">カテゴリ</span>
-        <button data-category="all" class="cat-btn font-mono text-[11px] tracking-widest px-3 py-1 rounded-full border border-[var(--color-accent)] text-[var(--color-accent)] bg-[var(--color-accent)]/5 transition cursor-pointer">
+        <span class="text-xs text-sub">カテゴリ</span>
+        <button data-category="all" class="cat-btn font-mono text-[11px] tracking-widest px-3 py-1 rounded-full border border-accent text-accent bg-accent/5 transition cursor-pointer">
           すべて
         </button>
-        <button data-category="指導法" class="cat-btn font-mono text-[11px] tracking-widest px-3 py-1 rounded-full border border-[var(--color-line)] text-[var(--color-sub)] hover:border-[var(--color-accent)] transition cursor-pointer">
+        <button data-category="指導法" class="cat-btn font-mono text-[11px] tracking-widest px-3 py-1 rounded-full border border-line text-sub hover:border-accent transition cursor-pointer">
           指導法
         </button>
-        <button data-category="認知科学" class="cat-btn font-mono text-[11px] tracking-widest px-3 py-1 rounded-full border border-[var(--color-line)] text-[var(--color-sub)] hover:border-[var(--color-accent)] transition cursor-pointer">
+        <button data-category="認知科学" class="cat-btn font-mono text-[11px] tracking-widest px-3 py-1 rounded-full border border-line text-sub hover:border-accent transition cursor-pointer">
           認知科学
         </button>
-        <button data-category="制度・環境" class="cat-btn font-mono text-[11px] tracking-widest px-3 py-1 rounded-full border border-[var(--color-line)] text-[var(--color-sub)] hover:border-[var(--color-accent)] transition cursor-pointer">
+        <button data-category="制度・環境" class="cat-btn font-mono text-[11px] tracking-widest px-3 py-1 rounded-full border border-line text-sub hover:border-accent transition cursor-pointer">
           制度・環境
         </button>
-        <button data-category="知っておくべき知見" class="cat-btn font-mono text-[11px] tracking-widest px-3 py-1 rounded-full border border-[var(--color-line)] text-[var(--color-sub)] hover:border-[var(--color-accent)] transition cursor-pointer">
+        <button data-category="知っておくべき知見" class="cat-btn font-mono text-[11px] tracking-widest px-3 py-1 rounded-full border border-line text-sub hover:border-accent transition cursor-pointer">
           知っておくべき知見
         </button>
-        <button data-category="家庭・外部" class="cat-btn font-mono text-[11px] tracking-widest px-3 py-1 rounded-full border border-[var(--color-line)] text-[var(--color-sub)] hover:border-[var(--color-accent)] transition cursor-pointer">
+        <button data-category="家庭・外部" class="cat-btn font-mono text-[11px] tracking-widest px-3 py-1 rounded-full border border-line text-sub hover:border-accent transition cursor-pointer">
           家庭・外部
         </button>
       </div>
 
       <div class="flex items-center gap-3 px-2">
-        <span class="text-xs text-[var(--color-sub)]">並び替え</span>
+        <span class="text-xs text-sub">並び替え</span>
         <button
           id="sort-effect"
-          class="font-mono text-[11px] uppercase tracking-widest px-3 py-1 rounded-full border border-[var(--color-accent)] text-[var(--color-accent)] bg-[var(--color-accent)]/5 transition cursor-pointer"
+          class="font-mono text-[11px] uppercase tracking-widest px-3 py-1 rounded-full border border-accent text-accent bg-accent/5 transition cursor-pointer"
         >
           効果量順
         </button>
         <button
           id="sort-evidence"
-          class="font-mono text-[11px] uppercase tracking-widest px-3 py-1 rounded-full border border-[var(--color-line)] text-[var(--color-sub)] hover:border-[var(--color-accent)] transition cursor-pointer"
+          class="font-mono text-[11px] uppercase tracking-widest px-3 py-1 rounded-full border border-line text-sub hover:border-accent transition cursor-pointer"
         >
           エビデンス強さ順
         </button>
       </div>
     </div>
 
-    <div id="strategy-list" class="border-b border-[var(--color-line)]">
+    <div id="strategy-list" class="border-b border-line">
       {
         strategies.map((s, i) => (
           <StrategyRow
@@ -393,8 +393,8 @@ const featuredConcerns = featuredConcernSlugs.map((slug) => {
       const list = document.getElementById("strategy-list");
       const btnEffect = document.getElementById("sort-effect");
       const btnEvidence = document.getElementById("sort-evidence");
-      const active = "border-[var(--color-accent)] text-[var(--color-accent)] bg-[var(--color-accent)]/5";
-      const inactive = "border-[var(--color-line)] text-[var(--color-sub)]";
+      const active = "border-accent text-accent bg-accent/5";
+      const inactive = "border-line text-sub";
 
       function sortList(key: string) {
         if (!list) return;

--- a/src/pages/policy-evidence.astro
+++ b/src/pages/policy-evidence.astro
@@ -169,23 +169,23 @@ const comparisons = [
 ];
 
 const alignmentLabel: Record<string, { text: string; color: string }> = {
-  mostly: { text: "概ね整合", color: "text-[var(--color-accent)]" },
+  mostly: { text: "概ね整合", color: "text-accent" },
   partial: { text: "部分的に整合", color: "text-amber-600" },
-  limited: { text: "エビデンス不足", color: "text-[var(--color-sub)]" },
+  limited: { text: "エビデンス不足", color: "text-sub" },
 };
 ---
 
 <Layout title="政策とエビデンス — EduEvidence JP">
   <section class="pt-10 sm:pt-14 md:pt-20 lg:pt-28 pb-10 sm:pb-14 md:pb-20">
-    <p class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]">
+    <p class="font-mono text-xs uppercase tracking-widest text-accent">
       Policy × Evidence
     </p>
     <h1
       class="mt-5 font-black text-4xl sm:text-5xl md:text-6xl lg:text-7xl leading-[1.15] tracking-tight"
     >
-      政策と<span class="text-[var(--color-accent)]">エビデンス</span>
+      政策と<span class="text-accent">エビデンス</span>
     </h1>
-    <div class="mt-6 max-w-2xl text-[var(--color-sub)] leading-loose text-sm sm:text-base">
+    <div class="mt-6 max-w-2xl text-sub leading-loose text-sm sm:text-base">
       <p>
         教育委員会や文部科学省から推進される主な政策を、研究のエビデンスと照らし合わせます。
       </p>
@@ -194,7 +194,7 @@ const alignmentLabel: Record<string, { text: string; color: string }> = {
 
   <section class="pb-12">
     <div
-      class="border border-[var(--color-accent)] rounded-xl p-6 md:p-8 bg-[var(--color-accent)]/[0.03] max-w-3xl"
+      class="border border-accent rounded-xl p-6 md:p-8 bg-accent/[0.03] max-w-3xl"
     >
       <p class="text-sm leading-loose">
         <strong>このページの読み方</strong> ——
@@ -212,9 +212,9 @@ const alignmentLabel: Record<string, { text: string; color: string }> = {
       comparisons.map((c, i) => {
         const al = alignmentLabel[c.alignment] ?? alignmentLabel.limited;
         return (
-          <div class="border-t border-[var(--color-line)] py-10 md:py-12">
+          <div class="border-t border-line py-10 md:py-12">
             <div class="grid grid-cols-12 gap-6 px-2">
-              <div class="col-span-2 md:col-span-1 font-mono text-sm text-[var(--color-sub)]">
+              <div class="col-span-2 md:col-span-1 font-mono text-sm text-sub">
                 {String(i + 1).padStart(2, "0")}
               </div>
 
@@ -232,13 +232,13 @@ const alignmentLabel: Record<string, { text: string; color: string }> = {
 
                 <div class="grid md:grid-cols-2 gap-6">
                   <div class="space-y-2">
-                    <div class="font-mono text-[11px] uppercase tracking-widest text-[var(--color-sub)]">
+                    <div class="font-mono text-[11px] uppercase tracking-widest text-sub">
                       政策の前提
                     </div>
                     <p class="text-sm leading-relaxed">{c.assumption}</p>
                   </div>
                   <div class="space-y-2">
-                    <div class="font-mono text-[11px] uppercase tracking-widest text-[var(--color-accent)]">
+                    <div class="font-mono text-[11px] uppercase tracking-widest text-accent">
                       エビデンスが示すこと
                     </div>
                     <p class="text-sm leading-relaxed">{c.evidence}</p>
@@ -249,7 +249,7 @@ const alignmentLabel: Record<string, { text: string; color: string }> = {
                   {c.strategies.map((s) => (
                     <a
                       href={s.href}
-                      class="link-underline text-[var(--color-accent)]"
+                      class="link-underline text-accent"
                     >
                       {s.name} →
                     </a>
@@ -257,7 +257,7 @@ const alignmentLabel: Record<string, { text: string; color: string }> = {
                   {c.column && (
                     <a
                       href={c.column.href}
-                      class="link-underline text-[var(--color-ink)]"
+                      class="link-underline text-ink"
                     >
                       コラム: {c.column.name} →
                     </a>
@@ -269,6 +269,6 @@ const alignmentLabel: Record<string, { text: string; color: string }> = {
         );
       })
     }
-    <div class="border-t border-[var(--color-line)]"></div>
+    <div class="border-t border-line"></div>
   </section>
 </Layout>

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -5,7 +5,7 @@ import Layout from "../layouts/Layout.astro";
 <Layout title="検索 — EduEvidence JP" description="指導法・コラム・用語を検索">
   <section class="py-10 xs:py-14 sm:py-20 md:py-28 space-y-8">
     <div class="space-y-2">
-      <p class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]">
+      <p class="font-mono text-xs uppercase tracking-widest text-accent">
         Search
       </p>
       <h1 class="font-black text-5xl md:text-6xl leading-[1.15] tracking-tight">
@@ -13,8 +13,8 @@ import Layout from "../layouts/Layout.astro";
       </h1>
     </div>
     <div id="search" class="max-w-2xl"></div>
-    <p id="search-fallback" class="text-sm text-[var(--color-sub)] hidden">
-      検索機能はビルド後の環境で動作します。<code class="font-mono text-xs bg-[var(--color-card)] px-1.5 py-0.5 rounded">npm run build && npm run preview</code> で確認できます。
+    <p id="search-fallback" class="text-sm text-sub hidden">
+      検索機能はビルド後の環境で動作します。<code class="font-mono text-xs bg-card px-1.5 py-0.5 rounded">npm run build && npm run preview</code> で確認できます。
     </p>
   </section>
 

--- a/src/pages/seasonal/july.astro
+++ b/src/pages/seasonal/july.astro
@@ -104,15 +104,15 @@ const scenes = [
 
 <Layout title="7月・学期末の教室 — EduEvidence JP">
   <section class="pt-10 sm:pt-14 md:pt-20 lg:pt-28 pb-10 sm:pb-14 md:pb-20">
-    <p class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]">
+    <p class="font-mono text-xs uppercase tracking-widest text-accent">
       Seasonal — July
     </p>
     <h1
       class="mt-5 font-black text-4xl sm:text-5xl md:text-6xl lg:text-7xl leading-[1.15] tracking-tight"
     >
-      7月・<span class="text-[var(--color-accent)]">学期末</span>の教室
+      7月・<span class="text-accent">学期末</span>の教室
     </h1>
-    <div class="mt-6 max-w-2xl text-[var(--color-sub)] leading-loose text-sm sm:text-base">
+    <div class="mt-6 max-w-2xl text-sub leading-loose text-sm sm:text-base">
       <p>
         通知表、夏休みの宿題、プール、個人面談——
         7月の教室で起きることを場面ごとに整理し、いま使えるエビデンスと公的情報への入口をまとめました。
@@ -122,7 +122,7 @@ const scenes = [
 
   <section class="pb-12">
     <div
-      class="border border-[var(--color-accent)] rounded-xl p-6 md:p-8 bg-[var(--color-accent)]/[0.03] max-w-3xl"
+      class="border border-accent rounded-xl p-6 md:p-8 bg-accent/[0.03] max-w-3xl"
     >
       <p class="text-sm leading-loose">
         <strong>このページの使い方</strong> ——
@@ -136,9 +136,9 @@ const scenes = [
   <section class="pb-12">
     {
       scenes.map((s, i) => (
-        <div class="border-t border-[var(--color-line)] py-10 md:py-12">
+        <div class="border-t border-line py-10 md:py-12">
           <div class="grid grid-cols-12 gap-6 px-2">
-            <div class="col-span-2 md:col-span-1 font-mono text-sm text-[var(--color-sub)]">
+            <div class="col-span-2 md:col-span-1 font-mono text-sm text-sub">
               {String(i + 1).padStart(2, "0")}
             </div>
 
@@ -149,11 +149,11 @@ const scenes = [
               <div class="space-y-2 text-xs">
                 {s.strategies.length > 0 && (
                   <div class="flex flex-wrap items-baseline gap-x-4 gap-y-1.5">
-                    <span class="font-mono text-[11px] tracking-widest text-[var(--color-sub)]">
+                    <span class="font-mono text-[11px] tracking-widest text-sub">
                       エビデンス
                     </span>
                     {s.strategies.map((t) => (
-                      <a href={t.href} class="link-underline text-[var(--color-accent)]">
+                      <a href={t.href} class="link-underline text-accent">
                         {t.name} →
                       </a>
                     ))}
@@ -161,11 +161,11 @@ const scenes = [
                 )}
                 {s.laws.length > 0 && (
                   <div class="flex flex-wrap items-baseline gap-x-4 gap-y-1.5">
-                    <span class="font-mono text-[11px] tracking-widest text-[var(--color-sub)]">
+                    <span class="font-mono text-[11px] tracking-widest text-sub">
                       法令・公的情報(EduLaw JP)
                     </span>
                     {s.laws.map((l) => (
-                      <a href={l.href} class="link-underline text-[var(--color-ink)]">
+                      <a href={l.href} class="link-underline text-ink">
                         {l.name} →
                       </a>
                     ))}
@@ -177,16 +177,16 @@ const scenes = [
         </div>
       ))
     }
-    <div class="border-t border-[var(--color-line)]"></div>
+    <div class="border-t border-line"></div>
   </section>
 
   <section class="pb-24">
-    <div class="text-sm text-[var(--color-sub)] leading-loose max-w-2xl">
+    <div class="text-sm text-sub leading-loose max-w-2xl">
       <p>
         法令・公的情報の全体は姉妹サイト
-        <a href="https://law.edu-evidence.org" class="link-underline text-[var(--color-accent)]">EduLaw JP</a>
+        <a href="https://law.edu-evidence.org" class="link-underline text-accent">EduLaw JP</a>
         に、日々の教育ニュースは
-        <a href="https://news.edu-evidence.org" class="link-underline text-[var(--color-accent)]">EduWatch JP</a>
+        <a href="https://news.edu-evidence.org" class="link-underline text-accent">EduWatch JP</a>
         にまとめています。
       </p>
     </div>

--- a/src/pages/strategies/[...slug].astro
+++ b/src/pages/strategies/[...slug].astro
@@ -92,10 +92,10 @@ if (badges.length === 0) badges.push("eef");
 const effectSign = d.monthsGained > 0 ? "+" : d.monthsGained === 0 ? "±" : "";
 const effectColor =
   d.monthsGained > 0
-    ? "text-[var(--color-accent)]"
+    ? "text-accent"
     : d.monthsGained === 0
-      ? "text-[var(--color-sub)]"
-      : "text-[var(--color-chart-red)]";
+      ? "text-sub"
+      : "text-chart-red";
 const effectNote =
   d.monthsGained > 0
     ? `3月時点で、通常より約${d.monthsGained}ヶ月先の学力水準に到達`
@@ -116,18 +116,18 @@ const effectNote =
   <div class="pt-10 pb-6">
     <a
       href="/"
-      class="font-mono text-xs uppercase tracking-widest text-[var(--color-sub)] hover:text-[var(--color-ink)]"
+      class="font-mono text-xs uppercase tracking-widest text-sub hover:text-ink"
     >
       ← 指導法一覧へ戻る
     </a>
   </div>
 
-  <header class="grid grid-cols-12 gap-6 pb-12 border-b border-[var(--color-line)]">
+  <header class="grid grid-cols-12 gap-6 pb-12 border-b border-line">
     <div class="col-span-12 md:col-span-8 space-y-6">
       <div class="space-y-1">
         <div class="flex items-center gap-3">
           <p
-            class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)] leading-none"
+            class="font-mono text-xs uppercase tracking-widest text-accent leading-none"
           >
             Strategy{d.lastVerified ? ` — 最終更新 ${d.lastVerified}` : ""}
           </p>
@@ -139,7 +139,7 @@ const effectNote =
             </span>
           ))}
         </div>
-        <p class="text-xs text-[var(--color-sub)]">指導法</p>
+        <p class="text-xs text-sub">指導法</p>
       </div>
       <h1
         class="font-black text-3xl sm:text-4xl md:text-5xl lg:text-6xl leading-[1.15] tracking-tight"
@@ -147,7 +147,7 @@ const effectNote =
         {d.title}
       </h1>
       <p
-        class="text-[var(--color-sub)] text-base md:text-lg leading-loose max-w-2xl"
+        class="text-sub text-base md:text-lg leading-loose max-w-2xl"
       >
         {d.summary}
       </p>
@@ -157,7 +157,7 @@ const effectNote =
             {d.tags.map((tag) => (
               <a
                 href={`/tags/${encodeURIComponent(tag)}`}
-                class="font-mono text-[11px] uppercase tracking-widest text-[var(--color-sub)] border border-[var(--color-line)] rounded-full px-3 py-1 hover:border-[var(--color-accent)] hover:text-[var(--color-accent)] transition"
+                class="font-mono text-[11px] uppercase tracking-widest text-sub border border-line rounded-full px-3 py-1 hover:border-accent hover:text-accent transition"
               >
                 {tag}
               </a>
@@ -171,7 +171,7 @@ const effectNote =
       class="col-span-12 md:col-span-4 md:pt-2 grid grid-cols-2 md:grid-cols-1 gap-y-6 gap-x-4 font-mono text-xs"
     >
       <div class="space-y-1">
-        <div class="uppercase tracking-widest text-[var(--color-sub)]">
+        <div class="uppercase tracking-widest text-sub">
           学習効果
         </div>
         <div
@@ -179,29 +179,29 @@ const effectNote =
         >
           {effectSign}{d.monthsGained}<span class="text-base ml-1">ヶ月</span>
         </div>
-        <div class="normal-case tracking-normal text-[var(--color-sub)] leading-snug">
+        <div class="normal-case tracking-normal text-sub leading-snug">
           {effectNote}
         </div>
       </div>
       <div class="space-y-1">
-        <div class="uppercase tracking-widest text-[var(--color-sub)]">
+        <div class="uppercase tracking-widest text-sub">
           エビデンス
         </div>
         <div class="text-amber-600 text-base">{stars}</div>
       </div>
       <div class="space-y-1">
-        <div class="uppercase tracking-widest text-[var(--color-sub)]">
+        <div class="uppercase tracking-widest text-sub">
           コスト
         </div>
-        <div class="text-[var(--color-accent)] text-base tracking-widest">
+        <div class="text-accent text-base tracking-widest">
           {yen}
         </div>
       </div>
       <div class="space-y-1">
-        <div class="uppercase tracking-widest text-[var(--color-sub)]">
+        <div class="uppercase tracking-widest text-sub">
           対象
         </div>
-        <div class="text-[var(--color-ink)] leading-relaxed">
+        <div class="text-ink leading-relaxed">
           {d.subjects.join(" · ")}<br />{d.grades.join(" · ")}
         </div>
       </div>
@@ -212,7 +212,7 @@ const effectNote =
     (d.evidence?.eef || d.evidence?.japan || d.evidence?.hattie || d.culturalContext || d.methodology) && (
       <section class="pt-12 max-w-2xl space-y-6">
         <div class="space-y-1">
-          <div class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]">
+          <div class="font-mono text-xs uppercase tracking-widest text-accent">
             Evidence Breakdown
           </div>
           <h2 class="text-2xl font-black tracking-tight">出典別のエビデンス</h2>
@@ -238,7 +238,7 @@ const effectNote =
                 )}
               </div>
               {d.evidence.eef.note && (
-                <p class="text-sm text-[var(--color-sub)] leading-relaxed" set:html={annotateGlossaryTerms(d.evidence.eef.note)} />
+                <p class="text-sm text-sub leading-relaxed" set:html={annotateGlossaryTerms(d.evidence.eef.note)} />
               )}
             </div>
           )}
@@ -261,17 +261,17 @@ const effectNote =
                   </span>
                 )}
                 {d.evidence.japan.researcher && (
-                  <span class="text-xs text-[var(--color-sub)]">{d.evidence.japan.researcher}</span>
+                  <span class="text-xs text-sub">{d.evidence.japan.researcher}</span>
                 )}
               </div>
               {d.evidence.japan.note && (
-                <p class="text-sm text-[var(--color-sub)] leading-relaxed" set:html={annotateGlossaryTerms(d.evidence.japan.note)} />
+                <p class="text-sm text-sub leading-relaxed" set:html={annotateGlossaryTerms(d.evidence.japan.note)} />
               )}
             </div>
           )}
 
           {d.evidence?.hattie && (
-            <div class="border border-[var(--color-line)] rounded-xl p-5 space-y-2 bg-amber-50/30 dark:bg-amber-300/5">
+            <div class="border border-line rounded-xl p-5 space-y-2 bg-amber-50/30 dark:bg-amber-300/5">
               <div class="flex items-baseline gap-3 flex-wrap">
                 <span class="font-mono text-xs uppercase tracking-widest text-amber-700 dark:text-amber-300">Hattie (Visible Learning)</span>
                 {d.evidence.hattie.cohensD !== undefined && (
@@ -280,49 +280,49 @@ const effectNote =
                   </span>
                 )}
               </div>
-              <p class="text-xs text-[var(--color-sub)] leading-relaxed">
-                Hattie の効果量は他のメタ分析と比べて楽観的な傾向があり、再現性に疑問が示されている場合があります。参考値としてお読みください。詳しくは <a href="/guide/cultural-context" class="link-underline text-[var(--color-accent)]">エビデンスの文脈</a> を参照。
+              <p class="text-xs text-sub leading-relaxed">
+                Hattie の効果量は他のメタ分析と比べて楽観的な傾向があり、再現性に疑問が示されている場合があります。参考値としてお読みください。詳しくは <a href="/guide/cultural-context" class="link-underline text-accent">エビデンスの文脈</a> を参照。
               </p>
               {d.evidence.hattie.note && (
-                <p class="text-sm text-[var(--color-sub)] leading-relaxed" set:html={annotateGlossaryTerms(d.evidence.hattie.note)} />
+                <p class="text-sm text-sub leading-relaxed" set:html={annotateGlossaryTerms(d.evidence.hattie.note)} />
               )}
             </div>
           )}
         </div>
 
         {d.methodology && (
-          <div class="border border-[var(--color-line)] rounded-xl p-5 space-y-3 bg-[var(--color-card)]">
+          <div class="border border-line rounded-xl p-5 space-y-3 bg-card">
             <div class="flex items-baseline gap-3">
-              <span class="font-mono text-xs uppercase tracking-widest text-[var(--color-sub)]">Technical Appendix</span>
-              <span class="text-xs text-[var(--color-sub)]">研究の詳細</span>
+              <span class="font-mono text-xs uppercase tracking-widest text-sub">Technical Appendix</span>
+              <span class="text-xs text-sub">研究の詳細</span>
             </div>
             <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 text-sm">
               {d.methodology.studies !== undefined && (
                 <div class="space-y-1">
-                  <div class="text-xs text-[var(--color-sub)]">研究数</div>
+                  <div class="text-xs text-sub">研究数</div>
                   <div class="font-black text-lg tabular-nums">{d.methodology.studies} 件</div>
                 </div>
               )}
               {d.methodology.sampleSize && (
                 <div class="space-y-1">
-                  <div class="text-xs text-[var(--color-sub)]">総サンプルサイズ</div>
+                  <div class="text-xs text-sub">総サンプルサイズ</div>
                   <div class="font-black text-lg tabular-nums">{d.methodology.sampleSize}</div>
                 </div>
               )}
               {d.methodology.effectSize && (
                 <div class="space-y-1 sm:col-span-2">
-                  <div class="text-xs text-[var(--color-sub)]">効果量</div>
+                  <div class="text-xs text-sub">効果量</div>
                   <div class="font-mono text-sm">{d.methodology.effectSize}</div>
                 </div>
               )}
             </div>
             {d.methodology.primaryMetaAnalysis && (
-              <div class="space-y-1 border-t border-[var(--color-line)] pt-3">
-                <div class="text-xs text-[var(--color-sub)]">主要エビデンスレビュー</div>
+              <div class="space-y-1 border-t border-line pt-3">
+                <div class="text-xs text-sub">主要エビデンスレビュー</div>
                 <div class="text-sm">
                   {d.methodology.primaryMetaAnalysis.authors} ({d.methodology.primaryMetaAnalysis.year}).{" "}
                   {d.methodology.primaryMetaAnalysis.url ? (
-                    <a href={d.methodology.primaryMetaAnalysis.url} target="_blank" rel="noopener" class="link-underline text-[var(--color-accent)]">
+                    <a href={d.methodology.primaryMetaAnalysis.url} target="_blank" rel="noopener" class="link-underline text-accent">
                       {d.methodology.primaryMetaAnalysis.title}
                     </a>
                   ) : (
@@ -332,22 +332,22 @@ const effectNote =
               </div>
             )}
             {d.methodology.limitations && (
-              <div class="space-y-1 border-t border-[var(--color-line)] pt-3">
-                <div class="text-xs text-[var(--color-sub)]">エビデンスの限界</div>
-                <p class="text-sm text-[var(--color-sub)] leading-relaxed" set:html={annotateGlossaryTerms(d.methodology.limitations)} />
+              <div class="space-y-1 border-t border-line pt-3">
+                <div class="text-xs text-sub">エビデンスの限界</div>
+                <p class="text-sm text-sub leading-relaxed" set:html={annotateGlossaryTerms(d.methodology.limitations)} />
               </div>
             )}
           </div>
         )}
 
         {d.culturalContext && (
-          <div class="border-l-4 border-[var(--color-accent)] pl-5 py-1 space-y-2">
-            <div class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]">
+          <div class="border-l-4 border-accent pl-5 py-1 space-y-2">
+            <div class="font-mono text-xs uppercase tracking-widest text-accent">
               日本の文脈で考慮したいこと
             </div>
             <p class="text-sm leading-loose" set:html={annotateGlossaryTerms(d.culturalContext)} />
-            <p class="text-xs text-[var(--color-sub)]">
-              なぜこの注記があるか:<a href="/guide/cultural-context" class="link-underline text-[var(--color-accent)] ml-1">エビデンスと文化的文脈</a>
+            <p class="text-xs text-sub">
+              なぜこの注記があるか:<a href="/guide/cultural-context" class="link-underline text-accent ml-1">エビデンスと文化的文脈</a>
             </p>
           </div>
         )}
@@ -369,13 +369,13 @@ const effectNote =
 
   {
     (d.sourceUrl || d.sourceTitle) && (
-      <section class="pt-8 border-t border-[var(--color-line)] max-w-2xl space-y-2">
-        <div class="text-xs text-[var(--color-sub)]">
+      <section class="pt-8 border-t border-line max-w-2xl space-y-2">
+        <div class="text-xs text-sub">
           参考にしている情報源
         </div>
         {d.sourceUrl ? (
           <a
-            class="link-underline text-[var(--color-ink)] hover:text-[var(--color-accent)]"
+            class="link-underline text-ink hover:text-accent"
             href={d.sourceUrl}
             target="_blank"
             rel="noopener"
@@ -383,7 +383,7 @@ const effectNote =
             {d.sourceTitle ?? d.sourceUrl}
           </a>
         ) : (
-          <p class="text-[var(--color-ink)]">{d.sourceTitle}</p>
+          <p class="text-ink">{d.sourceTitle}</p>
         )}
       </section>
     )
@@ -391,13 +391,13 @@ const effectNote =
 
   {
     relatedStrategyEntries.length > 0 && (
-      <section class="pt-10 mt-10 border-t border-[var(--color-line)] max-w-2xl space-y-6">
+      <section class="pt-10 mt-10 border-t border-line max-w-2xl space-y-6">
         <div class="space-y-1">
-          <div class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]">
+          <div class="font-mono text-xs uppercase tracking-widest text-accent">
             Related Strategies
           </div>
           <h2 class="text-2xl font-black tracking-tight">関連する指導法</h2>
-          <p class="text-sm text-[var(--color-sub)]">
+          <p class="text-sm text-sub">
             この指導法とあわせて検討したい、関連する指導法です。
           </p>
         </div>
@@ -421,13 +421,13 @@ const effectNote =
 
   {
     referringColumns.length > 0 && (
-      <section class="pt-10 mt-10 border-t border-[var(--color-line)] max-w-2xl space-y-6">
+      <section class="pt-10 mt-10 border-t border-line max-w-2xl space-y-6">
         <div class="space-y-1">
-          <div class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]">
+          <div class="font-mono text-xs uppercase tracking-widest text-accent">
             Mentioned in Columns
           </div>
           <h2 class="text-2xl font-black tracking-tight">この指導法を扱っているコラム</h2>
-          <p class="text-sm text-[var(--color-sub)]">
+          <p class="text-sm text-sub">
             本指導法を論点として取り上げたコラム。現場の文脈や政策との関係を読むことができます。
           </p>
         </div>
@@ -436,21 +436,21 @@ const effectNote =
             <li>
               <a
                 href={`/columns/${c.id}`}
-                class="group block border border-[var(--color-line)] rounded-xl p-4 transition hover:border-[var(--color-accent)] hover:bg-[var(--color-card)]"
+                class="group block border border-line rounded-xl p-4 transition hover:border-accent hover:bg-card"
               >
                 <div class="flex items-start justify-between gap-4">
                   <div class="flex-1 min-w-0 space-y-1">
-                    <h3 class="text-base md:text-lg font-black tracking-tight leading-snug group-hover:text-[var(--color-accent)] transition">
+                    <h3 class="text-base md:text-lg font-black tracking-tight leading-snug group-hover:text-accent transition">
                       {c.data.title}
                     </h3>
-                    <p class="text-sm text-[var(--color-sub)] leading-relaxed line-clamp-2">
+                    <p class="text-sm text-sub leading-relaxed line-clamp-2">
                       {c.data.summary}
                     </p>
-                    <div class="font-mono text-[10px] uppercase tracking-widest text-[var(--color-sub)]">
+                    <div class="font-mono text-[10px] uppercase tracking-widest text-sub">
                       {c.data.date}
                     </div>
                   </div>
-                  <span class="shrink-0 text-[var(--color-sub)] transition group-hover:translate-x-1">→</span>
+                  <span class="shrink-0 text-sub transition group-hover:translate-x-1">→</span>
                 </div>
               </a>
             </li>

--- a/src/pages/subjects/[subject].astro
+++ b/src/pages/subjects/[subject].astro
@@ -24,21 +24,21 @@ const strategies = allStrategies
 
 <Layout title={`${subject} — EduEvidence JP`}>
   <section class="pt-10 sm:pt-14 md:pt-20 lg:pt-28 pb-10 sm:pb-14 md:pb-20">
-    <p class="font-mono text-xs uppercase tracking-widest text-[var(--color-sub)]">
-      <a href="/subjects" class="hover:text-[var(--color-ink)]">Subjects</a> /
+    <p class="font-mono text-xs uppercase tracking-widest text-sub">
+      <a href="/subjects" class="hover:text-ink">Subjects</a> /
     </p>
-    <p class="mt-1 text-xs text-[var(--color-sub)]">教科で絞り込み</p>
+    <p class="mt-1 text-xs text-sub">教科で絞り込み</p>
     <h1 class="mt-5 font-black text-4xl sm:text-5xl md:text-6xl lg:text-7xl leading-[1.15] tracking-tight">
-      <span class="text-[var(--color-accent)]">{subject}</span>
+      <span class="text-accent">{subject}</span>
     </h1>
-    <div class="mt-6 max-w-2xl text-[var(--color-sub)] leading-loose text-sm sm:text-base space-y-1">
+    <div class="mt-6 max-w-2xl text-sub leading-loose text-sm sm:text-base space-y-1">
       <p>「{subject}」に関連する指導法</p>
       <p class="text-xs">{strategies.length}件</p>
     </div>
   </section>
 
   <section class="pb-24 space-y-8">
-    <div class="border-b border-[var(--color-line)]">
+    <div class="border-b border-line">
       {strategies.map((s, i) => (
         <StrategyRow
           index={i + 1}
@@ -53,7 +53,7 @@ const strategies = allStrategies
       ))}
     </div>
     <div>
-      <a href="/subjects" class="link-underline font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]">← 教科一覧へ戻る</a>
+      <a href="/subjects" class="link-underline font-mono text-xs uppercase tracking-widest text-accent">← 教科一覧へ戻る</a>
     </div>
   </section>
 </Layout>

--- a/src/pages/subjects/index.astro
+++ b/src/pages/subjects/index.astro
@@ -16,13 +16,13 @@ const subjects = [...subjectMap.entries()].sort((a, b) => b[1] - a[1]);
 
 <Layout title="教科から探す — EduEvidence JP">
   <section class="pt-10 sm:pt-14 md:pt-20 lg:pt-28 pb-10 sm:pb-14 md:pb-20">
-    <p class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]">
+    <p class="font-mono text-xs uppercase tracking-widest text-accent">
       Browse by subject
     </p>
     <h1 class="mt-5 font-black text-4xl sm:text-5xl md:text-6xl lg:text-7xl leading-[1.15] tracking-tight">
       教科から探す
     </h1>
-    <div class="mt-6 max-w-2xl text-[var(--color-sub)] leading-loose text-sm sm:text-base">
+    <div class="mt-6 max-w-2xl text-sub leading-loose text-sm sm:text-base">
       <p>担当する教科に関連する指導法を見つけられます。</p>
     </div>
   </section>
@@ -33,12 +33,12 @@ const subjects = [...subjectMap.entries()].sort((a, b) => b[1] - a[1]);
         subjects.map(([subj, count]) => (
           <a
             href={`/subjects/${encodeURIComponent(subj)}`}
-            class="group block border border-[var(--color-line)] rounded-xl p-6 hover:border-[var(--color-accent)] hover:bg-[var(--color-card)] transition space-y-2"
+            class="group block border border-line rounded-xl p-6 hover:border-accent hover:bg-card transition space-y-2"
           >
-            <div class="text-2xl font-black group-hover:text-[var(--color-accent)] transition">
+            <div class="text-2xl font-black group-hover:text-accent transition">
               {subj}
             </div>
-            <div class="text-xs text-[var(--color-sub)]">
+            <div class="text-xs text-sub">
               {count}件の指導法 →
             </div>
           </a>

--- a/src/pages/support.astro
+++ b/src/pages/support.astro
@@ -4,15 +4,15 @@ import Layout from "../layouts/Layout.astro";
 
 <Layout title="運営を支援する — EduEvidence JP">
   <section class="pt-10 sm:pt-14 md:pt-20 lg:pt-28 pb-10 sm:pb-14 md:pb-20">
-    <p class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]">
+    <p class="font-mono text-xs uppercase tracking-widest text-accent">
       Support
     </p>
     <h1
       class="mt-5 font-black text-4xl sm:text-5xl md:text-6xl lg:text-7xl leading-[1.15] tracking-tight"
     >
-      運営を<br /><span class="text-[var(--color-accent)]">支援</span>する
+      運営を<br /><span class="text-accent">支援</span>する
     </h1>
-    <div class="mt-6 max-w-2xl text-[var(--color-sub)] leading-loose text-sm sm:text-base">
+    <div class="mt-6 max-w-2xl text-sub leading-loose text-sm sm:text-base">
       <p>
         EduEvidence JP は非営利で運営しています。広告を入れず、教員にとって信頼できる情報源であり続けるために。
       </p>
@@ -22,26 +22,26 @@ import Layout from "../layouts/Layout.astro";
   <section class="pb-24 space-y-16">
 
     <!-- 運営費の透明化 -->
-    <div class="border border-[var(--color-line)] rounded-xl p-6 md:p-8 space-y-4">
-      <h2 class="text-sm font-bold tracking-tight text-[var(--color-ink)]">
+    <div class="border border-line rounded-xl p-6 md:p-8 space-y-4">
+      <h2 class="text-sm font-bold tracking-tight text-ink">
         毎月の運営費
       </h2>
       <div class="grid md:grid-cols-2 gap-6">
         <div class="space-y-1">
-          <div class="text-sm text-[var(--color-sub)]">サーバー・ホスティング</div>
-          <div class="font-black text-xl">¥0〜3,000<span class="text-sm font-normal text-[var(--color-sub)]"> /月</span></div>
+          <div class="text-sm text-sub">サーバー・ホスティング</div>
+          <div class="font-black text-xl">¥0〜3,000<span class="text-sm font-normal text-sub"> /月</span></div>
         </div>
         <div class="space-y-1">
-          <div class="text-sm text-[var(--color-sub)]">ドメイン</div>
-          <div class="font-black text-xl">¥100〜200<span class="text-sm font-normal text-[var(--color-sub)]"> /月</span></div>
+          <div class="text-sm text-sub">ドメイン</div>
+          <div class="font-black text-xl">¥100〜200<span class="text-sm font-normal text-sub"> /月</span></div>
         </div>
         <div class="space-y-1">
-          <div class="text-sm text-[var(--color-sub)]">合計(現在)</div>
-          <div class="font-black text-2xl text-[var(--color-accent)]">約 ¥3,000<span class="text-sm font-normal text-[var(--color-sub)]"> /月</span></div>
+          <div class="text-sm text-sub">合計(現在)</div>
+          <div class="font-black text-2xl text-accent">約 ¥3,000<span class="text-sm font-normal text-sub"> /月</span></div>
         </div>
         <div class="space-y-1">
-          <div class="text-sm text-[var(--color-sub)]">目標(監修体制構築後)</div>
-          <div class="font-black text-2xl">約 ¥50,000<span class="text-sm font-normal text-[var(--color-sub)]"> /月</span></div>
+          <div class="text-sm text-sub">目標(監修体制構築後)</div>
+          <div class="font-black text-2xl">約 ¥50,000<span class="text-sm font-normal text-sub"> /月</span></div>
         </div>
       </div>
     </div>
@@ -50,48 +50,48 @@ import Layout from "../layouts/Layout.astro";
     <div class="space-y-6">
       <h2 class="text-2xl font-black tracking-tight">支援の方法</h2>
       <div class="space-y-6">
-        <div class="border-t border-[var(--color-line)] pt-6 space-y-2">
+        <div class="border-t border-line pt-6 space-y-2">
           <div class="flex items-baseline gap-4">
-            <span class="font-mono text-xs text-[var(--color-sub)]">01</span>
+            <span class="font-mono text-xs text-sub">01</span>
             <h3 class="font-bold text-lg">寄付で支える</h3>
           </div>
-          <p class="text-sm text-[var(--color-sub)] leading-loose ml-8">
+          <p class="text-sm text-sub leading-loose ml-8">
             月額・単発の寄付を受け付けています。いただいた寄付はサーバー運営費・監修者への謝礼・コンテンツ拡充に充てます。
           </p>
-          <p class="font-mono text-xs text-[var(--color-sub)] ml-8">
+          <p class="font-mono text-xs text-sub ml-8">
             （寄付受付のセットアップは準備中です）
           </p>
         </div>
 
-        <div class="border-t border-[var(--color-line)] pt-6 space-y-2">
+        <div class="border-t border-line pt-6 space-y-2">
           <div class="flex items-baseline gap-4">
-            <span class="font-mono text-xs text-[var(--color-sub)]">02</span>
+            <span class="font-mono text-xs text-sub">02</span>
             <h3 class="font-bold text-lg">知識で支える</h3>
           </div>
-          <p class="text-sm text-[var(--color-sub)] leading-loose ml-8">
+          <p class="text-sm text-sub leading-loose ml-8">
             記事の内容に誤りを見つけた場合、日本の教育研究で本サイトに掲載すべきものをご存知の場合、
             または実践事例を共有いただける場合は、ぜひお知らせください。<br />
-            <a href="mailto:info@edu-evidence.org" class="link-underline text-[var(--color-ink)]">info@edu-evidence.org</a>
+            <a href="mailto:info@edu-evidence.org" class="link-underline text-ink">info@edu-evidence.org</a>
           </p>
         </div>
 
-        <div class="border-t border-[var(--color-line)] pt-6 space-y-2">
+        <div class="border-t border-line pt-6 space-y-2">
           <div class="flex items-baseline gap-4">
-            <span class="font-mono text-xs text-[var(--color-sub)]">03</span>
+            <span class="font-mono text-xs text-sub">03</span>
             <h3 class="font-bold text-lg">広めて支える</h3>
           </div>
-          <p class="text-sm text-[var(--color-sub)] leading-loose ml-8">
+          <p class="text-sm text-sub leading-loose ml-8">
             同僚の先生にこのサイトを紹介していただくだけでも大きな支援です。
             校内研修や勉強会の資料としてご活用ください(CC BY-SA 4.0ライセンスです)。
           </p>
         </div>
 
-        <div class="border-t border-[var(--color-line)] pt-6 space-y-2">
+        <div class="border-t border-line pt-6 space-y-2">
           <div class="flex items-baseline gap-4">
-            <span class="font-mono text-xs text-[var(--color-sub)]">04</span>
+            <span class="font-mono text-xs text-sub">04</span>
             <h3 class="font-bold text-lg">監修に参加する</h3>
           </div>
-          <p class="text-sm text-[var(--color-sub)] leading-loose ml-8">
+          <p class="text-sm text-sub leading-loose ml-8">
             教育研究者・教育心理学の専門家の方で、本サイトの監修にご協力いただける方を探しています。
           </p>
         </div>
@@ -101,22 +101,22 @@ import Layout from "../layouts/Layout.astro";
     <!-- 使途報告 -->
     <div class="space-y-4">
       <h2 class="text-2xl font-black tracking-tight">使途の透明化</h2>
-      <p class="text-sm text-[var(--color-sub)] leading-loose">
+      <p class="text-sm text-sub leading-loose">
         いただいた寄付の使途は、本ページで定期的に公開します。
         教員の皆さんから預かったお金が、どのように使われているかを常に見えるようにします。
       </p>
     </div>
 
     <!-- ニュースレター -->
-    <div id="newsletter" class="border border-[var(--color-line)] rounded-xl p-6 md:p-8 space-y-6">
+    <div id="newsletter" class="border border-line rounded-xl p-6 md:p-8 space-y-6">
       <div class="space-y-3">
         <h2 class="text-2xl font-black tracking-tight">ニュースレター</h2>
-        <p class="text-sm text-[var(--color-sub)] leading-loose">
+        <p class="text-sm text-sub leading-loose">
           新しい指導法ページの公開、既存記事の改訂、教育研究の注目ニュースをお届けします。<br />
           月1〜2回、短く、現場に役立つ情報だけ。
         </p>
       </div>
-      <p class="font-mono text-xs text-[var(--color-sub)]">
+      <p class="font-mono text-xs text-sub">
         （メール配信のセットアップは準備中です）
       </p>
     </div>

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -36,16 +36,16 @@ const totalCount = strategies.length + columns.length;
 
 <Layout title={`${tag} — EduEvidence JP`}>
   <section class="pt-10 sm:pt-14 md:pt-20 lg:pt-28 pb-10 sm:pb-14 md:pb-20">
-    <p class="font-mono text-xs uppercase tracking-widest text-[var(--color-sub)]">
-      <a href="/tags" class="hover:text-[var(--color-ink)]">Tags</a> /
+    <p class="font-mono text-xs uppercase tracking-widest text-sub">
+      <a href="/tags" class="hover:text-ink">Tags</a> /
     </p>
-    <p class="mt-1 text-xs text-[var(--color-sub)]">タグから絞り込み</p>
+    <p class="mt-1 text-xs text-sub">タグから絞り込み</p>
     <h1
       class="mt-5 font-black text-4xl sm:text-5xl md:text-6xl lg:text-7xl leading-[1.15] tracking-tight"
     >
-      <span class="text-[var(--color-accent)]">{tag}</span>
+      <span class="text-accent">{tag}</span>
     </h1>
-    <div class="mt-6 max-w-2xl text-[var(--color-sub)] leading-loose text-sm sm:text-base space-y-1">
+    <div class="mt-6 max-w-2xl text-sub leading-loose text-sm sm:text-base space-y-1">
       <p>「{tag}」に関連するコンテンツ</p>
       <p class="text-xs">指導法 {strategies.length}件 / コラム {columns.length}件</p>
     </div>
@@ -55,12 +55,12 @@ const totalCount = strategies.length + columns.length;
     strategies.length > 0 && (
       <section class="pb-16 space-y-6">
         <div class="space-y-1">
-          <div class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]">
+          <div class="font-mono text-xs uppercase tracking-widest text-accent">
             Strategies
           </div>
           <h2 class="text-2xl font-black tracking-tight">関連する指導法</h2>
         </div>
-        <div class="border-b border-[var(--color-line)]">
+        <div class="border-b border-line">
           {strategies.map((s, i) => (
             <StrategyRow
               index={i + 1}
@@ -82,7 +82,7 @@ const totalCount = strategies.length + columns.length;
     columns.length > 0 && (
       <section class="pb-16 space-y-6">
         <div class="space-y-1">
-          <div class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]">
+          <div class="font-mono text-xs uppercase tracking-widest text-accent">
             Columns
           </div>
           <h2 class="text-2xl font-black tracking-tight">関連するコラム</h2>
@@ -92,21 +92,21 @@ const totalCount = strategies.length + columns.length;
             <li>
               <a
                 href={`/columns/${c.id}`}
-                class="group block border border-[var(--color-line)] rounded-xl p-5 transition hover:border-[var(--color-accent)] hover:bg-[var(--color-card)]"
+                class="group block border border-line rounded-xl p-5 transition hover:border-accent hover:bg-card"
               >
                 <div class="flex items-start justify-between gap-4">
                   <div class="flex-1 min-w-0 space-y-2">
-                    <h3 class="text-lg md:text-xl font-black tracking-tight leading-snug group-hover:text-[var(--color-accent)] transition">
+                    <h3 class="text-lg md:text-xl font-black tracking-tight leading-snug group-hover:text-accent transition">
                       {c.data.title}
                     </h3>
-                    <p class="text-sm text-[var(--color-sub)] leading-relaxed line-clamp-2">
+                    <p class="text-sm text-sub leading-relaxed line-clamp-2">
                       {c.data.summary}
                     </p>
-                    <div class="font-mono text-[10px] uppercase tracking-widest text-[var(--color-sub)]">
+                    <div class="font-mono text-[10px] uppercase tracking-widest text-sub">
                       {c.data.date}
                     </div>
                   </div>
-                  <span class="shrink-0 text-[var(--color-sub)] transition group-hover:translate-x-1">→</span>
+                  <span class="shrink-0 text-sub transition group-hover:translate-x-1">→</span>
                 </div>
               </a>
             </li>
@@ -119,7 +119,7 @@ const totalCount = strategies.length + columns.length;
   {
     totalCount === 0 && (
       <section class="pb-24 max-w-2xl">
-        <p class="text-[var(--color-sub)] leading-relaxed">
+        <p class="text-sub leading-relaxed">
           このタグに対応するコンテンツはまだありません。
         </p>
       </section>
@@ -129,7 +129,7 @@ const totalCount = strategies.length + columns.length;
   <section class="pb-24">
     <a
       href="/tags"
-      class="link-underline font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]"
+      class="link-underline font-mono text-xs uppercase tracking-widest text-accent"
     >
       ← タグ一覧へ戻る
     </a>

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -22,7 +22,7 @@ const tags = [...tagMap.entries()].sort((a, b) => b[1] - a[1]);
 
 <Layout title="タグ一覧 — EduEvidence JP">
   <section class="pt-10 sm:pt-14 md:pt-20 lg:pt-28 pb-10 sm:pb-14 md:pb-20">
-    <p class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]">
+    <p class="font-mono text-xs uppercase tracking-widest text-accent">
       Tags
     </p>
     <h1
@@ -30,7 +30,7 @@ const tags = [...tagMap.entries()].sort((a, b) => b[1] - a[1]);
     >
       タグ一覧
     </h1>
-    <div class="mt-6 max-w-2xl text-[var(--color-sub)] leading-loose text-sm sm:text-base space-y-2">
+    <div class="mt-6 max-w-2xl text-sub leading-loose text-sm sm:text-base space-y-2">
       <p>
         指導法とコラムを関心のあるテーマから探すことができます。
       </p>
@@ -44,12 +44,12 @@ const tags = [...tagMap.entries()].sort((a, b) => b[1] - a[1]);
         tags.map(([tag, count]) => (
           <a
             href={`/tags/${encodeURIComponent(tag)}`}
-            class="group border border-[var(--color-line)] rounded-full px-4 py-2 hover:border-[var(--color-accent)] hover:bg-[var(--color-card)] transition"
+            class="group border border-line rounded-full px-4 py-2 hover:border-accent hover:bg-card transition"
           >
-            <span class="font-bold text-sm group-hover:text-[var(--color-accent)] transition">
+            <span class="font-bold text-sm group-hover:text-accent transition">
               {tag}
             </span>
-            <span class="font-mono text-xs text-[var(--color-sub)] ml-2">{count}</span>
+            <span class="font-mono text-xs text-sub ml-2">{count}</span>
           </a>
         ))
       }

--- a/src/pages/voices.astro
+++ b/src/pages/voices.astro
@@ -4,7 +4,7 @@ import Layout from "../layouts/Layout.astro";
 
 <Layout title="現場の声 — EduEvidence JP">
   <section class="pt-10 sm:pt-14 md:pt-20 lg:pt-28 pb-10 sm:pb-14 md:pb-20">
-    <p class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]">
+    <p class="font-mono text-xs uppercase tracking-widest text-accent">
       Voices from the field
     </p>
     <h1
@@ -12,7 +12,7 @@ import Layout from "../layouts/Layout.astro";
     >
       現場の声
     </h1>
-    <div class="mt-6 max-w-2xl text-[var(--color-sub)] leading-loose text-sm sm:text-base">
+    <div class="mt-6 max-w-2xl text-sub leading-loose text-sm sm:text-base">
       <p>
         本サイトの情報を実際の教室で活用された先生方の声を掲載します。
       </p>
@@ -21,7 +21,7 @@ import Layout from "../layouts/Layout.astro";
 
   <section class="pb-16 space-y-12">
     <div
-      class="border border-[var(--color-accent)] rounded-xl p-6 md:p-8 bg-[var(--color-accent)]/[0.03]"
+      class="border border-accent rounded-xl p-6 md:p-8 bg-accent/[0.03]"
     >
       <p class="text-sm leading-loose">
         <strong>このコーナーについて</strong> ——
@@ -31,40 +31,40 @@ import Layout from "../layouts/Layout.astro";
       </p>
     </div>
 
-    <div class="border border-[var(--color-line)] rounded-xl p-8 md:p-12 space-y-8">
+    <div class="border border-line rounded-xl p-8 md:p-12 space-y-8">
       <div class="text-center space-y-3">
-        <p class="font-mono text-xs uppercase tracking-widest text-[var(--color-accent)]">
+        <p class="font-mono text-xs uppercase tracking-widest text-accent">
           Open call
         </p>
         <h2 class="font-black text-2xl md:text-3xl tracking-tight">
           現場からの声を募集しています
         </h2>
-        <p class="text-sm text-[var(--color-sub)]">
+        <p class="text-sm text-sub">
           匿名での掲載も可能です。どんな形でも歓迎します。
         </p>
       </div>
 
       <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
-        <div class="border border-[var(--color-line)] rounded-lg p-5 space-y-2">
-          <p class="font-mono text-[10px] uppercase tracking-widest text-[var(--color-accent)]">01 Practice</p>
+        <div class="border border-line rounded-lg p-5 space-y-2">
+          <p class="font-mono text-[10px] uppercase tracking-widest text-accent">01 Practice</p>
           <h3 class="font-bold">実践の報告</h3>
-          <p class="text-xs text-[var(--color-sub)] leading-relaxed">
+          <p class="text-xs text-sub leading-relaxed">
             本サイトの指導法を試したときの手応え・工夫・子どもの反応。
             「うまくいった」だけでなく「うまくいかなかった」も貴重です。
           </p>
         </div>
-        <div class="border border-[var(--color-line)] rounded-lg p-5 space-y-2">
-          <p class="font-mono text-[10px] uppercase tracking-widest text-[var(--color-accent)]">02 Question</p>
+        <div class="border border-line rounded-lg p-5 space-y-2">
+          <p class="font-mono text-[10px] uppercase tracking-widest text-accent">02 Question</p>
           <h3 class="font-bold">現場の疑問</h3>
-          <p class="text-xs text-[var(--color-sub)] leading-relaxed">
+          <p class="text-xs text-sub leading-relaxed">
             「このテーマのエビデンスを知りたい」「この指導法は日本でも効くのか」など。
             コラムや戦略ページの追加の手がかりになります。
           </p>
         </div>
-        <div class="border border-[var(--color-line)] rounded-lg p-5 space-y-2">
-          <p class="font-mono text-[10px] uppercase tracking-widest text-[var(--color-accent)]">03 Info</p>
+        <div class="border border-line rounded-lg p-5 space-y-2">
+          <p class="font-mono text-[10px] uppercase tracking-widest text-accent">03 Info</p>
           <h3 class="font-bold">地域の施策・情報</h3>
-          <p class="text-xs text-[var(--color-sub)] leading-relaxed">
+          <p class="text-xs text-sub leading-relaxed">
             自治体・学校で進行中の施策、気になる研究や報告書の情報。
             全国的に見える化する材料になります。
           </p>
@@ -73,9 +73,9 @@ import Layout from "../layouts/Layout.astro";
 
       <div class="text-center space-y-2">
         <p class="text-sm">
-          <a href="mailto:info@edu-evidence.org" class="link-underline text-[var(--color-accent)]">info@edu-evidence.org</a> までお寄せください。
+          <a href="mailto:info@edu-evidence.org" class="link-underline text-accent">info@edu-evidence.org</a> までお寄せください。
         </p>
-        <p class="text-xs text-[var(--color-sub)]">
+        <p class="text-xs text-sub">
           氏名・所属・学年・教科は任意。匿名希望の場合はその旨を明記してください。
         </p>
       </div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -35,15 +35,15 @@
   --color-cost: oklch(50.8% 0.118 165.612);
   --color-rating: oklch(66.6% 0.179 58.318);
 
+  /* 派生値も @theme に置ける。ADR 0031 は「var() を含むため置けない」と    */
+  /* 書いたが誤りだった。実測では bg-accent-hover / border-accent-hover が  */
+  /* 生成され、[data-theme="dark"] の white 版への切替も効く。              */
+  --color-accent-hover: color-mix(in oklab, var(--color-accent) 85%, black);
+
   --leading-hero: 1.15;
 }
 
 @variant dark (&:where([data-theme="dark"], [data-theme="dark"] *));
-
-:root {
-  /* 派生値。var() を含むため @theme には置けない。 */
-  --color-accent-hover: color-mix(in oklab, var(--color-accent) 85%, black);
-}
 
 [data-theme="dark"] {
   --color-bg: #16181d;


### PR DESCRIPTION
デザインシステム構築の 2 本目。#411 で生やしたユーティリティに call site を移します。

## 置換

| | |
|---|---|
| 置換 | **760 箇所 / 30 ファイル** |
| 残存する色の任意値 | **0** |
| 差分 | +633 / −633 行 |

`text-[var(--color-sub)]` → `text-sub`、`border-[var(--color-line)]` → `border-line` のような機械的な置換です。行数が完全に一致しているのは、任意値がクラス名に置き換わっただけだからです。

置換件数の多いファイル: `index.astro` 135 / `guide/evidence.astro` 80 / `strategies/[...slug].astro` 63 / `guide/indicators.astro` 51 / `about.astro` 50。

## ADR 0031 の訂正を含みます

`--color-accent-hover` を `@theme` に移しました。

**ADR 0031 は「派生値は `var()` を含むため `@theme` に置けない」と書きましたが、これは誤りです。** 実測では `bg-accent-hover` / `border-accent-hover` が生成され、`[data-theme="dark"]` の `white` 版への切替も効きます。

```css
.bg-accent-hover{background-color:var(--color-accent-hover)}
.border-accent-hover{border-color:var(--color-accent-hover)}
```

この訂正がないと 2 箇所だけ任意値が残り、後続で入れる検査スクリプトに例外を作る必要がありました。

## 等価性の検証

**クラス名そのものが変更対象なので、クラス集合の比較は使えません。** computed style で測りました。

- 8 経路 × light/dark = **16 組合せ**
- **13,302 要素**の `color` / `background-color` / 境界 4 種 / `text-decoration-color` / `fill` / `outline`
- → **完全一致（差分ゼロ）**

## 検証

- `npm run check` 0 errors
- Playwright E2E **50 件**通過
- computed style 13,302 要素の全数比較

## 残るもの

Tailwind パレット直書きが **186 箇所**。#411 が `--color-source-*` / `--color-cost` / `--color-rating` を定義済みなので、次の PR で `text-amber-800` → `text-source-hattie` のように移します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)