### PR TITLE
docs(changelog): record the reader-facing changes from #411 and #417

### DIFF
--- a/src/pages/changelog.astro
+++ b/src/pages/changelog.astro
@@ -21,6 +21,24 @@ interface ChangelogEntry {
 
 const entries: ChangelogEntry[] = [
   {
+    date: "2026-08-03",
+    items: [
+      {
+        type: "fix",
+        text: "ダークモードで見えなくなっていた線を直しました。本文中の用語につく破線の下線と、グラフの上下の枠線が、暗い背景に溶けて判別できない状態でした",
+        links: [
+          { label: "用語つきの本文", href: "/strategies/feedback" },
+          { label: "グラフのあるコラム", href: "/columns/finland-education-myth" },
+        ],
+      },
+      {
+        type: "update",
+        text: "エビデンスの強さを示す★の色が、ページによって少し違っていたのを揃えました",
+        links: [{ label: "指標の読み方", href: "/guide/indicators" }],
+      },
+    ],
+  },
+  {
     date: "2026-08-01",
     items: [
       {


### PR DESCRIPTION
#411 と #417 はどちらも読者に見える変化を含みながら、**PR 内で changelog を更新していませんでした**。運用ルール（同 PR 内で更新する）に対する私の手落ちです。ログに穴を残さないため、いま記録します。

## 追加するエントリ（2026-08-03）

**fix — ダークモードで見えなくなっていた線**

- 本文中の用語につく破線の下線: light のアクセント色を直接書いていたため、暗い背景に対して 2.30:1 で判別できない状態でした
- グラフの上下の枠線: 半透明の黒で描いていたため 1.18:1 となり、事実上消えていました

**update — ★ の色の不統一**

コンポーネント経由で描かれる★とページに直接書かれた★で 1 段違う色になっていたのを揃えました。

## #412 を記録しない理由

任意値 760 箇所をユーティリティに置き換えただけで、**読者に見える変化がゼロ**だからです。13,302 要素の computed style が完全一致していることを確認済みです。運用ルールも「ユーザー価値のある変更だけを書く」としています。

## 検証

`npm run check` 0 errors / build 成功 / E2E 50 件通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)