### PR TITLE
refactor(design-system): move palette literals onto the source tokens

### DIFF
--- a/src/components/RelatedStrategyCard.astro
+++ b/src/components/RelatedStrategyCard.astro
@@ -29,9 +29,9 @@ interface Props {
 const { href, title, summary, monthsGained, evidenceStrength, evidence } = Astro.props;
 
 const badgeConfig = {
-  eef: { label: "EEF", color: "text-sky-800 border-sky-800/40 bg-sky-50 dark:text-sky-200 dark:border-sky-200/40 dark:bg-sky-200/10" },
-  japan: { label: "日本", color: "text-rose-700 border-rose-700/40 bg-rose-50 dark:text-rose-200 dark:border-rose-200/40 dark:bg-rose-200/10" },
-  hattie: { label: "Hattie", color: "text-amber-800 border-amber-800/40 bg-amber-50 dark:text-amber-200 dark:border-amber-200/40 dark:bg-amber-200/10" },
+  eef: { label: "EEF", color: "text-source-eef border-source-eef/40 bg-source-eef-bg" },
+  japan: { label: "日本", color: "text-source-japan border-source-japan/40 bg-source-japan-bg" },
+  hattie: { label: "Hattie", color: "text-source-hattie border-source-hattie/40 bg-source-hattie-bg" },
 } as const;
 type BadgeKey = keyof typeof badgeConfig;
 const badges: BadgeKey[] = [];
@@ -76,7 +76,7 @@ const effectBarSign =
       <p class="text-sm text-sub leading-relaxed line-clamp-2">
         {summary}
       </p>
-      <div class="font-mono text-[10px] uppercase tracking-widest text-amber-600" aria-label={`エビデンスの強さ ${evidenceStrength} / 5`}>
+      <div class="font-mono text-[10px] uppercase tracking-widest text-rating" aria-label={`エビデンスの強さ ${evidenceStrength} / 5`}>
         {stars}
       </div>
     </div>

--- a/src/components/StrategyRow.astro
+++ b/src/components/StrategyRow.astro
@@ -27,9 +27,9 @@ const num = String(index).padStart(2, "0");
 const stars = "★".repeat(evidenceStrength) + "☆".repeat(5 - evidenceStrength);
 
 const badgeConfig = {
-  eef: { label: "EEF", color: "text-sky-800 border-sky-800/40 bg-sky-50 dark:text-sky-200 dark:border-sky-200/40 dark:bg-sky-200/10" },
-  japan: { label: "日本", color: "text-rose-700 border-rose-700/40 bg-rose-50 dark:text-rose-200 dark:border-rose-200/40 dark:bg-rose-200/10" },
-  hattie: { label: "Hattie", color: "text-amber-800 border-amber-800/40 bg-amber-50 dark:text-amber-200 dark:border-amber-200/40 dark:bg-amber-200/10" },
+  eef: { label: "EEF", color: "text-source-eef border-source-eef/40 bg-source-eef-bg" },
+  japan: { label: "日本", color: "text-source-japan border-source-japan/40 bg-source-japan-bg" },
+  hattie: { label: "Hattie", color: "text-source-hattie border-source-hattie/40 bg-source-hattie-bg" },
 } as const;
 
 type BadgeKey = keyof typeof badgeConfig;
@@ -88,7 +88,7 @@ const effectBarSign =
       >
         <span>{subjects.join(" · ")}</span>
         <span>{grades.join(" · ")}</span>
-        <span class="text-amber-600 tracking-normal" aria-label={`エビデンスの強さ ${evidenceStrength} / 5`}>
+        <span class="text-rating tracking-normal" aria-label={`エビデンスの強さ ${evidenceStrength} / 5`}>
           {stars}
         </span>
       </div>

--- a/src/pages/changelog.astro
+++ b/src/pages/changelog.astro
@@ -971,9 +971,9 @@ const entries: ChangelogEntry[] = [
 ];
 
 const typeLabel: Record<string, { label: string; color: string }> = {
-  add: { label: "追加", color: "text-emerald-700 dark:text-emerald-300" },
-  update: { label: "更新", color: "text-amber-800 dark:text-amber-200" },
-  fix: { label: "修正", color: "text-rose-700 dark:text-rose-200" },
+  add: { label: "追加", color: "text-cost" },
+  update: { label: "更新", color: "text-source-hattie" },
+  fix: { label: "修正", color: "text-source-japan" },
   remove: { label: "削除", color: "text-sub" },
 };
 ---

--- a/src/pages/cost/index.astro
+++ b/src/pages/cost/index.astro
@@ -63,7 +63,7 @@ const costGroups = [
           <div class="space-y-4">
             <div class="space-y-2">
               <div class="flex items-baseline gap-4 px-2">
-                <span class="text-xl font-black text-emerald-700 dark:text-emerald-300 tracking-widest">{group.yen}</span>
+                <span class="text-xl font-black text-cost tracking-widest">{group.yen}</span>
                 <h2 class="text-xl font-black tracking-tight">{group.label}</h2>
                 <span class="text-xs text-sub">{strategies.length}件</span>
               </div>

--- a/src/pages/guide/evidence.astro
+++ b/src/pages/guide/evidence.astro
@@ -194,7 +194,7 @@ import Layout from "../../layouts/Layout.astro";
 
         <div class="space-y-2 pt-2">
           <h3 class="font-bold">日本の教育現場でよくある例</h3>
-          <div class="border border-amber-600/30 rounded-xl p-5 bg-amber-50/30 dark:border-amber-400/30 dark:bg-amber-400/5 space-y-3">
+          <div class="border border-source-hattie/30 rounded-xl p-5 bg-source-hattie-bg space-y-3">
             <p class="text-sm leading-loose">
               校内研究や研究紀要で発表される「本校で◯◯を実践したら、子どもの◯◯が向上した」は、
               上のピラミッドでは<strong>最下層(Level 1)</strong>に位置します。

--- a/src/pages/guide/indicators.astro
+++ b/src/pages/guide/indicators.astro
@@ -87,7 +87,7 @@ import Layout from "../../layouts/Layout.astro";
         <div class="space-y-3">
           <h3 class="font-bold">目安としての読み方</h3>
           <div class="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm text-center">
-            <div class="border border-red-600/30 dark:border-red-400/30 rounded-lg p-4 space-y-1 bg-red-50/30 dark:bg-red-400/10">
+            <div class="border border-chart-red/30 rounded-lg p-4 space-y-1 bg-chart-red/10">
               <div class="text-2xl font-black text-chart-red">-1 以下</div>
               <div class="text-sub">やらない方が<br />よかった領域</div>
             </div>
@@ -125,7 +125,7 @@ import Layout from "../../layouts/Layout.astro";
         <span class="font-mono text-xs uppercase tracking-widest text-sub">02</span>
         <h2 class="text-3xl font-black tracking-tight">エビデンスの強さ（★）</h2>
       </div>
-      <div class="text-4xl text-amber-500">★★★★☆</div>
+      <div class="text-4xl text-rating">★★★★☆</div>
       <div class="leading-loose text-ink/90 space-y-6">
         <p>
           その効果が<strong>どれだけ信頼できる研究で確かめられているか</strong>を示します。
@@ -135,23 +135,23 @@ import Layout from "../../layouts/Layout.astro";
           <h3 class="font-bold">★の基準</h3>
           <div class="space-y-3">
             <div class="flex gap-4 items-start">
-              <span class="text-amber-500 shrink-0">★☆☆☆☆</span>
+              <span class="text-rating shrink-0">★☆☆☆☆</span>
               <span>研究は存在するが数が少なく、結論は初期段階のもの</span>
             </div>
             <div class="flex gap-4 items-start">
-              <span class="text-amber-500 shrink-0">★★☆☆☆</span>
+              <span class="text-rating shrink-0">★★☆☆☆</span>
               <span>いくつかの研究はあるが、結果にばらつきがある</span>
             </div>
             <div class="flex gap-4 items-start">
-              <span class="text-amber-500 shrink-0">★★★☆☆</span>
+              <span class="text-rating shrink-0">★★★☆☆</span>
               <span>一定数の質の良い研究があり、概ね一致した結果が出ている</span>
             </div>
             <div class="flex gap-4 items-start">
-              <span class="text-amber-500 shrink-0">★★★★☆</span>
+              <span class="text-rating shrink-0">★★★★☆</span>
               <span>多数の質の高い研究で繰り返し確認されている</span>
             </div>
             <div class="flex gap-4 items-start">
-              <span class="text-amber-500 shrink-0">★★★★★</span>
+              <span class="text-rating shrink-0">★★★★★</span>
               <span>大規模で堅牢な研究が蓄積しており、結果の信頼性が非常に高い</span>
             </div>
           </div>
@@ -174,7 +174,7 @@ import Layout from "../../layouts/Layout.astro";
         <span class="font-mono text-xs uppercase tracking-widest text-sub">03</span>
         <h2 class="text-3xl font-black tracking-tight">導入コスト（¥）</h2>
       </div>
-      <div class="text-4xl text-emerald-700 dark:text-emerald-300 tracking-widest">¥¥···</div>
+      <div class="text-4xl text-cost tracking-widest">¥¥···</div>
       <div class="leading-loose text-ink/90 space-y-6">
         <p>
           その指導法を導入するのに、児童1人あたり年間どのくらいの<strong>金銭的コスト</strong>がかかるかの概算です。
@@ -187,35 +187,35 @@ import Layout from "../../layouts/Layout.astro";
           <h3 class="font-bold">¥の基準(児童1人あたり年間)</h3>
           <div class="space-y-3">
             <div class="flex gap-4 items-start">
-              <span class="text-emerald-700 dark:text-emerald-300 shrink-0 font-mono">¥····</span>
+              <span class="text-cost shrink-0 font-mono">¥····</span>
               <div>
                 <div><strong>0円〜約17,000円</strong>（EEF: £0–£80）</div>
                 <div class="text-sub text-sm">教師の工夫で始められる。特別な予算不要。例: フィードバック、メタ認知の指導、検索練習</div>
               </div>
             </div>
             <div class="flex gap-4 items-start">
-              <span class="text-emerald-700 dark:text-emerald-300 shrink-0 font-mono">¥¥···</span>
+              <span class="text-cost shrink-0 font-mono">¥¥···</span>
               <div>
                 <div><strong>約17,000〜43,000円</strong>（EEF: £80–£200）</div>
                 <div class="text-sub text-sm">少額の教材費や短時間の研修。例: 協同学習、SEL、マスタリーラーニング</div>
               </div>
             </div>
             <div class="flex gap-4 items-start">
-              <span class="text-emerald-700 dark:text-emerald-300 shrink-0 font-mono">¥¥¥··</span>
+              <span class="text-cost shrink-0 font-mono">¥¥¥··</span>
               <div>
                 <div><strong>約43,000〜150,000円</strong>（EEF: £200–£700）</div>
                 <div class="text-sub text-sm">まとまった教材費、定期的な研修、一部人員の確保。例: 少人数指導、保護者との連携プログラム</div>
               </div>
             </div>
             <div class="flex gap-4 items-start">
-              <span class="text-emerald-700 dark:text-emerald-300 shrink-0 font-mono">¥¥¥¥·</span>
+              <span class="text-cost shrink-0 font-mono">¥¥¥¥·</span>
               <div>
                 <div><strong>約150,000〜258,000円</strong>（EEF: £700–£1,200）</div>
                 <div class="text-sub text-sm">専門スタッフの配置、大規模な研修、ICT環境整備。例: 個別指導、補助スタッフの活用</div>
               </div>
             </div>
             <div class="flex gap-4 items-start">
-              <span class="text-emerald-700 dark:text-emerald-300 shrink-0 font-mono">¥¥¥¥¥</span>
+              <span class="text-cost shrink-0 font-mono">¥¥¥¥¥</span>
               <div>
                 <div><strong>約258,000円以上</strong>（EEF: £1,200以上）</div>
                 <div class="text-sub text-sm">学級編成の変更、教員増員など、組織的・制度的投資。例: 学級規模の縮小、教科担任制</div>
@@ -242,9 +242,9 @@ import Layout from "../../layouts/Layout.astro";
         <h2 class="text-3xl font-black tracking-tight">出典バッジ</h2>
       </div>
       <div class="flex flex-wrap gap-2">
-        <span class="font-mono text-[10px] tracking-widest uppercase border rounded-full px-2 py-0.5 leading-none inline-flex items-center h-5 text-sky-800 border-sky-800/40 bg-sky-50 dark:text-sky-200 dark:border-sky-200/40 dark:bg-sky-200/10">EEF</span>
-        <span class="font-mono text-[10px] tracking-widest uppercase border rounded-full px-2 py-0.5 leading-none inline-flex items-center h-5 text-rose-700 border-rose-700/40 bg-rose-50 dark:text-rose-200 dark:border-rose-200/40 dark:bg-rose-200/10">日本</span>
-        <span class="font-mono text-[10px] tracking-widest uppercase border rounded-full px-2 py-0.5 leading-none inline-flex items-center h-5 text-amber-800 border-amber-800/40 bg-amber-50 dark:text-amber-200 dark:border-amber-200/40 dark:bg-amber-200/10">Hattie</span>
+        <span class="font-mono text-[10px] tracking-widest uppercase border rounded-full px-2 py-0.5 leading-none inline-flex items-center h-5 text-source-eef border-source-eef/40 bg-source-eef-bg">EEF</span>
+        <span class="font-mono text-[10px] tracking-widest uppercase border rounded-full px-2 py-0.5 leading-none inline-flex items-center h-5 text-source-japan border-source-japan/40 bg-source-japan-bg">日本</span>
+        <span class="font-mono text-[10px] tracking-widest uppercase border rounded-full px-2 py-0.5 leading-none inline-flex items-center h-5 text-source-hattie border-source-hattie/40 bg-source-hattie-bg">Hattie</span>
       </div>
       <div class="leading-loose text-ink/90 space-y-6">
         <p>
@@ -255,21 +255,21 @@ import Layout from "../../layouts/Layout.astro";
           <h3 class="font-bold">各バッジの意味</h3>
           <div class="space-y-3">
             <div class="flex gap-4 items-start">
-              <span class="font-mono text-[10px] tracking-widest uppercase border rounded-full px-2 py-0.5 leading-none inline-flex items-center h-5 text-sky-800 border-sky-800/40 bg-sky-50 dark:text-sky-200 dark:border-sky-200/40 dark:bg-sky-200/10 shrink-0 mt-1">EEF</span>
+              <span class="font-mono text-[10px] tracking-widest uppercase border rounded-full px-2 py-0.5 leading-none inline-flex items-center h-5 text-source-eef border-source-eef/40 bg-source-eef-bg shrink-0 mt-1">EEF</span>
               <div>
                 <div><strong>英国 Education Endowment Foundation</strong></div>
                 <div class="text-sub text-sm">Teaching and Learning Toolkit に基づく。数百〜数千本のメタ分析を統合。本サイトの主要参照元。</div>
               </div>
             </div>
             <div class="flex gap-4 items-start">
-              <span class="font-mono text-[10px] tracking-widest uppercase border rounded-full px-2 py-0.5 leading-none inline-flex items-center h-5 text-rose-700 border-rose-700/40 bg-rose-50 dark:text-rose-200 dark:border-rose-200/40 dark:bg-rose-200/10 shrink-0 mt-1">日本</span>
+              <span class="font-mono text-[10px] tracking-widest uppercase border rounded-full px-2 py-0.5 leading-none inline-flex items-center h-5 text-source-japan border-source-japan/40 bg-source-japan-bg shrink-0 mt-1">日本</span>
               <div>
                 <div><strong>日本国内の研究</strong></div>
                 <div class="text-sub text-sm">中室牧子・松岡亮二・赤林英夫・耳塚寛明 等による実証研究。日本の文脈に最も近い知見。</div>
               </div>
             </div>
             <div class="flex gap-4 items-start">
-              <span class="font-mono text-[10px] tracking-widest uppercase border rounded-full px-2 py-0.5 leading-none inline-flex items-center h-5 text-amber-800 border-amber-800/40 bg-amber-50 dark:text-amber-200 dark:border-amber-200/40 dark:bg-amber-200/10 shrink-0 mt-1">Hattie</span>
+              <span class="font-mono text-[10px] tracking-widest uppercase border rounded-full px-2 py-0.5 leading-none inline-flex items-center h-5 text-source-hattie border-source-hattie/40 bg-source-hattie-bg shrink-0 mt-1">Hattie</span>
               <div>
                 <div><strong>Hattie の Visible Learning</strong></div>
                 <div class="text-sub text-sm">800以上のメタ分析を統合。影響力は大きいが、効果量が楽観的に出やすい傾向があり、参考値として扱う。</div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -166,7 +166,7 @@ const featuredConcerns = featuredConcernSlugs.map((slug) => {
           <span class="text-3xl font-black text-accent">+5<span class="text-base ml-1">ヶ月</span></span>
           <span class="text-3xl font-black text-chart-red">(<span class="text-base mr-0.5">-</span>5<span class="text-base ml-1">ヶ月</span>)</span>
         </div>
-        <div class="text-xl text-amber-500">★★★★☆</div>
+        <div class="text-xl text-rating">★★★★☆</div>
       </div>
       <div
         class="col-span-12 min-[900px]:col-span-9 text-sm md:text-base text-sub leading-loose space-y-3"
@@ -178,7 +178,7 @@ const featuredConcerns = featuredConcernSlugs.map((slug) => {
           逆に、<strong class="text-ink">◯ヶ月分遅れた</strong>。やらない方がよかった指導法。
         </p>
         <p>
-          <span class="text-amber-500">★</span> は<strong class="text-ink">「その数字をどこまで信じていいか」</strong>を表します。<br />
+          <span class="text-rating">★</span> は<strong class="text-ink">「その数字をどこまで信じていいか」</strong>を表します。<br />
           ★が多い = 多くの質の高い研究で繰り返し確かめられている。<br />
           ★が少ない = 研究がまだ少なく、数字が変わる可能性がある。
         </p>
@@ -217,9 +217,9 @@ const featuredConcerns = featuredConcernSlugs.map((slug) => {
           <div class="text-xs text-sub">データの出典</div>
         </div>
         <div class="flex items-center gap-2">
-          <span class="font-mono text-[10px] tracking-widest uppercase border rounded-full px-2 py-0.5 leading-none inline-flex items-center h-5 text-sky-800 border-sky-800/40 bg-sky-50 dark:text-sky-200 dark:border-sky-200/40 dark:bg-sky-200/10">EEF</span>
-          <span class="font-mono text-[10px] tracking-widest uppercase border rounded-full px-2 py-0.5 leading-none inline-flex items-center h-5 text-rose-700 border-rose-700/40 bg-rose-50 dark:text-rose-200 dark:border-rose-200/40 dark:bg-rose-200/10">日本</span>
-          <span class="font-mono text-[10px] tracking-widest uppercase border rounded-full px-2 py-0.5 leading-none inline-flex items-center h-5 text-amber-800 border-amber-800/40 bg-amber-50 dark:text-amber-200 dark:border-amber-200/40 dark:bg-amber-200/10">Hattie</span>
+          <span class="font-mono text-[10px] tracking-widest uppercase border rounded-full px-2 py-0.5 leading-none inline-flex items-center h-5 text-source-eef border-source-eef/40 bg-source-eef-bg">EEF</span>
+          <span class="font-mono text-[10px] tracking-widest uppercase border rounded-full px-2 py-0.5 leading-none inline-flex items-center h-5 text-source-japan border-source-japan/40 bg-source-japan-bg">日本</span>
+          <span class="font-mono text-[10px] tracking-widest uppercase border rounded-full px-2 py-0.5 leading-none inline-flex items-center h-5 text-source-hattie border-source-hattie/40 bg-source-hattie-bg">Hattie</span>
         </div>
       </div>
       <div class="col-span-12 min-[900px]:col-span-9 text-sm md:text-base text-sub leading-loose space-y-3">
@@ -239,9 +239,9 @@ const featuredConcerns = featuredConcernSlugs.map((slug) => {
           Visible Learning は、ジョン・ハッティが<strong class="text-ink">800以上のメタ分析を統合</strong>し、250以上の教育要因を効果量で順位づけした研究プロジェクトです。影響力は非常に大きいですが、<strong class="text-ink">効果量が楽観的に出やすい傾向</strong>があり、独立した研究で再現されない値もあります。本サイトでは EEF を主とし、Hattie は参考値として扱っています。
         </p>
         <p>
-          各指導法に <span class="font-mono text-[10px] tracking-widest uppercase border rounded-full px-1.5 py-0.5 text-sky-800 border-sky-800/40 bg-sky-50 dark:text-sky-200 dark:border-sky-200/40 dark:bg-sky-200/10">EEF</span>
-          <span class="font-mono text-[10px] tracking-widest uppercase border rounded-full px-1.5 py-0.5 text-rose-700 border-rose-700/40 bg-rose-50 dark:text-rose-200 dark:border-rose-200/40 dark:bg-rose-200/10">日本</span>
-          <span class="font-mono text-[10px] tracking-widest uppercase border rounded-full px-1.5 py-0.5 text-amber-800 border-amber-800/40 bg-amber-50 dark:text-amber-200 dark:border-amber-200/40 dark:bg-amber-200/10">Hattie</span>
+          各指導法に <span class="font-mono text-[10px] tracking-widest uppercase border rounded-full px-1.5 py-0.5 text-source-eef border-source-eef/40 bg-source-eef-bg">EEF</span>
+          <span class="font-mono text-[10px] tracking-widest uppercase border rounded-full px-1.5 py-0.5 text-source-japan border-source-japan/40 bg-source-japan-bg">日本</span>
+          <span class="font-mono text-[10px] tracking-widest uppercase border rounded-full px-1.5 py-0.5 text-source-hattie border-source-hattie/40 bg-source-hattie-bg">Hattie</span>
           のバッジがついており、どの出典に基づくかが一目でわかります。
         </p>
         <p class="text-xs">

--- a/src/pages/policy-evidence.astro
+++ b/src/pages/policy-evidence.astro
@@ -170,7 +170,7 @@ const comparisons = [
 
 const alignmentLabel: Record<string, { text: string; color: string }> = {
   mostly: { text: "概ね整合", color: "text-accent" },
-  partial: { text: "部分的に整合", color: "text-amber-600" },
+  partial: { text: "部分的に整合", color: "text-rating" },
   limited: { text: "エビデンス不足", color: "text-sub" },
 };
 ---

--- a/src/pages/strategies/[...slug].astro
+++ b/src/pages/strategies/[...slug].astro
@@ -79,9 +79,9 @@ const stars = "★".repeat(d.evidenceStrength) + "☆".repeat(5 - d.evidenceStre
 const yen = "¥".repeat(d.cost) + "·".repeat(5 - d.cost);
 
 const badgeConfig = {
-  eef: { label: "EEF", color: "text-sky-800 border-sky-800/40 bg-sky-50 dark:text-sky-200 dark:border-sky-200/40 dark:bg-sky-200/10" },
-  japan: { label: "日本研究", color: "text-rose-700 border-rose-700/40 bg-rose-50 dark:text-rose-200 dark:border-rose-200/40 dark:bg-rose-200/10" },
-  hattie: { label: "Hattie", color: "text-amber-800 border-amber-800/40 bg-amber-50 dark:text-amber-200 dark:border-amber-200/40 dark:bg-amber-200/10" },
+  eef: { label: "EEF", color: "text-source-eef border-source-eef/40 bg-source-eef-bg" },
+  japan: { label: "日本研究", color: "text-source-japan border-source-japan/40 bg-source-japan-bg" },
+  hattie: { label: "Hattie", color: "text-source-hattie border-source-hattie/40 bg-source-hattie-bg" },
 } as const;
 type BadgeKey = keyof typeof badgeConfig;
 const badges: BadgeKey[] = [];
@@ -187,7 +187,7 @@ const effectNote =
         <div class="uppercase tracking-widest text-sub">
           エビデンス
         </div>
-        <div class="text-amber-600 text-base">{stars}</div>
+        <div class="text-rating text-base">{stars}</div>
       </div>
       <div class="space-y-1">
         <div class="uppercase tracking-widest text-sub">
@@ -220,18 +220,18 @@ const effectNote =
 
         <div class="space-y-4">
           {d.evidence?.eef && (
-            <div class="border border-sky-800/40 dark:border-sky-200/40 rounded-xl p-5 space-y-2">
+            <div class="border border-source-eef/40 rounded-xl p-5 space-y-2">
               <div class="flex items-baseline gap-3">
-                <span class="font-mono text-xs uppercase tracking-widest text-sky-800 dark:text-sky-200">EEF Toolkit</span>
+                <span class="font-mono text-xs uppercase tracking-widest text-source-eef">EEF Toolkit</span>
                 {d.evidence.eef.monthsGained !== undefined && (
-                  <span class="font-black text-xl text-sky-800 dark:text-sky-200 tabular-nums">
+                  <span class="font-black text-xl text-source-eef tabular-nums">
                     {d.evidence.eef.monthsGained > 0 ? "+" : ""}
                     {d.evidence.eef.monthsGained}
                     <span class="text-xs font-sans ml-1">ヶ月</span>
                   </span>
                 )}
                 {d.evidence.eef.strength !== undefined && (
-                  <span class="text-amber-600 text-sm">
+                  <span class="text-rating text-sm">
                     {"★".repeat(d.evidence.eef.strength)}
                     {"☆".repeat(5 - d.evidence.eef.strength)}
                   </span>
@@ -244,18 +244,18 @@ const effectNote =
           )}
 
           {d.evidence?.japan && (
-            <div class="border border-rose-700/40 dark:border-rose-200/40 rounded-xl p-5 space-y-2">
+            <div class="border border-source-japan/40 rounded-xl p-5 space-y-2">
               <div class="flex items-baseline gap-3 flex-wrap">
-                <span class="font-mono text-xs uppercase tracking-widest text-rose-700 dark:text-rose-200">日本研究</span>
+                <span class="font-mono text-xs uppercase tracking-widest text-source-japan">日本研究</span>
                 {d.evidence.japan.monthsGained !== undefined && (
-                  <span class="font-black text-xl text-rose-700 dark:text-rose-200 tabular-nums">
+                  <span class="font-black text-xl text-source-japan tabular-nums">
                     {d.evidence.japan.monthsGained > 0 ? "+" : ""}
                     {d.evidence.japan.monthsGained}
                     <span class="text-xs font-sans ml-1">ヶ月</span>
                   </span>
                 )}
                 {d.evidence.japan.strength !== undefined && (
-                  <span class="text-amber-600 text-sm">
+                  <span class="text-rating text-sm">
                     {"★".repeat(d.evidence.japan.strength)}
                     {"☆".repeat(5 - d.evidence.japan.strength)}
                   </span>
@@ -271,11 +271,11 @@ const effectNote =
           )}
 
           {d.evidence?.hattie && (
-            <div class="border border-line rounded-xl p-5 space-y-2 bg-amber-50/30 dark:bg-amber-300/5">
+            <div class="border border-line rounded-xl p-5 space-y-2 bg-source-hattie-bg">
               <div class="flex items-baseline gap-3 flex-wrap">
-                <span class="font-mono text-xs uppercase tracking-widest text-amber-700 dark:text-amber-300">Hattie (Visible Learning)</span>
+                <span class="font-mono text-xs uppercase tracking-widest text-source-hattie">Hattie (Visible Learning)</span>
                 {d.evidence.hattie.cohensD !== undefined && (
-                  <span class="font-black text-xl text-amber-700 dark:text-amber-300 tabular-nums">
+                  <span class="font-black text-xl text-source-hattie tabular-nums">
                     d = {d.evidence.hattie.cohensD.toFixed(2)}
                   </span>
                 )}


### PR DESCRIPTION
デザインシステム構築の 3 本目。**src/ からパレット直書きが消えます。**

## 置換

パレット直書き **186 箇所 → 0**。#411 が定義したトークンに寄せました。

トークンが dark 値を自前で持つので、**light/dark のペアが 1 クラスに畳まれます**。

```
text-sky-800 border-sky-800/40 bg-sky-50
  dark:text-sky-200 dark:border-sky-200/40 dark:bg-sky-200/10
↓
text-source-eef border-source-eef/40 bg-source-eef-bg
```

6 クラスが 3 クラスになり、`dark:` 変種の書き忘れという事故が構造的に起きなくなります。

**ADR 0016 がこれで閉じます。** 同 ADR は Hattie の amber に `dark:` を足す対症療法を選び、構造的なトークン化を将来課題としていました。

## 見た目が変わるのは 26 件（全数掲載）

**バッジ本体とコスト表示は 1 件も変わりません。** 13,302 要素（8 経路）+ 3,662 要素（callout のある 4 ページ）を測って確認しました。差分ゼロということは、#411 でトークンに移した値がパレットの実値と完全一致していたということです。

変わるのは以下だけです。

| 対象 | 変更 | 件数 |
|---|---|---|
| ★ 表示 | amber-500 → amber-600 | 14 |
| Hattie 詳細の文字 | light 700→800 / dark 300→200 | 4 |
| Hattie 詳細の背景 | 30% の淡い地 → バッジ用背景 | 4 |
| 負の効果量カード | 同上 | 4 |

★ はコンポーネント経由が amber-600、ページ直書きが amber-500 という不統一でした。両方 `--color-rating` を読むので 14 個が 1 段濃くなります。

Hattie の callout は amber-700/300、バッジは amber-800/200 という不統一でした。1 段揃えます。

## 残した課題

**Hattie callout と赤カードの背景は、pill 用の背景色を大きなカード面にそのまま当てています。** light で従来よりはっきり濃くなります。

トークンから低い割合で導出すれば（`bg-source-hattie/5` のような形）、トークン化を保ったまま従来の淡さに戻せます。両テーマで目視して今回は許容と判断しましたが、**後で見直す価値があります**。

## 検証

- `npm run check` 0 errors
- Playwright E2E **50 件**通過
- computed style **16,964 要素**（12 経路 × light/dark）の比較で差分 26 件、すべて意図したもの
- ローカル目視 OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)